### PR TITLE
Add support for async IRSA TAP queries

### DIFF
--- a/src/neospy/irsa.py
+++ b/src/neospy/irsa.py
@@ -138,7 +138,7 @@ def query_irsa_tap(
     status.raise_for_status()
 
     # Status results can have one of 4 outcomes:
-    # QUEUED, EXECUTING, ERROR, COMPLETE
+    # QUEUED, EXECUTING, ERROR, COMPLETED
 
     start = time.time()
     time.sleep(0.15)
@@ -160,7 +160,7 @@ def query_irsa_tap(
         if delay < 30:
             delay += 1
 
-    if status.content.decode().upper() != "COMPLETE":
+    if status.content.decode().upper() != "COMPLETED":
         raise ValueError("Job Failed: ", status.content.decode())
 
     result = requests.get(url)


### PR DESCRIPTION
This switches the default IRSA queries to be async based, meaning very large queries may now be made.

<img width="568" alt="image" src="https://github.com/IPAC-SW/neospy/assets/8423587/da1e5f5b-fe21-4b48-878a-dcc2cd8da644">