### PR TITLE
Phase example incorrect mag calculation

### DIFF
--- a/src/examples/plot_phases.py
+++ b/src/examples/plot_phases.py
@@ -39,10 +39,10 @@ for i, state in enumerate(states):
     obj2earth = sun2earth - sun2obj
     mags.append(
         neospy.flux.hg_apparent_mag(
-            -sun2obj,
-            obj2earth,
-            neo_subset.g_phase.iloc[i],
+            sun2obj,
+            sun2earth,
             neo_subset.h_mag.iloc[i],
+            neo_subset.g_phase.iloc[i],
         )
     )
 
@@ -63,7 +63,7 @@ plt.ylabel("Counts")
 
 plt.subplot(2, 1, 2)
 plt.scatter(mags[elongs > 90], phases[elongs > 90], s=1)
-plt.xlim(0, 25)
+plt.xlim(10, 35)
 plt.xlabel("Visible Mag")
 plt.ylabel("Phase (Deg)")
 plt.tight_layout()


### PR DESCRIPTION
The previous PR introduced a regression in the phase example. This fixes that.

Bug:
![image](https://github.com/IPAC-SW/neospy/assets/8423587/c9375ab0-d2b7-4a33-a7e9-c81044ae1245)

This PR:
![image](https://github.com/IPAC-SW/neospy/assets/8423587/8d317839-d601-4a85-b844-19722da01bcf)
