### PR TITLE
Improve python interface to rust FOVs

### DIFF
--- a/src/neospy/rust/vector.rs
+++ b/src/neospy/rust/vector.rs
@@ -15,6 +15,7 @@ use pyo3::{PyResult, Python};
 #[derive(Clone, Debug)]
 pub struct Vector {
     pub raw: [f64; 3],
+    
     frame: PyFrames,
 }
 

--- a/src/neospy/ztf.py
+++ b/src/neospy/ztf.py
@@ -12,7 +12,7 @@ from .fov import ZtfCcdQuad, ZtfField, FOVList
 from .time import Time
 from .irsa import query_irsa_tap
 from .mpc import find_obs_code
-from .vector import Vector
+from .vector import Vector, State
 from .spice import SpiceKernels
 
 
@@ -98,9 +98,9 @@ def fetch_ZTF_fovs(year: int):
         verbose=True,
     )
 
-    # Exposures are 30 seconds, add 15 to select the midpoint of the observations
+    # Exposures are 30 seconds
     jds_str = [x.split("+")[0] for x in irsa_query["obsdate"]]
-    jds = np.array(Time(jds_str, "iso", "utc").jd) + 15 / 60 / 60 / 24
+    jds = np.array(Time(jds_str, "iso", "utc").jd)
 
     obs_info = find_obs_code("ZTF")
 
@@ -114,6 +114,7 @@ def fetch_ZTF_fovs(year: int):
             dec = getattr(row, f"dec{i + 1}")
             corners.append(Vector.from_ra_dec(ra, dec))
         observer = SpiceKernels.earth_pos_to_ecliptic(jd, *obs_info[:-1])
+        observer = State("ZTF", observer.jd, observer.pos, observer.vel)
 
         fov = ZtfCcdQuad(
             corners,


### PR DESCRIPTION
There were a few typos in the python `repr`s, along with the ZTFField objects being a pain to index through.

This also fixes a time offset in the ZTF Queries, making the fields almost match ZTF MPC submissions (there appears to be a remaining offset, but I believe that is due to a slightly incorrect time conversion when submitting time to the MPC). This slight remaining time offset is somewhat stochastic, and typically less than 1-2 seconds.

