### PR TITLE
Complete rewrite of reference frames.

### DIFF
--- a/src/neospy/rust/elements.rs
+++ b/src/neospy/rust/elements.rs
@@ -167,7 +167,7 @@ impl PyCometElements {
     /// Convert the orbital elements into a cartesian State.
     #[getter]
     pub fn state(&self) -> PyResult<PyState> {
-        Ok(self.0.try_to_state()?.into())
+        Ok(self.0.try_to_state()?.into_frame())
     }
 
     /// Eccentric Anomaly in degrees.

--- a/src/neospy/rust/fovs/definitions.rs
+++ b/src/neospy/rust/fovs/definitions.rs
@@ -236,7 +236,7 @@ impl PyGenericRectangle {
     /// The observer State.
     #[getter]
     pub fn observer(&self) -> PyState {
-        self.0.observer().clone().into()
+        self.0.observer().clone().into_frame()
     }
 
     /// Direction that the observer is looking.

--- a/src/neospy/rust/fovs/definitions.rs
+++ b/src/neospy/rust/fovs/definitions.rs
@@ -143,7 +143,7 @@ impl PyWiseCmos {
         frame_num: u64,
         scan_id: String,
     ) -> Self {
-        let pointing = pointing.into_vector(observer.frame());
+        let pointing = pointing.into_pyvector(observer.frame());
         let pointing = pointing.raw.into();
         let scan_id = scan_id.into();
         PyWiseCmos(fov::WiseCmos::new(
@@ -208,7 +208,7 @@ impl PyGenericRectangle {
         lon_width: f64,
         lat_width: f64,
     ) -> Self {
-        let pointing = pointing.into_vector(observer.frame());
+        let pointing = pointing.into_pyvector(observer.frame());
         PyGenericRectangle(fov::GenericRectangle::new(
             pointing.raw.into(),
             rotation.to_radians(),
@@ -314,7 +314,7 @@ impl PyNeosCmos {
         cmos_id: u8,
         band: u8,
     ) -> Self {
-        let pointing = pointing.into_vector(observer.frame());
+        let pointing = pointing.into_pyvector(observer.frame());
         let pointing = pointing.raw.into();
         PyNeosCmos(fov::NeosCmos::new(
             pointing,
@@ -482,7 +482,7 @@ impl PyNeosVisit {
         exposure_id: u8,
         band: u8,
     ) -> Self {
-        let pointing = pointing.into_vector(crate::frame::PyFrames::Ecliptic);
+        let pointing = pointing.into_pyvector(crate::frame::PyFrames::Ecliptic);
         let pointing = pointing.raw.into();
         PyNeosVisit(fov::NeosVisit::from_pointing(
             x_width.to_radians(),
@@ -630,7 +630,7 @@ impl PyZtfCcdQuad {
     ) -> Self {
         let corners = corners
             .into_iter()
-            .map(|v| v.into_vector(observer.frame()).raw.into())
+            .map(|v| v.into_pyvector(observer.frame()).raw.into())
             .collect::<Vec<_>>()
             .try_into()
             .unwrap();

--- a/src/neospy/rust/frame.rs
+++ b/src/neospy/rust/frame.rs
@@ -1,4 +1,4 @@
-use neospy_core::frames::*;
+use neospy_core::{frames::*, state::State};
 use pyo3::prelude::*;
 
 /// Defined inertial frames supported by the python side of NEOSpy
@@ -9,53 +9,14 @@ pub enum PyFrames {
     Equatorial,
     Galactic,
     FK4,
-    Undefined,
 }
 
-/// Provide a mapping from the python mapping above to the backend frames
-impl From<PyFrames> for neospy_core::frames::Frame {
-    fn from(value: PyFrames) -> Self {
-        match value {
-            PyFrames::Ecliptic => neospy_core::frames::Frame::Ecliptic,
-            PyFrames::Equatorial => neospy_core::frames::Frame::Equatorial,
-            PyFrames::Galactic => neospy_core::frames::Frame::Galactic,
-            PyFrames::FK4 => neospy_core::frames::Frame::FK4,
-            PyFrames::Undefined => neospy_core::frames::Frame::Unknown(0),
-        }
-    }
-}
-
-/// Provide a mapping from the python mapping above to the backend frames
-impl From<neospy_core::frames::Frame> for PyFrames {
-    fn from(value: neospy_core::frames::Frame) -> Self {
-        match value {
-            neospy_core::frames::Frame::Ecliptic => PyFrames::Ecliptic,
-            neospy_core::frames::Frame::Equatorial => PyFrames::Equatorial,
-            neospy_core::frames::Frame::FK4 => PyFrames::FK4,
-            neospy_core::frames::Frame::Galactic => PyFrames::Galactic,
-            _ => PyFrames::Undefined,
-        }
-    }
-}
-
-/// Convert a vector in the input frame to the same vector in the output frame.
-#[allow(clippy::too_many_arguments)]
-#[pyfunction]
-#[pyo3(name = "frame_change")]
-pub fn frame_change_py(
-    states: Vec<[f64; 3]>,
-    input_frame: PyFrames,
-    output_frame: PyFrames,
-) -> Vec<[f64; 3]> {
-    states
-        .into_iter()
-        .map(|vec| {
-            std::convert::Into::<Frame>::into(input_frame)
-                .try_vec_frame_change(vec.into(), output_frame.into())
-                .unwrap()
-                .into()
-        })
-        .collect()
+#[derive(Clone, Debug)]
+pub enum FrameState {
+    Ecliptic(State<Ecliptic>),
+    Equatorial(State<Equatorial>),
+    Galactic(State<Galactic>),
+    FK4(State<FK4>),
 }
 
 /// Compute a ECEF position from WCS84 Geodetic latitude/longitude/height.

--- a/src/neospy/rust/kepler.rs
+++ b/src/neospy/rust/kepler.rs
@@ -69,11 +69,11 @@ pub fn propagation_kepler_py(
             let center = state.center_id();
 
             let Some(state) = state.change_center(10).ok() else {
-                return State::new_nan(state.0.desig.clone(), jd, state.0.frame, center).into();
+                return State::new_nan(state.0.desig.clone(), jd, state.0.frame, center).into_frame();
             };
 
             let Some(mut new_state) = propagation::propagate_two_body(&state.0, jd).ok() else {
-                return State::new_nan(state.0.desig.clone(), jd, state.0.frame, center).into();
+                return State::new_nan(state.0.desig.clone(), jd, state.0.frame, center).into_frame();
             };
 
             if let Some(sun2obs) = &sun2obs {
@@ -86,12 +86,12 @@ pub fn propagation_kepler_py(
                     Ok(state) => state,
                     Err(_) => {
                         return State::new_nan(state.0.desig.clone(), jd, state.0.frame, center)
-                            .into()
+                            .into_frame()
                     }
                 };
             }
             PyState(new_state).change_center(center).unwrap_or(
-                State::new_nan(state.0.desig.clone(), jd, state.0.frame, state.0.center_id).into(),
+                State::new_nan(state.0.desig.clone(), jd, state.0.frame, state.0.center_id).into_frame(),
             )
         })
         .collect()

--- a/src/neospy/rust/lib.rs
+++ b/src/neospy/rust/lib.rs
@@ -32,7 +32,7 @@ mod vector;
 fn _core(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<frame::PyFrames>()?;
     m.add_class::<state::PyState>()?;
-    m.add_class::<vector::Vector>()?;
+    m.add_class::<vector::PyVector>()?;
     m.add_class::<elements::PyCometElements>()?;
     m.add_class::<simult_states::PySimultaneousStates>()?;
     m.add_class::<nongrav::PyNonGravModel>()?;
@@ -54,7 +54,6 @@ fn _core(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_class::<covariance::Covariance>()?;
 
-    m.add_function(wrap_pyfunction!(frame::frame_change_py, m)?)?;
     m.add_function(wrap_pyfunction!(frame::wgs_lat_lon_to_ecef, m)?)?;
 
     m.add_function(wrap_pyfunction!(kepler::compute_eccentric_anomaly_py, m)?)?;

--- a/src/neospy/rust/propagation.rs
+++ b/src/neospy/rust/propagation.rs
@@ -51,7 +51,7 @@ pub fn propagation_n_body_spk_py(
                         Err(e)?;
                     };
                     return Ok::<PyState, PyErr>(
-                        State::new_nan(state.desig, jd_final, state.frame, center).into(),
+                        State::new_nan(state.desig, jd_final, state.frame, center).into_frame(),
                     );
                 };
 
@@ -63,7 +63,9 @@ pub fn propagation_n_body_spk_py(
                     if !suppress_errors {
                         Err(NEOSpyError::ValueError("Input state contains NaNs.".into()))?;
                     };
-                    return Ok(State::new_nan(state.desig, jd_final, state.frame, center).into());
+                    return Ok(
+                        State::new_nan(state.desig, jd_final, state.frame, center).into_frame()
+                    );
                 }
                 let desig = state.desig.clone();
                 let frame = state.frame;
@@ -73,9 +75,9 @@ pub fn propagation_n_body_spk_py(
                             if !suppress_errors {
                                 Err(er)?;
                             }
-                            return Ok(State::new_nan(desig, jd_final, frame, center).into());
+                            return Ok(State::new_nan(desig, jd_final, frame, center).into_frame());
                         };
-                        Ok(state.into())
+                        Ok(state.into_frame())
                     }
                     Err(er) => {
                         if !suppress_errors {
@@ -89,7 +91,7 @@ pub fn propagation_n_body_spk_py(
                                     time
                                 );
                             };
-                            Ok(State::new_nan(desig, jd_final, frame, center).into())
+                            Ok(State::new_nan(desig, jd_final, frame, center).into_frame())
                         }
                     }
                 }

--- a/src/neospy/rust/simult_states.rs
+++ b/src/neospy/rust/simult_states.rs
@@ -83,7 +83,7 @@ impl PySimultaneousStates {
     /// States contained within.
     #[getter]
     pub fn states(&self) -> Vec<PyState> {
-        self.0.states.iter().map(|x| x.clone().into()).collect()
+        self.0.states.iter().map(|x| x.clone().into_frame()).collect()
     }
 
     /// The time of the simultaneous states.
@@ -126,7 +126,7 @@ impl PySimultaneousStates {
         if idx >= self.__len__() {
             return Err(PyErr::new::<exceptions::PyIndexError, _>(""));
         }
-        Ok(self.0.states[idx].clone().into())
+        Ok(self.0.states[idx].clone().into_frame())
     }
 
     /// If a FOV is present, calculate all vectors from the observer position to the

--- a/src/neospy_core/benches/propagation.rs
+++ b/src/neospy_core/benches/propagation.rs
@@ -10,7 +10,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 lazy_static! {
     static ref CIRCULAR: State<Ecliptic> = {
         State::new(
-            Desig::Name("Circular".into()),
+            Some(Desig::Name("Circular".into())),
             2451545.0,
             [0.0, 1., 0.0].into(),
             [-constants::GMS_SQRT, 0.0, 0.0].into(),
@@ -19,7 +19,7 @@ lazy_static! {
     };
     static ref ELLIPTICAL: State<Ecliptic> = {
         State::<Ecliptic>::new(
-            Desig::Name("Elliptical".into()),
+            Some(Desig::Name("Elliptical".into())),
             2451545.0,
             [0.0, 1.5, 0.0].into(),
             [-constants::GMS_SQRT, 0.0, 0.0].into(),
@@ -28,7 +28,7 @@ lazy_static! {
     };
     static ref PARABOLIC: State<Ecliptic> = {
         State::new(
-            Desig::Name("Parabolic".into()),
+            Some(Desig::Name("Parabolic".into())),
             2451545.0,
             [0.0, 2., 0.0].into(),
             [-constants::GMS_SQRT, 0.0, 0.0].into(),
@@ -37,7 +37,7 @@ lazy_static! {
     };
     static ref HYPERBOLIC: State<Ecliptic> = {
         State::new(
-            Desig::Name("Hyperbolic".into()),
+            Some(Desig::Name("Hyperbolic".into())),
             2451545.0,
             [0.0, 3., 0.0].into(),
             [-constants::GMS_SQRT, 0.0, 0.0].into(),
@@ -81,7 +81,7 @@ pub fn two_body_numeric(c: &mut Criterion) {
         HYPERBOLIC.clone(),
     ] {
         let name = match &state.desig {
-            Desig::Name(n) => n,
+            Some(Desig::Name(n)) => n,
             _ => panic!(),
         };
         twobody_num_group.bench_with_input(BenchmarkId::new("Single", name), &state, |b, s| {
@@ -100,7 +100,7 @@ pub fn n_body_prop(c: &mut Criterion) {
         HYPERBOLIC.clone(),
     ] {
         let name = match &state.desig {
-            Desig::Name(n) => n,
+            Some(Desig::Name(n)) => n,
             _ => panic!(),
         };
         nbody_group.bench_with_input(BenchmarkId::new("Single", name), &state, |b, s| {
@@ -123,7 +123,7 @@ pub fn two_body_analytic(c: &mut Criterion) {
         HYPERBOLIC.clone(),
     ] {
         let name = match &state.desig {
-            Desig::Name(n) => n,
+            Some(Desig::Name(n)) => n,
             _ => panic!(),
         };
         twobody_group.bench_with_input(BenchmarkId::new("Single", name), &state, |b, s| {

--- a/src/neospy_core/benches/propagation.rs
+++ b/src/neospy_core/benches/propagation.rs
@@ -1,5 +1,6 @@
 extern crate criterion;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use frames::Ecliptic;
 use lazy_static::lazy_static;
 use neospy_core::prelude::*;
 use neospy_core::*;
@@ -7,69 +8,66 @@ use pprof::criterion::{Output, PProfProfiler};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 lazy_static! {
-    static ref CIRCULAR: State = {
+    static ref CIRCULAR: State<Ecliptic> = {
         State::new(
             Desig::Name("Circular".into()),
             2451545.0,
             [0.0, 1., 0.0].into(),
             [-constants::GMS_SQRT, 0.0, 0.0].into(),
-            Frame::Ecliptic,
             0,
         )
     };
-    static ref ELLIPTICAL: State = {
-        State::new(
+    static ref ELLIPTICAL: State<Ecliptic> = {
+        State::<Ecliptic>::new(
             Desig::Name("Elliptical".into()),
             2451545.0,
             [0.0, 1.5, 0.0].into(),
             [-constants::GMS_SQRT, 0.0, 0.0].into(),
-            Frame::Ecliptic,
             0,
         )
     };
-    static ref PARABOLIC: State = {
+    static ref PARABOLIC: State<Ecliptic> = {
         State::new(
             Desig::Name("Parabolic".into()),
             2451545.0,
             [0.0, 2., 0.0].into(),
             [-constants::GMS_SQRT, 0.0, 0.0].into(),
-            Frame::Ecliptic,
             0,
         )
     };
-    static ref HYPERBOLIC: State = {
+    static ref HYPERBOLIC: State<Ecliptic> = {
         State::new(
             Desig::Name("Hyperbolic".into()),
             2451545.0,
             [0.0, 3., 0.0].into(),
             [-constants::GMS_SQRT, 0.0, 0.0].into(),
-            Frame::Ecliptic,
             0,
         )
     };
 }
 
-fn prop_n_body_radau(state: State, dt: f64) {
+fn prop_n_body_radau(state: State<Ecliptic>, dt: f64) {
     let jd = state.jd + dt;
-    propagation::propagate_n_body_spk(state, jd, false, None).unwrap();
+    propagation::propagate_n_body_spk(state.into_frame(), jd, false, None).unwrap();
 }
 
-fn prop_n_body_radau_par(state: State, dt: f64) {
-    let states: Vec<State> = (0..100).map(|_| state.clone()).collect();
-    let _tmp: Vec<State> = states
+fn prop_n_body_radau_par(state: State<Ecliptic>, dt: f64) {
+    let states: Vec<State<_>> = (0..100).map(|_| state.clone()).collect();
+    let _tmp: Vec<State<_>> = states
         .into_par_iter()
         .map(|s| {
             let jd = s.jd + dt;
-            propagation::propagate_n_body_spk(s, jd, false, None).unwrap()
+            propagation::propagate_n_body_spk(s.into_frame(), jd, false, None).unwrap()
         })
         .collect();
 }
 
-fn prop_2_body_radau(state: State, dt: f64) {
-    propagation::propagation_central(&state, state.jd + dt).unwrap();
+fn prop_2_body_radau(state: State<Ecliptic>, dt: f64) {
+    let jd = state.jd + dt;
+    propagation::propagation_central(&state.into_frame(), jd).unwrap();
 }
 
-fn prop_2_body_kepler(state: State, dt: f64) {
+fn prop_2_body_kepler(state: State<Ecliptic>, dt: f64) {
     propagation::propagate_two_body(&state, state.jd + dt).unwrap();
 }
 

--- a/src/neospy_core/benches/spice.rs
+++ b/src/neospy_core/benches/spice.rs
@@ -1,16 +1,20 @@
 extern crate criterion;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use neospy_core::{spice::get_spk_singleton, state::State};
+use neospy_core::{
+    frames::{Ecliptic, Equatorial},
+    spice::get_spk_singleton,
+    state::State,
+};
 use pprof::criterion::{Output, PProfProfiler};
 
 fn spice_get_raw_state(jd: f64) {
     let spice = get_spk_singleton().try_read().unwrap();
     for _ in 0..1000 {
-        let _ = spice.try_get_raw_state(5, jd).unwrap();
+        let _: State<Equatorial> = spice.try_get_raw_state(5, jd).unwrap();
     }
 }
 
-fn spice_change_center(mut state: State) {
+fn spice_change_center(mut state: State<Ecliptic>) {
     let spice = get_spk_singleton().try_read().unwrap();
     for _ in 0..500 {
         spice.try_change_center(&mut state, 10).unwrap();
@@ -21,17 +25,13 @@ fn spice_change_center(mut state: State) {
 fn spice_get_state(jd: f64) {
     let spice = get_spk_singleton().try_read().unwrap();
     for _ in 0..1000 {
-        let _ = spice
-            .try_get_state(5, jd, 10, neospy_core::frames::Frame::Ecliptic)
-            .unwrap();
+        let _ = spice.try_get_state::<Ecliptic>(5, jd, 10).unwrap();
     }
 }
 
 pub fn spice_benchmark(c: &mut Criterion) {
     let spice = get_spk_singleton().try_read().unwrap();
-    let state = spice
-        .try_get_state(5, 2451545.0, 10, neospy_core::frames::Frame::Ecliptic)
-        .unwrap();
+    let state = spice.try_get_state::<Ecliptic>(5, 2451545.0, 10).unwrap();
     c.bench_function("spice_get_raw_state", |b| {
         b.iter(|| spice_get_raw_state(black_box(2451545.0)))
     });

--- a/src/neospy_core/src/elements.rs
+++ b/src/neospy_core/src/elements.rs
@@ -19,7 +19,7 @@ use std::marker::PhantomData;
 #[derive(Debug, Clone)]
 pub struct CometElements<T: InertialFrame> {
     /// Designation of the object
-    pub desig: Desig,
+    pub desig: Option<Desig>,
 
     /// Epoch of fit
     pub epoch: f64,
@@ -48,7 +48,7 @@ pub struct CometElements<T: InertialFrame> {
 impl<T: InertialFrame> CometElements<T> {
     /// Create a new CometaryElements.
     pub fn new(
-        desig: Desig,
+        desig: Option<Desig>,
         epoch: f64,
         eccentricity: f64,
         inclination: f64,
@@ -80,7 +80,7 @@ impl<T: InertialFrame> CometElements<T> {
     /// The units of the vectors are AU and AU/Day, with the central mass assumed
     /// to be the Sun.
     ///
-    fn from_pos_vel(desig: Desig, epoch: f64, pos: &Vector<T>, vel: &Vector<T>) -> Self {
+    fn from_pos_vel(desig: Option<Desig>, epoch: f64, pos: &Vector<T>, vel: &Vector<T>) -> Self {
         let vel_scaled = vel / GMS_SQRT;
         let v_mag2 = vel_scaled.norm_squared();
         let p_mag = pos.norm();
@@ -336,7 +336,7 @@ mod tests {
     fn test_specific_conversion() {
         // This was previously a failed instance.
         let elem = CometElements::<Ecliptic>::new(
-            Desig::Empty,
+            None,
             2461722.5,
             0.7495474422690582,
             0.1582845445910239,
@@ -349,7 +349,7 @@ mod tests {
 
         // This was previously a failed instance.
         let elem = CometElements::<Ecliptic> {
-            desig: Desig::Empty,
+            desig: None,
             epoch: 2455341.243793971,
             eccentricity: 1.001148327267,
             inclination: 2.433767,
@@ -371,7 +371,7 @@ mod tests {
                     for peri_arg in [-2.0, 0.0, 0.1, 0.5, 10.0] {
                         for peri_dist in [0.1, 0.5, 10.0] {
                             let elem = CometElements {
-                                desig: Desig::Empty,
+                                desig: None,
                                 epoch: 10.0,
                                 eccentricity: ecc,
                                 inclination: incl,
@@ -384,7 +384,7 @@ mod tests {
                             let [pos, vel] = elem.to_pos_vel().unwrap();
                             assert!((Vector::<Ecliptic>::new(pos).norm() - peri_dist).abs() < 1e-6);
                             let new_elem = CometElements::<Ecliptic>::from_pos_vel(
-                                Desig::Empty,
+                                None,
                                 10.0,
                                 &pos.into(),
                                 &vel.into(),
@@ -408,7 +408,7 @@ mod tests {
                             for peri_arg in [-1.0, 0.0, 1.0] {
                                 for peri_dist in [0.3, 0.5] {
                                     let elem = CometElements {
-                                        desig: Desig::Empty,
+                                        desig: None,
                                         epoch,
                                         eccentricity: ecc,
                                         inclination: incl,
@@ -421,7 +421,7 @@ mod tests {
                                     let [pos, vel] =
                                         elem.to_pos_vel().expect("Failed to convert to state.");
                                     let new_elem = CometElements::<Ecliptic>::from_pos_vel(
-                                        Desig::Empty,
+                                        None,
                                         epoch,
                                         &pos.into(),
                                         &vel.into(),
@@ -476,7 +476,7 @@ mod tests {
                         for peri_arg in [0.0, 1.0] {
                             for peri_dist in [0.3, 0.5] {
                                 let elem = CometElements {
-                                    desig: Desig::Empty,
+                                    desig: None,
                                     epoch,
                                     eccentricity: ecc,
                                     inclination: incl,
@@ -488,7 +488,7 @@ mod tests {
                                 };
                                 let [pos, vel] = elem.to_pos_vel().unwrap();
                                 let new_elem = CometElements::<Ecliptic>::from_pos_vel(
-                                    Desig::Empty,
+                                    None,
                                     epoch,
                                     &pos.into(),
                                     &vel.into(),

--- a/src/neospy_core/src/fov/fov_like.rs
+++ b/src/neospy_core/src/fov/fov_like.rs
@@ -2,83 +2,73 @@
 //! This trait defines field of view checks for portions of the sky.
 
 use super::*;
-use nalgebra::Vector3;
 use rayon::prelude::*;
 
 use crate::constants::C_AU_PER_DAY_INV;
+use crate::frames::InertialFrame;
 use crate::prelude::*;
 
 /// Field of View like objects.
 /// These may contain multiple unique sky patches, so as a result the expected
 /// behavior is to return the index as well as the [`Contains`] for the closest
 /// sky patch.
-pub trait FovLike: Sync + Sized {
+pub trait FovLike<F: InertialFrame>: Sync + Sized {
     /// Return the FOV of the patch at the specified index.
     /// This will panic if the index is out of allowed bounds.
     fn get_fov(&self, index: usize) -> FOV;
 
     /// Position of the observer.
-    fn observer(&self) -> &State;
+    fn observer(&self) -> &State<F>;
 
     /// Is the specified vector contained within this FOVLike object.
     /// A ['Contains'] is returned for each sky patch.
-    fn contains(&self, obs_to_obj: &Vector3<f64>) -> (usize, Contains);
+    fn contains(&self, obs_to_obj: &Vector<F>) -> (usize, Contains);
 
     /// Number of sky patches contained within this FOV.
     fn n_patches(&self) -> usize;
 
-    /// Change the target frame to the new frame.
-    fn try_frame_change_mut(&mut self, new_frame: Frame) -> Result<(), NEOSpyError>;
-
     /// Check if a static source is visible. This assumes the vector passed in is at an
     /// infinite distance from the observer.
     #[inline]
-    fn check_static(&self, pos: &Vector3<f64>) -> (usize, Contains) {
+    fn check_static(&self, pos: &Vector<F>) -> (usize, Contains) {
         self.contains(pos)
     }
 
     /// Assuming the object undergoes linear motion, check to see if it is within the
     /// field of view.
     #[inline]
-    fn check_linear(&self, state: &State) -> (usize, Contains, State) {
-        let pos: Vector3<_> = state.pos.into();
-        let vel = state.vel.into();
+    fn check_linear(&self, state: &State<F>) -> (usize, Contains, State<F>) {
+        let pos = state.pos.into_frame();
+        let vel = state.vel.into_frame();
         let obs = self.observer();
 
-        let obs_pos: Vector3<_> = obs.pos.into();
+        let obs_pos = obs.pos.into_frame();
 
-        let rel_pos = pos - obs_pos;
+        let rel_pos = pos - &obs_pos;
 
         // This also accounts for first order light delay.
         let dt = obs.jd - state.jd - rel_pos.norm() * C_AU_PER_DAY_INV;
-        let new_pos = pos + vel * dt;
-        let new_rel_pos = new_pos - obs_pos;
+        let new_pos = pos + &(vel * dt);
+        let new_rel_pos = new_pos - &obs_pos;
         let (idx, contains) = self.contains(&new_rel_pos);
-        let new_state = State::new(
-            state.desig.clone(),
-            obs.jd,
-            new_pos,
-            vel,
-            obs.frame,
-            obs.center_id,
-        );
+        let new_state = State::new(state.desig.clone(), obs.jd, new_pos, vel, obs.center_id);
         (idx, contains, new_state)
     }
 
     /// Assuming the object undergoes two-body motion, check to see if it is within the
     /// field of view.
     #[inline]
-    fn check_two_body(&self, state: &State) -> Result<(usize, Contains, State), NEOSpyError> {
+    fn check_two_body(&self, state: &State<F>) -> Result<(usize, Contains, State<F>), NEOSpyError> {
         let obs = self.observer();
-        let obs_pos: Vector3<_> = obs.pos.into();
+        let obs_pos = obs.pos;
 
         // bring state up to observer time.
         let final_state = propagate_two_body(state, obs.jd)?;
 
         // correct for light delay
-        let dt = -(Vector3::from(final_state.pos) - obs_pos).norm() * C_AU_PER_DAY_INV;
+        let dt = -(final_state.pos - &obs_pos).norm() * C_AU_PER_DAY_INV;
         let final_state = propagate_two_body(&final_state, obs.jd + dt)?;
-        let rel_pos = Vector3::from(final_state.pos) - obs_pos;
+        let rel_pos = final_state.pos - &obs_pos;
 
         let (idx, contains) = self.contains(&rel_pos);
         Ok((idx, contains, final_state))
@@ -87,16 +77,17 @@ pub trait FovLike: Sync + Sized {
     /// Assuming the object undergoes n-body motion, check to see if it is within the
     /// field of view.
     #[inline]
-    fn check_n_body(&self, state: &State) -> Result<(usize, Contains, State), NEOSpyError> {
+    fn check_n_body(&self, state: &State<F>) -> Result<(usize, Contains, State<F>), NEOSpyError> {
         let obs = self.observer();
-        let obs_pos = Vector3::from(obs.pos);
+        let obs_pos = obs.pos;
 
-        let exact_state = propagate_n_body_spk(state.clone(), obs.jd, false, None)?;
+        let exact_state =
+            propagate_n_body_spk(state.clone().into_frame(), obs.jd, false, None)?.into_frame();
 
         // correct for light delay
-        let dt = -(Vector3::from(exact_state.pos) - obs_pos).norm() * C_AU_PER_DAY_INV;
+        let dt = -(exact_state.pos - &obs_pos).norm() * C_AU_PER_DAY_INV;
         let final_state = propagate_two_body(&exact_state, obs.jd + dt)?;
-        let rel_pos = Vector3::from(final_state.pos) - obs_pos;
+        let rel_pos = final_state.pos - &obs_pos;
 
         let (idx, contains) = self.contains(&rel_pos);
 
@@ -126,17 +117,19 @@ pub trait FovLike: Sync + Sized {
     ///             to 10 (the Sun).
     /// * `dt_limit` - Length of time in days where two body motion is considered valid.
     ///
-    fn check_visible(&self, states: &[State], dt_limit: f64) -> Vec<Option<SimultaneousStates>> {
+    fn check_visible(
+        &self,
+        states: &[State<F>],
+        dt_limit: f64,
+    ) -> Vec<Option<SimultaneousStates<F>>> {
         let obs_state = self.observer();
 
-        let final_states: Vec<(usize, State)> = states
+        let final_states: Vec<(usize, State<F>)> = states
             .par_iter()
-            .filter_map(|state: &State| {
+            .filter_map(|state: &State<F>| {
                 // assuming linear motion, how far can the object have moved relative
                 // to the observer? Then add a factor of 2 for safety
-                let max_dist = (Vector3::from(state.vel) - Vector3::from(obs_state.vel)).norm()
-                    * dt_limit
-                    * 2.0;
+                let max_dist = (state.vel - &obs_state.vel).norm() * dt_limit * 2.0;
 
                 if (state.jd - obs_state.jd).abs() < dt_limit {
                     let (_, contains, _) = self.check_linear(state);
@@ -166,7 +159,7 @@ pub trait FovLike: Sync + Sized {
             })
             .collect();
 
-        let mut detector_states = vec![Vec::<State>::new(); self.n_patches()];
+        let mut detector_states = vec![Vec::<State<F>>::new(); self.n_patches()];
         for (idx, state) in final_states.into_iter() {
             detector_states[idx].push(state)
         }
@@ -182,23 +175,23 @@ pub trait FovLike: Sync + Sized {
 
     /// Given an object ID, attempt to load the object from the SPKs.
     /// This will fail silently if the object is not found.
-    fn check_spks(&self, obj_ids: &[i64]) -> Vec<Option<SimultaneousStates>> {
+    fn check_spks(&self, obj_ids: &[i64]) -> Vec<Option<SimultaneousStates<F>>> {
         let obs = self.observer();
         let spk = get_spk_singleton().try_read().unwrap();
 
-        let mut visible: Vec<Vec<State>> = vec![Vec::new(); self.n_patches()];
+        let mut visible: Vec<Vec<State<F>>> = vec![Vec::new(); self.n_patches()];
 
         let states: Vec<_> = obj_ids
             .into_par_iter()
-            .filter_map(|&obj_id| {
-                match spk.try_get_state(obj_id, obs.jd, obs.center_id, obs.frame) {
+            .filter_map(
+                |&obj_id| match spk.try_get_state(obj_id, obs.jd, obs.center_id) {
                     Ok(state) => match self.check_linear(&state) {
                         (idx, Contains::Inside, state) => Some((idx, state)),
                         _ => None,
                     },
                     _ => None,
-                }
-            })
+                },
+            )
             .collect();
 
         states
@@ -215,8 +208,8 @@ pub trait FovLike: Sync + Sized {
     }
 
     /// Given a collection of static positions, return all which are visible.
-    fn check_statics(&self, pos: &[Vector3<f64>]) -> Vec<Option<(Vec<Vector3<f64>>, FOV)>> {
-        let mut visible: Vec<Vec<Vector3<f64>>> = vec![Vec::new(); self.n_patches()];
+    fn check_statics(&self, pos: &[Vector<F>]) -> Vec<Option<(Vec<Vector<F>>, FOV)>> {
+        let mut visible: Vec<Vec<Vector<F>>> = vec![Vec::new(); self.n_patches()];
 
         let vis_pos: Vec<_> = pos
             .iter()

--- a/src/neospy_core/src/fov/generic.rs
+++ b/src/neospy_core/src/fov/generic.rs
@@ -135,19 +135,18 @@ mod tests {
     use crate::constants::GMS_SQRT;
     use crate::frames::Ecliptic;
     use crate::prelude::*;
-    use crate::state::Desig;
 
     #[test]
     fn test_check_visible() {
         let circular = State::<Ecliptic>::new(
-            Desig::Empty,
+            None,
             2451545.0,
             [0.0, 1., 0.0].into(),
             [-GMS_SQRT, 0.0, 0.0].into(),
             0,
         );
         let circular_back = State::<Ecliptic>::new(
-            Desig::Empty,
+            None,
             2451545.0,
             [1.0, 0.0, 0.0].into(),
             [0.0, GMS_SQRT, 0.0].into(),

--- a/src/neospy_core/src/fov/mod.rs
+++ b/src/neospy_core/src/fov/mod.rs
@@ -9,7 +9,6 @@ pub mod ztf;
 
 pub use fov_like::*;
 pub use generic::*;
-use nalgebra::Vector3;
 pub use neos::*;
 pub use patches::*;
 pub use wise::*;
@@ -17,7 +16,10 @@ pub use ztf::*;
 
 use serde::{Deserialize, Serialize};
 
-use crate::prelude::*;
+use crate::{
+    frames::{Equatorial, Vector},
+    prelude::*,
+};
 
 /// Allowed FOV objects, either contiguous or joint.
 /// Many of these exist solely to carry additional metadata.
@@ -33,10 +35,10 @@ pub enum FOV {
     ZtfCcdQuad(ZtfCcdQuad),
 
     /// Generic cone FOV without any additional metadata.
-    GenericCone(GenericCone),
+    GenericCone(GenericCone<Equatorial>),
 
     /// Generic rectangle FOV without any additional metadata.
-    GenericRectangle(GenericRectangle),
+    GenericRectangle(GenericRectangle<Equatorial>),
 
     /// Full ZTF field of up to 64 individual files.
     ZtfField(ZtfField),
@@ -47,7 +49,11 @@ pub enum FOV {
 
 impl FOV {
     /// Check if a collection of states are visible to this FOV using orbital propagation
-    pub fn check_visible(self, states: &[State], dt_limit: f64) -> Vec<Option<SimultaneousStates>> {
+    pub fn check_visible(
+        self,
+        states: &[State<Equatorial>],
+        dt_limit: f64,
+    ) -> Vec<Option<SimultaneousStates<Equatorial>>> {
         match self {
             FOV::Wise(fov) => fov.check_visible(states, dt_limit),
             FOV::NeosCmos(fov) => fov.check_visible(states, dt_limit),
@@ -60,7 +66,7 @@ impl FOV {
     }
 
     /// Observer position in this FOV
-    pub fn observer(&self) -> &State {
+    pub fn observer(&self) -> &State<Equatorial> {
         match self {
             FOV::Wise(fov) => fov.observer(),
             FOV::NeosCmos(fov) => fov.observer(),
@@ -73,7 +79,7 @@ impl FOV {
     }
 
     /// Check if any loaded SPK objects are visible to this FOV
-    pub fn check_spks(&self, obj_ids: &[i64]) -> Vec<Option<SimultaneousStates>> {
+    pub fn check_spks(&self, obj_ids: &[i64]) -> Vec<Option<SimultaneousStates<Equatorial>>> {
         match self {
             FOV::Wise(fov) => fov.check_spks(obj_ids),
             FOV::NeosCmos(fov) => fov.check_spks(obj_ids),
@@ -87,7 +93,10 @@ impl FOV {
 
     /// Check if static sources are visible in this FOV.
     /// Position must be in the correct frame!
-    pub fn check_statics(&self, pos: &[Vector3<f64>]) -> Vec<Option<(Vec<Vector3<f64>>, FOV)>> {
+    pub fn check_statics(
+        &self,
+        pos: &[Vector<Equatorial>],
+    ) -> Vec<Option<(Vec<Vector<Equatorial>>, FOV)>> {
         match self {
             FOV::Wise(fov) => fov.check_statics(pos),
             FOV::NeosCmos(fov) => fov.check_statics(pos),
@@ -96,19 +105,6 @@ impl FOV {
             FOV::GenericRectangle(fov) => fov.check_statics(pos),
             FOV::ZtfField(fov) => fov.check_statics(pos),
             FOV::NeosVisit(fov) => fov.check_statics(pos),
-        }
-    }
-
-    /// Change the frame of this FOV
-    pub fn try_frame_change_mut(&mut self, target_frame: Frame) -> Result<(), NEOSpyError> {
-        match self {
-            FOV::Wise(fov) => fov.try_frame_change_mut(target_frame),
-            FOV::NeosCmos(fov) => fov.try_frame_change_mut(target_frame),
-            FOV::NeosVisit(fov) => fov.try_frame_change_mut(target_frame),
-            FOV::ZtfCcdQuad(fov) => fov.try_frame_change_mut(target_frame),
-            FOV::GenericCone(fov) => fov.try_frame_change_mut(target_frame),
-            FOV::GenericRectangle(fov) => fov.try_frame_change_mut(target_frame),
-            FOV::ZtfField(fov) => fov.try_frame_change_mut(target_frame),
         }
     }
 }

--- a/src/neospy_core/src/fov/neos.rs
+++ b/src/neospy_core/src/fov/neos.rs
@@ -1,9 +1,8 @@
 //! # NEOS field of views
 use super::{closest_inside, Contains, FovLike, OnSkyRectangle, SkyPatch, FOV};
 use crate::constants::{NEOS_HEIGHT, NEOS_WIDTH};
-use crate::frames::rotate_around;
+use crate::frames::{Equatorial, Vector};
 use crate::prelude::*;
-use nalgebra::Vector3;
 use serde::{Deserialize, Serialize};
 
 /// NEOS bands
@@ -35,10 +34,10 @@ impl From<u8> for NeosBand {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NeosCmos {
     /// State of the observer
-    observer: State,
+    observer: State<Equatorial>,
 
     /// Patch of sky
-    pub patch: OnSkyRectangle,
+    pub patch: OnSkyRectangle<Equatorial>,
 
     /// Rotation of the FOV.
     pub rotation: f64,
@@ -73,9 +72,9 @@ impl NeosCmos {
     /// Create a NEOS FOV
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        pointing: Vector3<f64>,
+        pointing: Vector<Equatorial>,
         rotation: f64,
-        observer: State,
+        observer: State<Equatorial>,
         side_id: u16,
         stack_id: u8,
         quad_id: u8,
@@ -85,8 +84,7 @@ impl NeosCmos {
         cmos_id: u8,
         band: NeosBand,
     ) -> Self {
-        let patch =
-            OnSkyRectangle::new(pointing, rotation, NEOS_WIDTH, NEOS_HEIGHT, observer.frame);
+        let patch = OnSkyRectangle::new(pointing, rotation, NEOS_WIDTH, NEOS_HEIGHT);
         Self {
             observer,
             patch,
@@ -103,7 +101,7 @@ impl NeosCmos {
     }
 }
 
-impl FovLike for NeosCmos {
+impl FovLike<Equatorial> for NeosCmos {
     fn get_fov(&self, index: usize) -> FOV {
         if index != 0 {
             panic!("FOV only has a single patch")
@@ -112,24 +110,18 @@ impl FovLike for NeosCmos {
     }
 
     #[inline]
-    fn observer(&self) -> &State {
+    fn observer(&self) -> &State<Equatorial> {
         &self.observer
     }
 
     #[inline]
-    fn contains(&self, obs_to_obj: &Vector3<f64>) -> (usize, Contains) {
+    fn contains(&self, obs_to_obj: &Vector<Equatorial>) -> (usize, Contains) {
         (0, self.patch.contains(obs_to_obj))
     }
 
     #[inline]
     fn n_patches(&self) -> usize {
         1
-    }
-
-    fn try_frame_change_mut(&mut self, target_frame: Frame) -> Result<(), NEOSpyError> {
-        self.observer.try_change_frame_mut(target_frame)?;
-        self.patch = self.patch.try_frame_change(target_frame)?;
-        Ok(())
     }
 }
 
@@ -140,7 +132,7 @@ pub struct NeosVisit {
     chips: Box<[NeosCmos; 4]>,
 
     /// Observer position
-    observer: State,
+    observer: State<Equatorial>,
 
     /// Rotation of the FOV.
     pub rotation: f64,
@@ -226,9 +218,9 @@ impl NeosVisit {
         x_width: f64,
         y_width: f64,
         gap_angle: f64,
-        pointing: Vector3<f64>,
+        pointing: Vector<Equatorial>,
         rotation: f64,
-        observer: State,
+        observer: State<Equatorial>,
         side_id: u16,
         stack_id: u8,
         quad_id: u8,
@@ -240,7 +232,7 @@ impl NeosVisit {
         // Rotate the Z axis to match the defined rotation angle, this vector is not
         // orthogonal to the pointing vector, but is in the correct plane of the final
         // up vector.
-        let up_vec = rotate_around(&Vector3::new(0.0, 0.0, 1.0), pointing, -rotation);
+        let up_vec = Vector::new([0.0, 0.0, 1.0]).rotate_around(pointing, -rotation);
 
         // construct the vector orthogonal to the pointing and rotated z axis vectors.
         let left_vec = pointing.cross(&up_vec);
@@ -260,58 +252,26 @@ impl NeosVisit {
         // pointing vector is in the middle of the 'a' in the central gap.
 
         // the Y direction is bounded by 2 planes, calculate them one time
-        let y_top: Vector3<f64> = rotate_around(&up_vec, left_vec, y_width / 2.0);
-        let y_bottom: Vector3<f64> = rotate_around(&(-up_vec), left_vec, -y_width / 2.0);
+        let y_top = up_vec.rotate_around(left_vec, y_width / 2.0);
+        let y_bottom = (-up_vec).rotate_around(left_vec, -y_width / 2.0);
 
         let half_gap = gap_angle / 2.0;
 
         // for each chip calculate the x bounds
-        let chip_1_a: Vector3<f64> = rotate_around(&left_vec, up_vec, -x_width / 2.0);
-        let chip_1_b: Vector3<f64> = -rotate_around(&left_vec, up_vec, -x_width / 4.0 - half_gap);
-        let chip_2_a: Vector3<f64> = rotate_around(&left_vec, up_vec, -x_width / 4.0 + half_gap);
-        let chip_2_b: Vector3<f64> = -rotate_around(&left_vec, up_vec, -half_gap);
-        let chip_3_a: Vector3<f64> = rotate_around(&left_vec, up_vec, half_gap);
-        let chip_3_b: Vector3<f64> = -rotate_around(&left_vec, up_vec, x_width / 4.0 - half_gap);
-        let chip_4_a: Vector3<f64> = rotate_around(&left_vec, up_vec, x_width / 4.0 + half_gap);
-        let chip_4_b: Vector3<f64> = -rotate_around(&left_vec, up_vec, x_width / 2.0);
+        let chip_1_a = left_vec.rotate_around(up_vec, -x_width / 2.0);
+        let chip_1_b = -left_vec.rotate_around(up_vec, -x_width / 4.0 - half_gap);
+        let chip_2_a = left_vec.rotate_around(up_vec, -x_width / 4.0 + half_gap);
+        let chip_2_b = -left_vec.rotate_around(up_vec, -half_gap);
+        let chip_3_a = left_vec.rotate_around(up_vec, half_gap);
+        let chip_3_b = -left_vec.rotate_around(up_vec, x_width / 4.0 - half_gap);
+        let chip_4_a = left_vec.rotate_around(up_vec, x_width / 4.0 + half_gap);
+        let chip_4_b = -left_vec.rotate_around(up_vec, x_width / 2.0);
 
         // make the patches for each chip
-        let chip_1_patch = OnSkyRectangle::from_normals(
-            [
-                chip_1_a.into(),
-                y_top.into(),
-                chip_1_b.into(),
-                y_bottom.into(),
-            ],
-            observer.frame,
-        );
-        let chip_2_patch = OnSkyRectangle::from_normals(
-            [
-                chip_2_a.into(),
-                y_top.into(),
-                chip_2_b.into(),
-                y_bottom.into(),
-            ],
-            observer.frame,
-        );
-        let chip_3_patch = OnSkyRectangle::from_normals(
-            [
-                chip_3_a.into(),
-                y_top.into(),
-                chip_3_b.into(),
-                y_bottom.into(),
-            ],
-            observer.frame,
-        );
-        let chip_4_patch = OnSkyRectangle::from_normals(
-            [
-                chip_4_a.into(),
-                y_top.into(),
-                chip_4_b.into(),
-                y_bottom.into(),
-            ],
-            observer.frame,
-        );
+        let chip_1_patch = OnSkyRectangle::from_normals([chip_1_a, y_top, chip_1_b, y_bottom]);
+        let chip_2_patch = OnSkyRectangle::from_normals([chip_2_a, y_top, chip_2_b, y_bottom]);
+        let chip_3_patch = OnSkyRectangle::from_normals([chip_3_a, y_top, chip_3_b, y_bottom]);
+        let chip_4_patch = OnSkyRectangle::from_normals([chip_4_a, y_top, chip_4_b, y_bottom]);
 
         // make the chips
         let chip_1 = NeosCmos {
@@ -384,25 +344,25 @@ impl NeosVisit {
     }
 
     /// Return the central pointing vector.
-    pub fn pointing(&self) -> Vector3<f64> {
-        let mut pointing = Vector3::<f64>::zeros();
+    pub fn pointing(&self) -> Vector<Equatorial> {
+        let mut pointing = Vector::new([0.0; 3]);
         self.chips
             .iter()
-            .for_each(|chip| pointing += *chip.patch.pointing());
+            .for_each(|chip| pointing = pointing + &chip.patch.pointing());
         pointing.normalize()
     }
 }
 
-impl FovLike for NeosVisit {
+impl FovLike<Equatorial> for NeosVisit {
     fn get_fov(&self, index: usize) -> FOV {
         FOV::NeosCmos(self.chips[index].clone())
     }
 
-    fn observer(&self) -> &State {
+    fn observer(&self) -> &State<Equatorial> {
         &self.observer
     }
 
-    fn contains(&self, obs_to_obj: &Vector3<f64>) -> (usize, Contains) {
+    fn contains(&self, obs_to_obj: &Vector<Equatorial>) -> (usize, Contains) {
         closest_inside(
             &self
                 .chips
@@ -414,15 +374,5 @@ impl FovLike for NeosVisit {
 
     fn n_patches(&self) -> usize {
         4
-    }
-
-    fn try_frame_change_mut(&mut self, target_frame: Frame) -> Result<(), NEOSpyError> {
-        let _ = self
-            .chips
-            .iter_mut()
-            .map(|ccd| ccd.try_frame_change_mut(target_frame))
-            .collect::<Result<Vec<_>, _>>()?;
-        self.observer.try_change_frame_mut(target_frame)?;
-        Ok(())
     }
 }

--- a/src/neospy_core/src/fov/patches.rs
+++ b/src/neospy_core/src/fov/patches.rs
@@ -1,9 +1,7 @@
 //! Basic Geometric shapes on a sphere (typically the celestial sphere)
 
-use crate::frames::{rotate_around, Frame};
+use crate::frames::{InertialFrame, Vector};
 use crate::io::serde_const_arr;
-use crate::prelude::NEOSpyError;
-use nalgebra::{UnitVector3, Vector3};
 use serde::{Deserialize, Serialize};
 use std::f64::consts::FRAC_PI_2;
 
@@ -44,18 +42,12 @@ pub(super) fn closest_inside(contains: &[Contains]) -> (usize, Contains) {
 }
 
 /// Trait which defines an area on the surface area of a sphere.
-pub trait SkyPatch: Sized {
+pub trait SkyPatch<T: InertialFrame>: Sized {
     /// Checks to see if a unit vector is within the bounded area.
-    fn contains(&self, obs_to_obj: &Vector3<f64>) -> Contains;
-
-    /// Frame of reference for the bounded area
-    fn frame(&self) -> Frame;
-
-    /// Change the frame of the bounded area to the new target frame.
-    fn try_frame_change(&self, target_frame: Frame) -> Result<Self, NEOSpyError>;
+    fn contains(&self, obs_to_obj: &Vector<T>) -> Contains;
 
     /// Center of the field of view
-    fn pointing(&self) -> UnitVector3<f64>;
+    fn pointing(&self) -> Vector<T>;
 }
 
 /// A Spherical Polygon as represented by a series of planes through the central axis.
@@ -77,31 +69,25 @@ pub trait SkyPatch: Sized {
 /// meaning that constructed polygons can only have great circle edges.
 ///
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct SphericalPolygon<const N_SIDES: usize> {
+pub struct SphericalPolygon<const N_SIDES: usize, T: InertialFrame> {
     /// Normal vectors which define the boundary of a polygon.
     #[serde(with = "serde_const_arr")]
-    edge_normals: [[f64; 3]; N_SIDES],
-
-    /// Coordinate frame where the boundary is defined.
-    pub frame: Frame,
+    edge_normals: [Vector<T>; N_SIDES],
 }
 
 /// A rectangular patch of sky.
-pub type OnSkyRectangle = SphericalPolygon<4>;
+pub type OnSkyRectangle<F> = SphericalPolygon<4, F>;
 
-impl OnSkyRectangle {
+impl<F: InertialFrame> OnSkyRectangle<F> {
     /// Construct a rectangular spherical polygon.
     ///
     /// # Arguments
     ///
     /// * `edge_normals` - Normal vectors which define the boundary of a polygon.
     /// * `frame` - Coordinate frame of the rectangle.
-    pub fn from_normals(edge_normals: [[f64; 3]; 4], frame: Frame) -> Self {
+    pub fn from_normals(edge_normals: [Vector<F>; 4]) -> Self {
         // construct the 4 normal vectors
-        Self {
-            edge_normals,
-            frame,
-        }
+        Self { edge_normals }
     }
 
     /// Construct a rectangular spherical polygon.
@@ -118,17 +104,11 @@ impl OnSkyRectangle {
     /// * `lat_width` - If the rotation is 0, this defines the width of the rectangle
     ///                 latitudinally in radians.
     /// * `frame` - Coordinate frame of the rectangle.
-    pub fn new(
-        pointing: Vector3<f64>,
-        rotation: f64,
-        lon_width: f64,
-        lat_width: f64,
-        frame: Frame,
-    ) -> Self {
+    pub fn new(pointing: Vector<F>, rotation: f64, lon_width: f64, lat_width: f64) -> Self {
         // Rotate the Z axis to match the defined rotation angle, this vector is not
         // orthogonal to the pointing vector, but is in the correct plane of the final
         // up vector.
-        let up_vec = rotate_around(&Vector3::new(0.0, 0.0, 1.0), pointing, -rotation);
+        let up_vec = Vector::new([0.0, 0.0, 1.0]).rotate_around(pointing, -rotation);
 
         // construct the vector orthogonal to the pointing and rotate z axis vectors.
         // left = cross(up, pointing)
@@ -141,52 +121,65 @@ impl OnSkyRectangle {
         let up_vec = pointing.cross(&left_vec);
 
         // These have to be enumerated in clockwise order for the pointing calculation to be correct.
-        let n1: Vector3<f64> = rotate_around(&left_vec, up_vec, -lon_width / 2.0);
-        let n2: Vector3<f64> = rotate_around(&up_vec, left_vec, lat_width / 2.0);
-        let n3: Vector3<f64> = rotate_around(&(-left_vec), up_vec, lon_width / 2.0);
-        let n4: Vector3<f64> = rotate_around(&(-up_vec), left_vec, -lat_width / 2.0);
+        let n1 = left_vec.rotate_around(up_vec, -lon_width / 2.0);
+        let n2 = up_vec.rotate_around(left_vec, lat_width / 2.0);
+        let n3 = (-left_vec).rotate_around(up_vec, lon_width / 2.0);
+        let n4 = (-up_vec).rotate_around(left_vec, -lat_width / 2.0);
 
         // construct the 4 normal vectors
         Self {
-            edge_normals: [n1.into(), n2.into(), n3.into(), n4.into()],
-            frame,
+            edge_normals: [n1, n2, n3, n4],
         }
     }
 
     /// Construct the patch from the 4 corners of the field of view.
     /// Corners have to be provided in the clockwise order around the center of the FOV.
-    pub fn from_corners(corners: [Vector3<f64>; 4], frame: Frame) -> Self {
+    pub fn from_corners(corners: [Vector<F>; 4]) -> Self {
         let n1 = corners[0].cross(&corners[1]).normalize();
         let n2 = corners[1].cross(&corners[2]).normalize();
         let n3 = corners[2].cross(&corners[3]).normalize();
         let n4 = corners[3].cross(&corners[0]).normalize();
 
         Self {
-            edge_normals: [n1.into(), n2.into(), n3.into(), n4.into()],
-            frame,
+            edge_normals: [n1, n2, n3, n4],
         }
     }
 
     /// Latitudinal width of the patch, the assumes the patch is rectangular.
     pub fn lat_width(&self) -> f64 {
         let pointing = self.pointing();
-        2.0 * (FRAC_PI_2 - pointing.angle(&Vector3::from(self.edge_normals[1])))
+        2.0 * (FRAC_PI_2 - pointing.angle(&self.edge_normals[1]))
     }
 
     /// Longitudinal width of the patch, the assumes the patch is rectangular.
     pub fn lon_width(&self) -> f64 {
         let pointing = self.pointing();
-        2.0 * (FRAC_PI_2 - pointing.angle(&Vector3::from(self.edge_normals[0])))
+        2.0 * (FRAC_PI_2 - pointing.angle(&self.edge_normals[0]))
     }
 }
 
-impl<const D: usize> SkyPatch for SphericalPolygon<D> {
+impl<const D: usize, F: InertialFrame> SphericalPolygon<D, F> {
+    /// Convert the frame of reference of this spherical polygon to a different frame
+    pub fn into_fram<Target: InertialFrame>(&self) -> SphericalPolygon<D, Target> {
+        let new_edges = self
+            .edge_normals
+            .iter()
+            .map(|vec| vec.into_frame())
+            .collect::<Vec<_>>();
+        let new_edges: [Vector<_>; D] = new_edges.try_into().unwrap();
+
+        SphericalPolygon::<D, Target> {
+            edge_normals: new_edges,
+        }
+    }
+}
+
+impl<const D: usize, T: InertialFrame> SkyPatch<T> for SphericalPolygon<D, T> {
     /// Is the obs_to_obj vector inside of the polygon.
-    fn contains(&self, obs_to_obj: &Vector3<f64>) -> Contains {
+    fn contains(&self, obs_to_obj: &Vector<T>) -> Contains {
         let mut closest_edge = f64::NEG_INFINITY;
         for normal in self.edge_normals.iter() {
-            let normal = Vector3::from(*normal);
-            let d = obs_to_obj.dot(&normal);
+            let d = obs_to_obj.dot(normal);
             if d.is_nan() {
                 return Contains::Outside(d);
             }
@@ -204,86 +197,59 @@ impl<const D: usize> SkyPatch for SphericalPolygon<D> {
         }
     }
 
-    fn frame(&self) -> Frame {
-        self.frame
-    }
-
-    fn try_frame_change(&self, target_frame: Frame) -> Result<Self, NEOSpyError> {
-        let new_edges = self
-            .edge_normals
-            .iter()
-            .map(|vec| {
-                self.frame
-                    .try_vec_frame_change(Vector3::from(*vec), target_frame)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        let new_edges: Vec<[f64; 3]> = new_edges.into_iter().map(|e| e.into()).collect();
-        let new_edges: [[f64; 3]; D] = new_edges.try_into().unwrap();
-
-        Ok(Self {
-            edge_normals: new_edges,
-            frame: target_frame,
-        })
-    }
-
-    fn pointing(&self) -> UnitVector3<f64> {
-        let mut x = 0.0;
-        let mut y = 0.0;
-        let mut z = 0.0;
+    fn pointing(&self) -> Vector<T> {
+        let mut final_vec = Vector::new([0.0; 3]);
 
         for (idx, idy) in (0..D).zip(1..D) {
-            let v = Vector3::from(self.edge_normals[idx])
-                .cross(&Vector3::from(self.edge_normals[idy]))
+            let v = self.edge_normals[idx]
+                .cross(&self.edge_normals[idy])
                 .normalize();
 
-            x += v.x;
-            y += v.y;
-            z += v.z;
+            final_vec = final_vec + &v;
         }
 
-        let v = Vector3::from(self.edge_normals[D - 1])
-            .cross(&Vector3::from(self.edge_normals[0]))
+        let v = self.edge_normals[D - 1]
+            .cross(&self.edge_normals[0])
             .normalize();
-        x += v.x;
-        y += v.y;
-        z += v.z;
+        final_vec = final_vec + &v;
 
-        UnitVector3::new_normalize([x, y, z].into())
+        final_vec.normalize()
     }
 }
 
 /// Represent a cone on a sphere.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct SphericalCone {
+pub struct SphericalCone<F: InertialFrame> {
     /// Unit vector which defines the direction of the cone.
-    pointing: [f64; 3],
+    pointing: Vector<F>,
 
     /// Size of the cone in degrees.
     pub angle: f64,
-
-    frame: Frame,
 }
 
-impl SphericalCone {
+impl<F: InertialFrame> SphericalCone<F> {
     /// Construct a new `SphericalCone` given the central vector and the angle of the
     /// cone.
-    pub fn new(pointing: &Vector3<f64>, angle: f64, frame: Frame) -> Self {
+    pub fn new(pointing: &Vector<F>, angle: f64) -> Self {
         let pointing = pointing.normalize();
-        Self {
-            pointing: pointing.into(),
-            angle,
-            frame,
+        Self { pointing, angle }
+    }
+
+    /// Change the frame
+    pub fn into_frame<Target: InertialFrame>(&self) -> SphericalCone<Target> {
+        let pointing = self.pointing.into_frame();
+
+        SphericalCone::<Target> {
+            pointing,
+            angle: self.angle,
         }
     }
 }
 
-impl SkyPatch for SphericalCone {
+impl<F: InertialFrame> SkyPatch<F> for SphericalCone<F> {
     /// Is the obs_to_obj vector inside of the cone.
-    fn contains(&self, obs_to_obj: &Vector3<f64>) -> Contains {
-        let dist = Vector3::from(self.pointing)
-            .dot(&obs_to_obj.normalize())
-            .acos()
-            .abs();
+    fn contains(&self, obs_to_obj: &Vector<F>) -> Contains {
+        let dist = self.pointing.dot(&obs_to_obj.normalize()).acos().abs();
         match dist {
             // if d is less than the angle, it is inside cone
             d if d < self.angle => Contains::Inside,
@@ -309,29 +275,15 @@ impl SkyPatch for SphericalCone {
         }
     }
 
-    fn frame(&self) -> Frame {
-        self.frame
-    }
-
-    fn try_frame_change(&self, target_frame: Frame) -> Result<Self, NEOSpyError> {
-        let pointing = self
-            .frame
-            .try_vec_frame_change(Vector3::from(self.pointing), target_frame)?;
-
-        Ok(Self {
-            pointing: pointing.into(),
-            angle: self.angle,
-            frame: target_frame,
-        })
-    }
-
-    fn pointing(&self) -> UnitVector3<f64> {
-        UnitVector3::new_normalize(self.pointing.into())
+    fn pointing(&self) -> Vector<F> {
+        self.pointing
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::frames::Ecliptic;
+
     use super::*;
 
     #[test]
@@ -341,8 +293,8 @@ mod tests {
         let outside = [1.0, 0.1, 0.0].into();
         let just_inside = [1.0, (0.05f64).sin() * 0.99, (0.05f64).sin() * 0.99].into();
         let just_outside = [1.0, (0.05f64).sin() * 1.01, (0.05f64).sin() * 1.01].into();
-        let fov = OnSkyRectangle::new([1.0, 0.0, 0.0].into(), 0.0, 0.1, 0.1, Frame::Ecliptic);
-        let fov_rot = OnSkyRectangle::new([1.0, 0.0, 0.0].into(), rot, 0.1, 0.1, Frame::Ecliptic);
+        let fov = OnSkyRectangle::<Ecliptic>::new([1.0, 0.0, 0.0].into(), 0.0, 0.1, 0.1);
+        let fov_rot = OnSkyRectangle::<Ecliptic>::new([1.0, 0.0, 0.0].into(), rot, 0.1, 0.1);
 
         assert!(fov.contains(&inside).is_inside());
         assert!(fov.contains(&just_inside).is_inside());
@@ -351,14 +303,14 @@ mod tests {
 
         assert!(fov_rot.contains(&inside).is_inside());
         assert!(!fov_rot.contains(&just_inside).is_inside());
-        assert!((fov_rot.pointing().into_inner() - Vector3::from([1.0, 0.0, 0.0])).norm() < 1e-10);
+        assert!((fov_rot.pointing() - &Vector::new([1.0, 0.0, 0.0])).norm() < 1e-10);
     }
 
     #[test]
     fn test_rectangular_patch_latlong() {
         let rot = (45f64).to_radians();
-        let fov = OnSkyRectangle::new([1.0, 0.0, 0.0].into(), 0.0, 0.1, 0.2, Frame::Ecliptic);
-        let fov_rot = OnSkyRectangle::new([1.0, 0.0, 0.0].into(), rot, 0.1, 0.2, Frame::Ecliptic);
+        let fov = OnSkyRectangle::<Ecliptic>::new([1.0, 0.0, 0.0].into(), 0.0, 0.1, 0.2);
+        let fov_rot = OnSkyRectangle::<Ecliptic>::new([1.0, 0.0, 0.0].into(), rot, 0.1, 0.2);
 
         assert!((fov.lat_width() - 0.2).abs() < 1e-10);
         assert!((fov.lon_width() - 0.1).abs() < 1e-10);

--- a/src/neospy_core/src/frames/definitions.rs
+++ b/src/neospy_core/src/frames/definitions.rs
@@ -9,7 +9,7 @@ use std::f64::consts::PI;
 use std::fmt::Debug;
 
 /// Frame which supports vector conversion
-pub trait InertialFrame: Sized + Sync + Send + Clone + Copy + Debug {
+pub trait InertialFrame: 'static + Sized + Sync + Send + Clone + Copy + Debug {
     /// Convert a vector from input frame to equatorial frame.
     fn to_equatorial(vec: Vector3<f64>) -> Vector3<f64>;
 

--- a/src/neospy_core/src/frames/mod.rs
+++ b/src/neospy_core/src/frames/mod.rs
@@ -4,7 +4,9 @@
 //!
 
 mod definitions;
+mod vector;
 mod wgs_84;
 
 pub use definitions::*;
+pub use vector::*;
 pub use wgs_84::*;

--- a/src/neospy_core/src/frames/vector.rs
+++ b/src/neospy_core/src/frames/vector.rs
@@ -1,0 +1,266 @@
+use super::{Ecliptic, Equatorial, InertialFrame};
+use nalgebra::{Rotation3, UnitVector3, Vector3};
+use serde::{Deserialize, Serialize};
+use std::f64::consts::{PI, TAU};
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::ops::{Add, Div, Index, IndexMut, Mul, Neg, Sub};
+
+/// Vector with frame information.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq)]
+pub struct Vector<T: InertialFrame> {
+    /// Julian Date
+    vec: [f64; 3],
+
+    /// PhantomData is used here as the scale is only a record keeping convenience.
+    frame: PhantomData<T>,
+}
+
+impl<T: InertialFrame> Vector<T> {
+    /// New Vector
+    pub fn new(vec: [f64; 3]) -> Self {
+        Vector::<T> {
+            vec,
+            frame: PhantomData,
+        }
+    }
+
+    /// New Vector of NANs
+    pub fn new_nan() -> Self {
+        Vector::<T> {
+            vec: [f64::NAN, f64::NAN, f64::NAN],
+            frame: PhantomData,
+        }
+    }
+
+    /// Convert Vector from one frame to another.
+    pub fn into_frame<Target: InertialFrame>(self) -> Vector<Target> {
+        let vec = T::convert::<Target>(self.into());
+        Vector::<Target>::new(vec.into())
+    }
+
+    /// Rotate a vector around the specified rotation vector.
+    ///
+    /// # Arguments
+    ///
+    /// * `rotation_vec` - The single vector around which to rotate the vectors.
+    /// * `angle` - The angle in radians to rotate the vectors.
+    ///
+    pub fn rotate_around(self, rotation_vec: Vector<T>, angle: f64) -> Self {
+        let rot =
+            Rotation3::from_axis_angle(&UnitVector3::new_normalize(rotation_vec.into()), angle);
+        rot.transform_vector(&self.into()).into()
+    }
+
+    /// Dot product between two vectors
+    pub fn dot(&self, other: &Vector<T>) -> f64 {
+        self.vec
+            .iter()
+            .zip(other.vec.iter())
+            .map(|(a, b)| a * b)
+            .sum()
+    }
+
+    /// Cross product between two vectors
+    pub fn cross(&self, other: &Vector<T>) -> Vector<T> {
+        Vector3::from(self.vec)
+            .cross(&Vector3::from(other.vec))
+            .into()
+    }
+
+    /// Squared euclidean length.
+    pub fn norm_squared(&self) -> f64 {
+        self.vec.iter().map(|a| a.powi(2)).sum()
+    }
+
+    /// The euclidean length of the vector.
+    pub fn norm(&self) -> f64 {
+        self.vec.iter().map(|a| a.powi(2)).sum::<f64>().sqrt()
+    }
+
+    /// THe angle betweeen two vectors in radians.
+    pub fn angle(&self, other: &Self) -> f64 {
+        Vector3::from(self.vec).angle(&Vector3::from(other.vec))
+    }
+
+    /// Create a new vector of unit length in the same direction as this vector.
+    pub fn normalize(&self) -> Self {
+        self / self.norm()
+    }
+
+    /// Create a unit vector from polar spherical theta and phi angles in radians.
+    ///
+    /// <https://en.wikipedia.org/wiki/Spherical_coordinate_system#Cartesian_coordinates>
+    pub fn from_polar_spherical(theta: f64, phi: f64) -> Self {
+        let (theta_sin, theta_cos) = theta.sin_cos();
+        let (phi_sin, phi_cos) = phi.sin_cos();
+        [theta_sin * phi_cos, theta_sin * phi_sin, theta_cos].into()
+    }
+
+    /// Convert a unit vector to polar spherical coordinates.
+    ///
+    /// <https://en.wikipedia.org/wiki/Spherical_coordinate_system#Cartesian_coordinates>
+    pub fn to_polar_spherical(&self) -> (f64, f64) {
+        let theta = self.vec[2].acos();
+        let phi = self.vec[1].atan2(self.vec[0]) % TAU;
+        (theta, phi)
+    }
+}
+
+impl Vector<Ecliptic> {
+    /// Create a unit vector from latitude and longitude in units of radians.
+    pub fn from_lat_lon(lat: f64, lon: f64) -> Self {
+        Self::from_polar_spherical(PI / 2.0 - lat, lon)
+    }
+
+    /// Convert a unit vector to latitude and longitude.
+    ///
+    /// Input vector needs to be in the [`Frame::Ecliptic`] frame.
+    pub fn to_lat_lon(self) -> (f64, f64) {
+        let (mut lat, mut lon) = self.to_polar_spherical();
+        if lat > PI {
+            lat = TAU - lat;
+            lon += PI
+        }
+        (PI / 2.0 - lat, lon)
+    }
+}
+
+impl Vector<Equatorial> {
+    /// Create a unit vector from ra and dec in units of radians.
+    pub fn from_ra_dec(ra: f64, dec: f64) -> Self {
+        Self::from_polar_spherical(PI / 2.0 - dec, ra)
+    }
+
+    /// Convert a unit vector to ra and dec.
+    ///
+    /// Input vector needs to be in the [`Frame::Equatorial`] frame.
+    pub fn to_ra_dec(self) -> (f64, f64) {
+        let (mut dec, mut ra) = self.to_polar_spherical();
+        if dec > PI {
+            dec = TAU - dec;
+            ra += PI
+        }
+        (ra, PI / 2.0 - dec)
+    }
+}
+
+impl<T: InertialFrame> Index<usize> for Vector<T> {
+    type Output = f64;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.vec[index]
+    }
+}
+
+impl<T: InertialFrame> IndexMut<usize> for Vector<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.vec[index]
+    }
+}
+
+impl<T: InertialFrame> IntoIterator for Vector<T> {
+    type Item = f64;
+    type IntoIter = std::array::IntoIter<Self::Item, 3>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vec.into_iter()
+    }
+}
+
+impl<T: InertialFrame> From<[f64; 3]> for Vector<T> {
+    fn from(value: [f64; 3]) -> Self {
+        Vector::new(value)
+    }
+}
+
+impl<T: InertialFrame> From<Vector3<f64>> for Vector<T> {
+    fn from(value: Vector3<f64>) -> Self {
+        Vector::new(value.into())
+    }
+}
+
+impl<T: InertialFrame> From<Vector<T>> for Vector3<f64> {
+    fn from(value: Vector<T>) -> Self {
+        value.vec.into()
+    }
+}
+
+impl<T: InertialFrame> From<Vector<T>> for [f64; 3] {
+    fn from(value: Vector<T>) -> Self {
+        value.vec
+    }
+}
+
+impl<T: InertialFrame> From<Vector<T>> for Vec<f64> {
+    fn from(value: Vector<T>) -> Self {
+        value.vec.into()
+    }
+}
+
+impl<T: InertialFrame> Sub<&Vector<T>> for Vector<T> {
+    type Output = Vector<T>;
+    fn sub(mut self, rhs: &Vector<T>) -> Self::Output {
+        (0..3).for_each(|i| self.vec[i] -= rhs.vec[i]);
+        self
+    }
+}
+
+impl<T: InertialFrame> Add<&Vector<T>> for Vector<T> {
+    type Output = Vector<T>;
+    fn add(mut self, rhs: &Vector<T>) -> Self::Output {
+        (0..3).for_each(|i| self.vec[i] += rhs.vec[i]);
+        self
+    }
+}
+
+impl<T: InertialFrame> Div<f64> for Vector<T> {
+    type Output = Vector<T>;
+    fn div(mut self, rhs: f64) -> Self::Output {
+        (0..3).for_each(|i| self.vec[i] /= rhs);
+        self
+    }
+}
+
+impl<T: InertialFrame> Div<f64> for &Vector<T> {
+    type Output = Vector<T>;
+    fn div(self, rhs: f64) -> Self::Output {
+        let mut vec = self.vec;
+        (0..3).for_each(|i| vec[i] /= rhs);
+        vec.into()
+    }
+}
+
+impl<T: InertialFrame> Mul<f64> for Vector<T> {
+    type Output = Vector<T>;
+    fn mul(mut self, rhs: f64) -> Self::Output {
+        (0..3).for_each(|i| self.vec[i] *= rhs);
+        self
+    }
+}
+
+impl<T: InertialFrame> Mul<f64> for &Vector<T> {
+    type Output = Vector<T>;
+    fn mul(self, rhs: f64) -> Self::Output {
+        let mut vec = self.vec;
+        (0..3).for_each(|i| vec[i] *= rhs);
+        vec.into()
+    }
+}
+
+impl<T: InertialFrame> Neg for &Vector<T> {
+    type Output = Vector<T>;
+    fn neg(self) -> Self::Output {
+        let mut vec = self.vec;
+        (0..3).for_each(|i| vec[i] = -vec[i]);
+        vec.into()
+    }
+}
+
+impl<T: InertialFrame> Neg for Vector<T> {
+    type Output = Vector<T>;
+    fn neg(self) -> Self::Output {
+        let mut vec = self.vec;
+        (0..3).for_each(|i| vec[i] = -vec[i]);
+        vec.into()
+    }
+}

--- a/src/neospy_core/src/lib.rs
+++ b/src/neospy_core/src/lib.rs
@@ -53,7 +53,6 @@ pub mod prelude {
         black_body_flux, frm_facet_temperature, lambertian_flux, neatm_facet_temperature,
         CometMKParams, FrmParams, HGParams, NeatmParams,
     };
-    pub use crate::frames::Frame;
     pub use crate::propagation::{propagate_n_body_spk, propagate_two_body};
     pub use crate::simult_states::SimultaneousStates;
     pub use crate::spice::{get_pck_singleton, get_spk_singleton};

--- a/src/neospy_core/src/propagation/kepler.rs
+++ b/src/neospy_core/src/propagation/kepler.rs
@@ -3,10 +3,10 @@
 //! such as the solar system.
 //!
 
-use crate::constants::*;
 use crate::errors::NEOSpyError;
 use crate::fitting::newton_raphson;
 use crate::state::State;
+use crate::{constants::*, frames::InertialFrame};
 use nalgebra::{ComplexField, Vector3};
 use std::f64::consts::TAU;
 
@@ -310,7 +310,10 @@ pub fn analytic_2_body(
 /// recommended to use a center of the Sun (10) for this computation.
 ///
 /// This is the fastest method for getting a relatively good estimate of the orbits.
-pub fn propagate_two_body(state: &State, jd_final: f64) -> Result<State, NEOSpyError> {
+pub fn propagate_two_body<F: InertialFrame>(
+    state: &State<F>,
+    jd_final: f64,
+) -> Result<State<F>, NEOSpyError> {
     let (pos, vel) = analytic_2_body(
         jd_final - state.jd,
         &state.pos.into(),
@@ -321,9 +324,8 @@ pub fn propagate_two_body(state: &State, jd_final: f64) -> Result<State, NEOSpyE
     Ok(State::new(
         state.desig.to_owned(),
         jd_final,
-        pos,
-        vel,
-        state.frame,
+        pos.into(),
+        vel.into(),
         state.center_id,
     ))
 }

--- a/src/neospy_core/src/propagation/mod.rs
+++ b/src/neospy_core/src/propagation/mod.rs
@@ -144,7 +144,7 @@ pub fn propagation_n_body_vec(
 
     let mut pos: Vec<f64> = Vec::new();
     let mut vel: Vec<f64> = Vec::new();
-    let mut desigs: Vec<Desig> = Vec::new();
+    let mut desigs: Vec<Option<Desig>> = Vec::new();
 
     for (id, _mass, _radius) in MASSIVE_OBJECTS.iter() {
         let planet: State<Equatorial> = spk.try_get_state(*id, jd_init, 0)?;

--- a/src/neospy_core/src/propagation/state_transition.rs
+++ b/src/neospy_core/src/propagation/state_transition.rs
@@ -1,113 +1,119 @@
-use crate::constants::GMS_SQRT;
-use crate::errors::NEOSpyError;
-use crate::prelude::State;
-use crate::propagation::{central_accel, central_accel_grad, CentralAccelMeta, RK45Integrator};
-use nalgebra::{Const, Matrix6, SVector, Vector3, U1, U6};
+// use crate::constants::GMS_SQRT;
+// use crate::errors::NEOSpyError;
+// use crate::frames::{Ecliptic, Equatorial};
+// use crate::prelude::State;
+// use crate::propagation::{central_accel, central_accel_grad, CentralAccelMeta, RK45Integrator};
+// use nalgebra::{Const, Matrix6, SVector, Vector3, U1, U6};
 
-fn stm_ivp_eqn(
-    jd: f64,
-    state: &SVector<f64, 42>,
-    meta: &mut CentralAccelMeta,
-    exact_eval: bool,
-) -> Result<SVector<f64, 42>, NEOSpyError> {
-    let mut res = SVector::<f64, 42>::zeros();
+// fn stm_ivp_eqn(
+//     jd: f64,
+//     state: &SVector<f64, 42>,
+//     meta: &mut CentralAccelMeta,
+//     exact_eval: bool,
+// ) -> Result<SVector<f64, 42>, NEOSpyError> {
+//     let mut res = SVector::<f64, 42>::zeros();
 
-    // first 6 values of the state are pos and vel respectively.
-    let pos = Vector3::new(state[0], state[1], state[2]);
-    let vel = Vector3::new(state[3], state[4], state[5]);
-    let accel = central_accel(jd, &pos, &vel, meta, exact_eval)?;
+//     // first 6 values of the state are pos and vel respectively.
+//     let pos = Vector3::new(state[0], state[1], state[2]);
+//     let vel = Vector3::new(state[3], state[4], state[5]);
+//     let accel = central_accel(jd, &pos, &vel, meta, exact_eval)?;
 
-    // the derivative of pos is the velocity, and the derivative of vel is the acceleration
-    // set those as appropriate for the output state
-    res.fixed_rows_mut::<3>(0).set_column(0, &vel);
-    res.fixed_rows_mut::<3>(3).set_column(0, &accel);
+//     // the derivative of pos is the velocity, and the derivative of vel is the acceleration
+//     // set those as appropriate for the output state
+//     res.fixed_rows_mut::<3>(0).set_column(0, &vel);
+//     res.fixed_rows_mut::<3>(3).set_column(0, &accel);
 
-    // the remainder of res is the state transition matrix calculation.
-    let mut stm = Matrix6::<f64>::zeros();
-    stm.fixed_view_mut::<3, 3>(0, 3)
-        .set_diagonal(&Vector3::repeat(1.0));
+//     // the remainder of res is the state transition matrix calculation.
+//     let mut stm = Matrix6::<f64>::zeros();
+//     stm.fixed_view_mut::<3, 3>(0, 3)
+//         .set_diagonal(&Vector3::repeat(1.0));
 
-    let grad = central_accel_grad(0.0, &pos, &vel, meta);
-    let mut view = stm.fixed_view_mut::<3, 3>(3, 0);
-    view.set_row(0, &grad.row(0));
-    view.set_row(1, &grad.row(1));
-    view.set_row(2, &grad.row(2));
+//     let grad = central_accel_grad(0.0, &pos, &vel, meta);
+//     let mut view = stm.fixed_view_mut::<3, 3>(3, 0);
+//     view.set_row(0, &grad.row(0));
+//     view.set_row(1, &grad.row(1));
+//     view.set_row(2, &grad.row(2));
 
-    let vec_reshape = state
-        .fixed_rows::<36>(6)
-        .into_owned()
-        .reshape_generic(U6, U6);
-    res.rows_mut(6, 36).set_column(
-        0,
-        &(stm * vec_reshape)
-            .into_owned()
-            .reshape_generic(Const::<36>, U1),
-    );
+//     let vec_reshape = state
+//         .fixed_rows::<36>(6)
+//         .into_owned()
+//         .reshape_generic(U6, U6);
+//     res.rows_mut(6, 36).set_column(
+//         0,
+//         &(stm * vec_reshape)
+//             .into_owned()
+//             .reshape_generic(Const::<36>, U1),
+//     );
 
-    Ok(res)
-}
+//     Ok(res)
+// }
+
+use nalgebra::Matrix6;
+
+use crate::{frames::Equatorial, state::State};
 
 /// Compute a state transition matrix assuming only 2-body mechanics.
 ///
 /// This uses a Runge-Kutta 4/5 algorithm.
 pub fn compute_state_transition(
-    state: &mut State,
-    jd: f64,
-    central_mass: f64,
+    _state: &mut State<Equatorial>,
+    _jd: f64,
+    _central_mass: f64,
 ) -> ([[f64; 3]; 2], Matrix6<f64>) {
-    let meta = CentralAccelMeta {
-        mass_scaling: central_mass,
-        ..Default::default()
-    };
+    panic!()
+    // let meta = CentralAccelMeta {
+    //     mass_scaling: central_mass,
+    //     ..Default::default()
+    // };
 
-    let mut initial_state = SVector::<f64, 42>::zeros();
+    // let mut initial_state = SVector::<f64, 42>::zeros();
 
-    initial_state.rows_mut(6, 36).set_column(
-        0,
-        &Matrix6::<f64>::identity().reshape_generic(Const::<36>, U1),
-    );
+    // initial_state.rows_mut(6, 36).set_column(
+    //     0,
+    //     &Matrix6::<f64>::identity().reshape_generic(Const::<36>, U1),
+    // );
 
-    initial_state
-        .fixed_rows_mut::<3>(0)
-        .set_column(0, &state.pos.into());
-    initial_state
-        .fixed_rows_mut::<3>(3)
-        .set_column(0, &(Vector3::from(state.vel) / GMS_SQRT));
-    let rad = RK45Integrator::integrate(
-        &stm_ivp_eqn,
-        initial_state,
-        state.jd * GMS_SQRT,
-        jd * GMS_SQRT,
-        meta,
-        1e-12,
-    )
-    .unwrap();
+    // initial_state
+    //     .fixed_rows_mut::<3>(0)
+    //     .set_column(0, &state.pos.into_frame());
+    // initial_state
+    //     .fixed_rows_mut::<3>(3)
+    //     .set_column(0, &(Vector3::from(state.vel) / GMS_SQRT));
+    // let rad = RK45Integrator::integrate(
+    //     &stm_ivp_eqn,
+    //     initial_state,
+    //     state.jd * GMS_SQRT,
+    //     jd * GMS_SQRT,
+    //     meta,
+    //     1e-12,
+    // )
+    // .unwrap();
 
-    let vec_reshape = rad
-        .0
-        .fixed_rows::<36>(6)
-        .into_owned()
-        .reshape_generic(U6, U6)
-        .transpose();
+    // let vec_reshape = rad
+    //     .0
+    //     .fixed_rows::<36>(6)
+    //     .into_owned()
+    //     .reshape_generic(U6, U6)
+    //     .transpose();
 
-    let scaling_a = Matrix6::<f64>::from_diagonal(
-        &[
-            1.0,
-            1.0,
-            1.0,
-            1.0 / GMS_SQRT,
-            1.0 / GMS_SQRT,
-            1.0 / GMS_SQRT,
-        ]
-        .into(),
-    );
-    let scaling_b =
-        Matrix6::<f64>::from_diagonal(&[1.0, 1.0, 1.0, GMS_SQRT, GMS_SQRT, GMS_SQRT].into());
-    (
-        [
-            rad.0.fixed_rows::<3>(0).into(),
-            (rad.0.fixed_rows::<3>(3) * GMS_SQRT).into(),
-        ],
-        scaling_a * vec_reshape * scaling_b,
-    )
+    // let scaling_a = Matrix6::<f64>::from_diagonal(
+    //     &[
+    //         1.0,
+    //         1.0,
+    //         1.0,
+    //         1.0 / GMS_SQRT,
+    //         1.0 / GMS_SQRT,
+    //         1.0 / GMS_SQRT,
+    //     ]
+    //     .into(),
+    // );
+    // let scaling_b =
+    //     Matrix6::<f64>::from_diagonal(&[1.0, 1.0, 1.0, GMS_SQRT, GMS_SQRT, GMS_SQRT].into());
+    // (
+    //     [
+    //         rad.0.fixed_rows::<3>(0).into(),
+    //         (rad.0.fixed_rows::<3>(3) * GMS_SQRT).into(),
+    //     ],
+    //     scaling_a * vec_reshape * scaling_b,
+    // )
 }

--- a/src/neospy_core/src/spice/pck.rs
+++ b/src/neospy_core/src/spice/pck.rs
@@ -10,7 +10,7 @@
 use super::daf::{DAFType, DafFile};
 use super::pck_segments::PckSegment;
 use crate::errors::NEOSpyError;
-use crate::frames::Frame;
+use crate::frames::EclipticNonInertial;
 
 use std::io::Cursor;
 use std::mem::MaybeUninit;
@@ -49,7 +49,11 @@ impl PckCollection {
 
     /// Get the raw orientation from the loaded PCK files.
     /// This orientation will have the frame of what was originally present in the file.
-    pub fn try_get_orientation(&self, id: isize, jd: f64) -> Result<Frame, NEOSpyError> {
+    pub fn try_get_orientation(
+        &self,
+        id: isize,
+        jd: f64,
+    ) -> Result<EclipticNonInertial, NEOSpyError> {
         for segment in self.segments.iter() {
             if id == segment.center_id && segment.contains(jd) {
                 return segment.try_get_orientation(jd);

--- a/src/neospy_core/src/spice/spk_segments.rs
+++ b/src/neospy_core/src/spice/spk_segments.rs
@@ -167,7 +167,7 @@ impl SpkSegment {
 
         match self.ref_frame {
             SpiceFrames::ECLIPJ2000 => Ok(State::<Ecliptic>::new(
-                Desig::Naif(self.obj_id),
+                Some(Desig::Naif(self.obj_id)),
                 jd,
                 pos.into(),
                 vel.into(),
@@ -175,7 +175,7 @@ impl SpkSegment {
             )
             .into_frame()),
             SpiceFrames::J2000 => Ok(State::<Equatorial>::new(
-                Desig::Naif(self.obj_id),
+                Some(Desig::Naif(self.obj_id)),
                 jd,
                 pos.into(),
                 vel.into(),


### PR DESCRIPTION
This is a fundamental rewrite of how rust backend handles frame of references.

There is no longer an Enum which defines possible frames, frame information is now embedded in the type information.
This helps with a few things:
- Less data to carry around (not a lot, but everything helps)
- Some conversions used to be fallible, now all frame conversions are infallible.
- NonInertialFrames are now their own Type, and support for them has been restricted to where it belongs.
- Vectors now exist in the Rust similar to the python, these Vectors carry Frame type information.
- 
Current testing shows a general slight speed improvements, I would imaging primarily coming from making everything infallible.