### PR TITLE
Division for negative number was rounding up

### DIFF
--- a/src/neospy_core/src/time/mod.rs
+++ b/src/neospy_core/src/time/mod.rs
@@ -123,13 +123,13 @@ impl Time<UTC> {
 
         let mut l = offset.div_euclid(1.0) as i64 + 68569;
 
-        let n = (4 * l) / 146097;
-        l -= (146097 * n + 3) / 4;
-        let i = (4000 * (l + 1)) / 1461001;
-        l -= (1461 * i) / 4 - 31;
-        let k = (80 * l) / 2447;
-        let day = l - (2447 * k) / 80;
-        l = k / 11;
+        let n = (4 * l).div_euclid(146097);
+        l -= (146097 * n + 3).div_euclid(4);
+        let i = (4000 * (l + 1)).div_euclid(1461001);
+        l -= (1461 * i).div_euclid(4) - 31;
+        let k = (80 * l).div_euclid(2447);
+        let day = l - (2447 * k).div_euclid(80);
+        l = k.div_euclid(11);
 
         let month = k + 2 - 12 * l;
         let year = 100 * (n - 49) + i + l;
@@ -223,6 +223,11 @@ mod tests {
 
         let t2 = Time::<UTC>::from_year_month_day(763, 9, 18, 0.5);
         assert!(t2.jd == 2000000.);
+
+        let ymd = Time::<UTC>::new(-68774.4991992591).year_month_day();
+        assert!(ymd.0 == -4901);
+        assert!(ymd.1 == 8);
+        assert!(ymd.2 == 8);
     }
 
     #[test]


### PR DESCRIPTION
This is normal behavior for negative numbers on CPUs, but unexpected behavior for math. This required changing the divisions to `div_euclid` to match the expected behavior.

``` rust
     let x = -5 / 3;
     assert!(x, -1);

     let y = -5.div_euclid(3); // this is the mathematically expected behavior
     assert!(y, -2);
```

Fixes #70 

Here is sweeping JD back to -1e6 JD, and performing a YMD conversion for each day:
<img width="598" alt="image" src="https://github.com/IPAC-SW/neospy/assets/8423587/83ce2dfb-5412-47c6-994b-9f12008f2e7b">
<img width="583" alt="image" src="https://github.com/IPAC-SW/neospy/assets/8423587/32f013b9-9444-46e6-8acd-de2962d9d070">
<img width="562" alt="image" src="https://github.com/IPAC-SW/neospy/assets/8423587/9660bb47-59c7-4631-824c-a849671601a6">

This is now expected behavior.

