### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.1]  - 2024 - 5 - 13
 
 ### Added
 
@@ -40,4 +40,5 @@ Initial Release
 
 
 [Unreleased]: https://github.com/IPAC-SW/neospy/tree/main
+[0.2.1]: https://github.com/IPAC-SW/neospy/releases/tag/v0.2.1
 [0.2.0]: https://github.com/IPAC-SW/neospy/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "_core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neospy"
-version = "0.2.0"
+version = "0.2.1"
 description = "NEO Surveyor Simulation Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "ddahlen@ipac.caltech.edu"},

--- a/src/neospy_core/Cargo.toml
+++ b/src/neospy_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neospy_core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION

## [0.2.1]  - 2024 - 5 - 13

### Added

- Added support for querying SPK kernels of a specific epoch of fit from JPL Horizons.
- Added support for looking up the MPC preferred unpacked designation for asteroids.

### Changed

- Change documentation to clarify that designations are unpacked.
- Updated MPC Obs codes to include NEO Surveyor with code C58.
- Updated NAIF ID list to include new designations for about 20-30 comets.
- Renamed underlying `_rust` binary to `_core`.
- Moved NAIF ID list to a dedicated CSV file which is read during compilation.
- Rename `population.diameter` to `population.power_law`.

### Removed

- Removed main belt construction tools, out of scope and not accurate enough.
- Removed redundant MPC name resolver function.

