### PR TITLE
Improve mission phase checks

### DIFF
--- a/src/neospy/irsa.py
+++ b/src/neospy/irsa.py
@@ -61,7 +61,7 @@ def query_irsa_tap(
         jd = neospy.Time(56823.933738, 'mjd').jd
 
         # This time corresponds to this phase:
-        phase = neospy.wise.WISE_phase_from_jd(jd)
+        phase = neospy.wise.mission_phase_from_jd(jd)
 
         # Single source table on IRSA is then: phase.source_table
 

--- a/src/neospy/rust/fovs/checks.rs
+++ b/src/neospy/rust/fovs/checks.rs
@@ -65,11 +65,16 @@ pub fn fov_spk_checks_py(obj_ids: Vec<isize>, fovs: FOVListLike) -> Vec<Vec<PySi
     let fovs = fovs.into_sorted_vec_fov();
 
     fovs.into_par_iter()
-        .map(|fov| {
-            let vis: Vec<_> = fov.check_spks(&obj_ids);
-            vis.into_iter()
+        .filter_map(|fov| {
+            let vis: Vec<_> = fov
+                .check_spks(&obj_ids)
+                .into_iter()
                 .filter_map(|pop| pop.map(|p| PySimultaneousStates(Box::new(p))))
-                .collect()
+                .collect();
+            match vis.is_empty() {
+                true => None,
+                false => Some(vis),
+            }
         })
         .collect()
 }

--- a/src/tests/test_wise.py
+++ b/src/tests/test_wise.py
@@ -1,32 +1,34 @@
 from neospy.wise import (
     MISSION_PHASES,
-    WISE_phase_from_jd,
-    WISE_phase_from_scan,
+    mission_phase_from_jd,
+    mission_phase_from_scan,
 )
 
 
-def test_WISE_phase_from_jd():
+def test_mission_phase_from_jd():
     for phase in MISSION_PHASES.values():
-        p0 = WISE_phase_from_jd(phase.jd_start)
+        p0 = mission_phase_from_jd(phase.jd_start)
         assert p0 == phase, p0.name + "  " + phase.name
-        p1 = WISE_phase_from_jd(phase.jd_end - 1)
+        p1 = mission_phase_from_jd(phase.jd_end - 1)
         assert p1 == phase, p1.name + "  " + phase.name
 
-    assert WISE_phase_from_jd(1000) is None
+    assert mission_phase_from_jd(1000) is None
 
 
-def test_WISE_phase_from_scan():
-    for letter in "rst":
+def test_mission_phase_from_scan():
+    for letter in "rs":
         scan_id = "10000" + letter
-        assert WISE_phase_from_scan(scan_id) == MISSION_PHASES["Reactivation_2022"]
-        scan_id = "45687" + letter
-        assert WISE_phase_from_scan(scan_id) is None
+        assert mission_phase_from_scan(scan_id) == MISSION_PHASES["Reactivation_2019"]
+        scan_id = "57042" + letter
+        assert mission_phase_from_scan(scan_id) is None
 
     scan_id = "01000a"
-    assert WISE_phase_from_scan(scan_id) == MISSION_PHASES["Cryo"]
-    scan_id = "08000k"
-    assert WISE_phase_from_scan(scan_id) == MISSION_PHASES["3-Band"]
+    assert mission_phase_from_scan(scan_id) == MISSION_PHASES["Cryo"]
+    scan_id = "08000b"
+    assert mission_phase_from_scan(scan_id) == MISSION_PHASES["3-Band"]
     scan_id = "09000a"
-    assert WISE_phase_from_scan(scan_id) == MISSION_PHASES["Post-Cryo"]
+    assert mission_phase_from_scan(scan_id) == MISSION_PHASES["Post-Cryo"]
     scan_id = "49000a"
-    assert WISE_phase_from_scan(scan_id) == MISSION_PHASES["Reactivation_2014"]
+    assert mission_phase_from_scan(scan_id) == MISSION_PHASES["Reactivation_2014"]
+    scan_id = "46000s"
+    assert mission_phase_from_scan(scan_id) == MISSION_PHASES["Reactivation_2022"]


### PR DESCRIPTION
This makes it more explicit where scan ids are converted to mission phases. This is a bit fuzzy around reactivation year boundaries, but is FAR more accurate.

This has been tested by loading every single field of view through all phases through 2023 december, verifying that it returns the correct phase except near year boundaries where it may be off by a year, but still return "Reactivation_".

It is precisely correct for non-reactivation phases.