### PR TITLE
Add relax=True to WCS loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restructured the Rust FOVs to be organized by observatory.
 - Renamed `SpiceKernels.cache_kernel_reload` to `kernel_reload` and changed it's args.
 
+### Fixed
+
+- Astropy will no longer warning about deprecated WCS header values for NEOWISE images.
+
 ## [0.2.2] - 2024 - 5 - 20
 
 ### Added

--- a/docs/tutorials/kona.rst
+++ b/docs/tutorials/kona.rst
@@ -55,7 +55,7 @@ calculated from the corners of the frame.
     # Build the corner position of the FOV in RA/DEC, and build those into vectors
     # The WCS will raise a warning because the FITs files produced by WISE use an
     # old format.
-    frame_wcs = WCS(frame.header)
+    frame_wcs = WCS(frame.header, relax=True)
     corners = []
     dx, dy = frame_wcs.pixel_shape
     for x, y in zip([0, 0, dx, dx], [0, dy, dy, 0]):

--- a/src/neospy/irsa.py
+++ b/src/neospy/irsa.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import warnings
 import io
 from functools import lru_cache
 import requests
@@ -174,12 +173,10 @@ def plot_fits_image(fit, vmin=-3, vmax=7, cmap="bone_r"):
     correctly onto the current image.
     """
     data = np.nan_to_num(fit.data)
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore")
-        wcs = WCS(fit.header)
-        if not plt.get_fignums():
-            plt.figure(dpi=120, figsize=(6, 6), facecolor="w")
-        ax = plt.subplot(projection=wcs)
+    wcs = WCS(fit.header, relax=True)
+    if not plt.get_fignums():
+        plt.figure(dpi=120, figsize=(6, 6), facecolor="w")
+    ax = plt.subplot(projection=wcs)
 
     data_no_bkg = data - np.median(data)
     # np.std below is doing a full frame std, which grabs the flux

--- a/src/neospy/wise.py
+++ b/src/neospy/wise.py
@@ -498,10 +498,8 @@ def plot_frames(
         except OSError:
             continue
         data = np.nan_to_num(fit.data)
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            wcs = WCS(fit.header)
-            ax = plt.subplot(2, 2, band, projection=wcs)
+        wcs = WCS(fit.header, relax=True)
+        ax = plt.subplot(2, 2, band, projection=wcs)
 
         data_no_bkg = data - np.median(data)
         # np.std below is doing a full frame std, which grabs the flux


### PR DESCRIPTION
Astropy will no longer warning about deprecated WCS header values for NEOWISE images.

Fixes #34 