### PR TITLE
Release version 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [0.2.2] - 2024 - 5 - 20
 
 ### Added
 
@@ -72,6 +72,6 @@ Initial Release
   Along with many helpful interfaces to web tools such as JPL Horizons or IPAC's IRSA.
 
 
-[Unreleased]: https://github.com/IPAC-SW/neospy/tree/main
+[0.2.2]: https://github.com/IPAC-SW/neospy/tree/main
 [0.2.1]: https://github.com/IPAC-SW/neospy/releases/tag/v0.2.1
 [0.2.0]: https://github.com/IPAC-SW/neospy/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "_core"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, IPAC-SW
+Copyright (c) 2024, Caltech IPAC
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "neospy"
-copyright = "2024, Dar Dahlen"
+copyright = "2024, Caltech IPAC"
 author = "Dar Dahlen"
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "ddahlen@ipac.caltech.edu"},
            {name = "Joe Masiero", email = "jmasiero@ipac.caltech.edu"},
           ]
-license = {text = "MIT"}
+license = {text = "BSD"}
 requires-python = ">=3.9"
 classifiers=["Programming Language :: Python :: 3"]
 dependencies = ["astropy>=5.3.4",

--- a/src/neospy_core/Cargo.toml
+++ b/src/neospy_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neospy_core"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION

### Added

- Added support for downloading ZTF full fields FOV information into the neospy cache.
- Added simple lookup for observatory ecliptic state using MPC observatory codes.
- Added 'Tutorials' to the documentation, these are larger worked examples which do not
  build at the same time as the standard docs. They are designed to be examples which
  take significant compute, and may run for many minutes.
- Added Tutorials for 'KONA' and 'WISE Precovery'.

### Changed

- Moved population definitions to the base level and renamed it `population`.
- Changed references to diameters in the broken power law sampler.
- FOV propagation tests now return a flatten list of states.
- Renamed `data` to `cache` to more accurately represent its function.

### Fixed

- Coordinate frame conversion was resulting in incorrect coordinate positions when
  passing Equatorial based frames to some FOV related functions. Specifically it was
  failing to convert the Equatorial frame to Ecliptic frame before performing orbit
  calculations.