### PR TITLE
Cleaning up pyo3 interface code and fixing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Moved python wrappers over propagation into the rust backend entirely.
+- Simplified polymorphic support in the rust wrappers, removing some intermediate
+  objects which were over-complicating the interface.
+
+### Fixed
+
+- Fixed documentation on Time which was not being displayed correctly in python.
+
+
 ## [0.2.4] - 2024 - 7 - 15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 neospy_core = { version = "*", path = "src/neospy_core", features=["pyo3"]}
-pyo3 = { version =  "^0.21.2", features = ["extension-module"] }
+pyo3 = { version =  "^0.22.1", features = ["extension-module"] }
 serde = { version = "^1.0.203", features = ["derive"] }
 nalgebra = {version = "^0.33.0"}
 itertools = "^0.13.0"
@@ -29,3 +29,4 @@ default-members = ["src/neospy_core"]
 
 [profile.release]
 opt-level = 3
+pyo3_disable_reference_pool = true

--- a/docs/tutorials/background.rst
+++ b/docs/tutorials/background.rst
@@ -64,30 +64,30 @@ few milliseconds).
 
 Examples of time scales (roughly in order of creation):
 
-    - **TAI** - Time measured by atomic clocks on the surface of the Earth. This is
-      strictly monotonically increasing time, and is the basis for measurement of all
-      time.
-    - **Terrestrial Time (TT)** - Basically defined by 1 second on an atomic clock on
-      Earth's surface. It is a more modern equivalent to UT. Using the SI units
-      definition of a second. This is by definition offset from TAI by 32.184 seconds.
-    - **Universal Time (UT or UT1)** - Time scale based upon Earth's rotation with
-      respect to the ICRF reference frame. This is one of the oldest definitions.
-      Unfortunately, Earth's rotation rate varies slightly over time, due to this, this
-      definition slowly drifts from TT on a yearly basis. It can only be measured,
-      predicting it with accuracy is currently impossible. This is an inconvient system
-      when a regulatory agency is attempting to broadcast time to the world, as it is
-      constantly changing. A result of this was the creation of the UTC system.
-    - **Coordinated Universal Time (UTC)** - Equivalent scaling as Terrestrial Time(TT)
-      however, they are offset by ~32.184 seconds (this amount varies due to leap
-      seconds, which are covered below).
-    - **Ephemeris Time (ET)** - An attempt to fix the UT time to correct for Earths
-      rotation rate variance. This has been replaced by more modern scales. This has
-      been largely replaced by TDB time.
-    - **Barycentric Dynamical Time (TDB)** - Basically defined as 1 second of an atomic
-      clock in the reference frame of the Solar System, but outside of gravitational
-      fields. However an offset has been applied to make it as close to TT as is
-      reasonably possible. This is the current reference time which JPL Ephemeris
-      uses.
+  - **TAI** - Time measured by atomic clocks on the surface of the Earth. This is
+    strictly monotonically increasing time, and is the basis for measurement of all
+    time.
+  - **Terrestrial Time (TT)** - Basically defined by 1 second on an atomic clock on
+    Earth's surface. It is a more modern equivalent to UT. Using the SI units
+    definition of a second. This is by definition offset from TAI by 32.184 seconds.
+  - **Universal Time (UT or UT1)** - Time scale based upon Earth's rotation with
+    respect to the ICRF reference frame. This is one of the oldest definitions.
+    Unfortunately, Earth's rotation rate varies slightly over time, due to this, this
+    definition slowly drifts from TT on a yearly basis. It can only be measured,
+    predicting it with accuracy is currently impossible. This is an inconvient system
+    when a regulatory agency is attempting to broadcast time to the world, as it is
+    constantly changing. A result of this was the creation of the UTC system.
+  - **Coordinated Universal Time (UTC)** - Equivalent scaling as Terrestrial Time(TT)
+    however, they are offset by ~32.184 seconds (this amount varies due to leap
+    seconds, which are covered below).
+  - **Ephemeris Time (ET)** - An attempt to fix the UT time to correct for Earths
+    rotation rate variance. This has been replaced by more modern scales. This has
+    been largely replaced by TDB time.
+  - **Barycentric Dynamical Time (TDB)** - Basically defined as 1 second of an atomic
+    clock in the reference frame of the Solar System, but outside of gravitational
+    fields. However an offset has been applied to make it as close to TT as is
+    reasonably possible. This is the current reference time which JPL Ephemeris
+    uses.
 
 In addition to the rate of passage of time (scale), it is necessary to pick the 0
 point. Examples of this include the Julian Date (JD) or the Modified Julian Date (MJD).

--- a/docs/tutorials/propagation.rst
+++ b/docs/tutorials/propagation.rst
@@ -35,22 +35,22 @@ understanding of what is required in order to accurately model their motion. The
 listed in approximately the order of their effects on objects (though order may change
 due to varying circumstances).
 
-- *Newtonian Gravity* - Typically what is imagined when people say the force of gravity.
-- *Corrections for Relativity (GR)* - The orbit of Mercury precesses due to effects from 
+  - **Newtonian Gravity** - Typically what is imagined when people say the force of gravity.
+  - **Corrections for Relativity (GR)** - The orbit of Mercury precesses due to effects from 
     relativity, and in fact many NEOs, or even objects which get close enough to planets
     will experience effects from relativity.  
-- *Gravity from Minor Planets* - Main belt asteroids are often non-negligible.
+  - **Gravity from Minor Planets** - Main belt asteroids are often non-negligible.
     The motion of objects through the main belt often needs to include the mass of
     asteroids such as Ceres, which makes up an appreciable fraction of the total mass of
     the belt.  
-- *Oblateness of the Sun/Planets* - The Sun and Planets are not ideal spheres, and as a
+  - **Oblateness of the Sun/Planets** - The Sun and Planets are not ideal spheres, and as a
     result, cannot be exactly modeled as a point source. This non-sphericity can be
     written as an expansion of spherical harmonic-like terms, commonly written as `J`
     terms. The first non-trivial term of this expansion is the oblateness, referred to
     as `J2`. This term by itself will cause objects in orbit of the central mass to
     have their longitude of ascending node precess as a function of how inclined they
     are with respect to the equator of the central mass.  
-- *Non-gravitational Forces* - The forces above are a result of gravity, however there
+  - **Non-gravitational Forces** - The forces above are a result of gravity, however there
     are many potential forces which an object may experience, these include things such
     as outgassing, radiation pressure, the Yarkovsky effect, and the Poynting-Robertson
     effect. These effects typically have some relation to the total solar radiation that

--- a/src/neospy/propagation.py
+++ b/src/neospy/propagation.py
@@ -8,9 +8,9 @@ from typing import Optional
 from scipy import optimize
 import numpy as np
 
-from .vector import Vector, State
-from . import _core, spice
-from ._core import NonGravModel
+from .vector import State
+from . import spice
+from ._core import NonGravModel, propagate_n_body, propagate_two_body
 
 
 __all__ = [
@@ -19,78 +19,6 @@ __all__ = [
     "NonGravModel",
     "moid",
 ]
-
-
-def propagate_n_body(
-    states: list[State],
-    jd: float,
-    include_asteroids: bool = False,
-    non_gravs: Optional[list[NonGravModel]] = None,
-    suppress_errors: bool = True,
-) -> list[State]:
-    """
-    Propagate the provided :class:`~neospy.State` using N body mechanics to the
-    specified times, no approximations are made, this can be very CPU intensive.
-
-    This does not compute light delay, however it does include corrections for general
-    relativity due to the Sun.
-
-    Parameters
-    ----------
-    states:
-        The initial states, this is a list of multiple State objects.
-    jd:
-        A JD to propagate the initial states to.
-    include_asteroids:
-        If this is true, the computation will include the largest 5 asteroids.
-        The asteroids are: Ceres, Pallas, Interamnia, Hygiea, and Vesta.
-    non_gravs:
-        A list of non-gravitational terms for each object. If provided, then every
-        object must have an associated :class:`~NonGravModel` or `None`.
-    suppress_errors:
-        If True, errors during propagation will return NaN for the relevant state
-        vectors, but propagation will continue.
-
-    Returns
-    -------
-    Iterable
-        A :class:`~neospy.State` at the new time.
-    """
-    if non_gravs is None:
-        non_gravs = [None for _ in range(len(states))]
-    elif len(non_gravs) != len(states):
-        raise ValueError("non_gravs must be the same length as states.")
-    return _core.propagate_n_body_spk(
-        states, jd, include_asteroids, non_gravs, suppress_errors
-    )
-
-
-def propagate_two_body(
-    states: list[State],
-    jd: float,
-    observer_pos: Optional[Vector] = None,
-) -> list[State]:
-    """
-    Propagate the :class:`~neospy.State` for all the objects to the specified time.
-    This assumes 2 body interactions.
-
-    Parameters
-    ----------
-    states:
-        The input vector state to propagate.
-    jd:
-        The desired time at which to estimate the objects' state.
-    observer_pos:
-        A vector of length 3 describing the position of an observer. If this is
-        provided then the estimated states will be returned as a result of light
-        propagation delay.
-
-    Returns
-    -------
-    State
-        Final state after propagating to the target time.
-    """
-    return _core.propagate_two_body(states, jd, observer_pos)
 
 
 def _moid_single(obj0: State, other: State):

--- a/src/neospy/rust/covariance.rs
+++ b/src/neospy/rust/covariance.rs
@@ -125,7 +125,14 @@ impl Covariance {
                 .ok_or(NEOSpyError::ValueError("Covariance missing 'vz'".into()))?;
             let pos = VectorLike::Arr([x, y, z]);
             let vel = VectorLike::Arr([vx, vy, vz]);
-            Ok(PyState::new(Some(desig), epoch, pos, vel, None, None))
+            Ok(PyState::new(
+                Some(desig),
+                epoch.into(),
+                pos,
+                vel,
+                None,
+                None,
+            ))
         } else {
             Err(NEOSpyError::ValueError("Covariance cannot be converted to a state, \
             the covariance parameters must either contain: \

--- a/src/neospy/rust/flux/common.rs
+++ b/src/neospy/rust/flux/common.rs
@@ -84,7 +84,7 @@ pub fn solar_flux_py(dist: f64, wavelength: f64) -> PyResult<f64> {
 /// emissivity :
 ///     Emissivity of the object, 0.9 by default.
 #[pyfunction]
-#[pyo3(name = "sub_solar_temperature")]
+#[pyo3(name = "sub_solar_temperature", signature = (obj2sun, geom_albedo, g_param, beaming, emissivity=None))]
 pub fn sub_solar_temperature_py(
     obj2sun: VectorLike,
     geom_albedo: f64,
@@ -222,7 +222,7 @@ pub fn frm_facet_temperature_py(
 /// float
 ///     Flux in units of Jy.
 #[pyfunction]
-#[pyo3(name = "neatm_flux")]
+#[pyo3(name = "neatm_flux", signature = (sun2obj, sun2obs, v_albedo, g_param, beaming, diameter, wavelength, emissivity=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn neatm_thermal_py(
     sun2obj: VectorLike,
@@ -289,7 +289,7 @@ pub fn neatm_thermal_py(
 /// float
 ///     Flux in units of Jy.
 #[pyfunction]
-#[pyo3(name = "frm_flux")]
+#[pyo3(name = "frm_flux", signature = (sun2obj, sun2obs, v_albedo, g_param, diameter, wavelength, emissivity=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn frm_thermal_py(
     sun2obj: VectorLike,
@@ -370,7 +370,7 @@ pub fn frm_thermal_py(
 ///     (Total apparent magnitude, Magnitude of the nucleus)
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(name = "comet_apparent_mags")]
+#[pyo3(name = "comet_apparent_mags", signature = (sun2obj, sun2obs, mk_1=None, mk_2=None, phase_corr=None))]
 pub fn comet_mags_py(
     sun2obj: VectorLike,
     sun2obs: VectorLike,

--- a/src/neospy/rust/flux/models.rs
+++ b/src/neospy/rust/flux/models.rs
@@ -40,6 +40,7 @@ impl From<neospy_core::flux::ModelResults> for PyModelResults {
 #[pymethods]
 impl PyModelResults {
     #[new]
+    #[pyo3(signature = (fluxes, thermal_fluxes, hg_fluxes, v_band_magnitude, v_band_flux, magnitudes=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         fluxes: Vec<f64>,
@@ -188,6 +189,8 @@ impl From<neospy_core::flux::NeatmParams> for PyNeatmParams {
 impl PyNeatmParams {
     #[new]
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (desig, band_wavelength, band_albedos, h_mag=None, diam=None,
+        vis_albedo=None, beaming=None, g_param=None, c_hg=None, emissivity=None, zero_mags=None))]
     pub fn new(
         desig: String,
         band_wavelength: Vec<f64>,
@@ -225,6 +228,8 @@ impl PyNeatmParams {
     /// This requires all 4 albedos to be provided.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (desig, band_albedos, h_mag=None, diam=None, vis_albedo=None,
+        beaming=None, g_param=None, c_hg=None, emissivity=None))]
     pub fn new_wise(
         desig: String,
         band_albedos: Vec<f64>,
@@ -256,6 +261,8 @@ impl PyNeatmParams {
     /// Create a new NeatmParams with NEOS bands and zero magnitudes.
     /// This requires 2 albedos to be provided, one for each band.
     #[staticmethod]
+    #[pyo3(signature = (desig, band_albedos, h_mag=None, diam=None, vis_albedo=None, beaming=None,
+        g_param=None, c_hg=None, emissivity=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn new_neos(
         desig: String,
@@ -471,6 +478,8 @@ impl From<neospy_core::flux::FrmParams> for PyFrmParams {
 impl PyFrmParams {
     #[new]
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (desig, band_wavelength, band_albedos, h_mag=None, diam=None,
+        vis_albedo=None, g_param=None, c_hg=None, emissivity=None, zero_mags=None))]
     pub fn new(
         desig: String,
         band_wavelength: Vec<f64>,
@@ -505,6 +514,8 @@ impl PyFrmParams {
     /// This requires all 4 albedos to be provided.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (desig, band_albedos, h_mag=None, diam=None, vis_albedo=None, g_param=None,
+        c_hg=None, emissivity=None))]
     pub fn new_wise(
         desig: String,
         band_albedos: Vec<f64>,
@@ -532,6 +543,8 @@ impl PyFrmParams {
     /// This requires 2 albedos to be provided, one for each band.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (desig, band_albedos, h_mag=None, diam=None, vis_albedo=None, g_param=None,
+        c_hg=None, emissivity=None))]
     pub fn new_neos(
         desig: String,
         band_albedos: Vec<f64>,

--- a/src/neospy/rust/flux/reflected.rs
+++ b/src/neospy/rust/flux/reflected.rs
@@ -63,7 +63,8 @@ pub fn hg_phase_curve_correction_py(g_param: f64, phase_angle: f64) -> f64 {
 ///     Flux in Jy per unit frequency.
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(name = "hg_apparent_flux")]
+#[pyo3(name = "hg_apparent_flux", signature = (sun2obj, sun2obs, g_param, wavelength, v_albedo,
+    h_mag=None, diameter=None, c_hg=None))]
 pub fn hg_apparent_flux_py(
     sun2obj: VectorLike,
     sun2obs: VectorLike,

--- a/src/neospy/rust/fovs/checks.rs
+++ b/src/neospy/rust/fovs/checks.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 
 use crate::{
-    simult_states::{PySimultaneousStates, SimulStateLike},
+    simult_states::PySimultaneousStates,
     vector::{Vector, VectorLike},
 };
 
@@ -23,10 +23,10 @@ use crate::{
 /// dt: float
 ///     Length of time in days where 2-body mechanics is a good approximation.
 #[pyfunction]
-#[pyo3(name = "fov_state_check")]
+#[pyo3(name = "fov_state_check", signature = (obj_state, fovs, dt_limit=None))]
 pub fn fov_checks_py(
     py: Python<'_>,
-    obj_state: SimulStateLike,
+    obj_state: PySimultaneousStates,
     fovs: FOVListLike,
     dt_limit: Option<f64>,
 ) -> PyResult<Vec<PySimultaneousStates>> {
@@ -35,7 +35,7 @@ pub fn fov_checks_py(
     let fovs = fovs.into_sorted_vec_fov();
 
     // This is only here for a check to verify the states are valid
-    let pop = obj_state.into_simul_state(py)?;
+    let pop = obj_state.0;
 
     let mut jd = pop.jd;
     let mut big_jd = jd;

--- a/src/neospy/rust/frame.rs
+++ b/src/neospy/rust/frame.rs
@@ -2,7 +2,7 @@ use neospy_core::frames::*;
 use pyo3::prelude::*;
 
 /// Defined inertial frames supported by the python side of NEOSpy
-#[pyclass(frozen, name = "Frames", module = "neospy")]
+#[pyclass(frozen, eq, eq_int, name = "Frames", module = "neospy")]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PyFrames {
     Ecliptic,

--- a/src/neospy/rust/horizons.rs
+++ b/src/neospy/rust/horizons.rs
@@ -68,6 +68,9 @@ impl neospy_core::io::FileIO for HorizonsProperties {}
 impl HorizonsProperties {
     #[new]
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (desig, group=None, epoch=None, eccentricity=None, inclination=None,
+        lon_of_ascending=None, peri_arg=None, peri_dist=None, peri_time=None, h_mag=None,
+        vis_albedo=None, diameter=None, moid=None, g_phase=None, arc_len=None, covariance=None))]
     pub fn new(
         desig: String,
         group: Option<String>,

--- a/src/neospy/rust/kepler.rs
+++ b/src/neospy/rust/kepler.rs
@@ -7,6 +7,7 @@ use pyo3::{pyfunction, PyResult};
 use rayon::prelude::*;
 
 use crate::state::PyState;
+use crate::time::PyTime;
 use crate::vector::Vector;
 
 /// Solve kepler's equation for the Eccentric Anomaly.
@@ -43,8 +44,8 @@ pub fn compute_eccentric_anomaly_py(
         .collect())
 }
 
-/// Given a collection of states, and an amount of time (days). Move the states
-/// in time using two body mechanics by the desired `dt`.
+/// Propagate the :class:`~neospy.State` for all the objects to the specified time.
+/// This assumes 2 body interactions.
 ///
 /// This is a multi-core operation.
 ///
@@ -54,15 +55,23 @@ pub fn compute_eccentric_anomaly_py(
 ///     List of states, which are in units of AU from the Sun and velocity is in AU/Day.
 /// jd :
 ///     Time to integrate to in JD days with TDB scaling.
-/// sun2obj :
-///     Position of the observer in AU.
+/// observer_pos :
+///     A vector of length 3 describing the position of an observer. If this is
+///     provided then the estimated states will be returned as a result of light
+///     propagation delay.
+///
+/// Returns
+/// -------
+/// State
+///     Final states after propagating to the target time.
 #[pyfunction]
-#[pyo3(name = "propagate_two_body")]
+#[pyo3(name = "propagate_two_body", signature = (states, jd, observer_pos=None))]
 pub fn propagation_kepler_py(
     states: Vec<PyState>,
-    jd: f64,
-    sun2obs: Option<Vector>,
+    jd: PyTime,
+    observer_pos: Option<Vector>,
 ) -> Vec<PyState> {
+    let jd = jd.jd();
     states
         .par_iter()
         .map(|state| {
@@ -76,10 +85,10 @@ pub fn propagation_kepler_py(
                 return State::new_nan(state.0.desig.clone(), jd, state.0.frame, center).into();
             };
 
-            if let Some(sun2obs) = &sun2obs {
-                let sun2obs = Vector3::<f64>::from(sun2obs.raw);
+            if let Some(observer_pos) = &observer_pos {
+                let observer_pos = Vector3::<f64>::from(observer_pos.raw);
                 let delay =
-                    -(Vector3::from(new_state.pos) - sun2obs).norm() / constants::C_AU_PER_DAY;
+                    -(Vector3::from(new_state.pos) - observer_pos).norm() / constants::C_AU_PER_DAY;
 
                 new_state = match propagation::propagate_two_body(&new_state, new_state.jd + delay)
                 {

--- a/src/neospy/rust/lib.rs
+++ b/src/neospy/rust/lib.rs
@@ -1,4 +1,4 @@
-use pyo3::prelude::{pymodule, wrap_pyfunction, Bound, PyModule, PyResult, Python};
+use pyo3::prelude::*;
 
 mod covariance;
 mod elements;

--- a/src/neospy/rust/spice/pck.rs
+++ b/src/neospy/rust/spice/pck.rs
@@ -40,7 +40,7 @@ pub fn pck_load_py(filenames: Vec<String>) -> PyResult<()> {
 /// name : String
 ///     Optional name of the state.
 #[pyfunction]
-#[pyo3(name = "pck_earth_frame_to_ecliptic")]
+#[pyo3(name = "pck_earth_frame_to_ecliptic", signature = (pos, jd, new_center, name=None))]
 pub fn pck_earth_frame_py(
     pos: [f64; 3],
     jd: f64,

--- a/src/neospy/rust/spice/spk.rs
+++ b/src/neospy/rust/spice/spk.rs
@@ -3,6 +3,7 @@ use pyo3::{pyfunction, PyResult};
 
 use crate::frame::PyFrames;
 use crate::state::PyState;
+use crate::time::PyTime;
 
 /// Load all specified files into the SPK shared memory singleton.
 #[pyfunction]
@@ -78,7 +79,8 @@ pub fn spk_reset_py() {
 ///     Frame of reference for the state.
 #[pyfunction]
 #[pyo3(name = "spk_state")]
-pub fn spk_state_py(id: i64, jd: f64, center: i64, frame: PyFrames) -> PyResult<PyState> {
+pub fn spk_state_py(id: i64, jd: PyTime, center: i64, frame: PyFrames) -> PyResult<PyState> {
+    let jd = jd.jd();
     let spk = get_spk_singleton().try_read().unwrap();
     let mut state = spk.try_get_state(id, jd, center, frame.into())?;
     state.try_naif_id_to_name();
@@ -97,7 +99,8 @@ pub fn spk_state_py(id: i64, jd: f64, center: i64, frame: PyFrames) -> PyResult<
 ///     Time (JD) in TDB scaled time.
 #[pyfunction]
 #[pyo3(name = "spk_raw_state")]
-pub fn spk_raw_state_py(id: i64, jd: f64) -> PyResult<PyState> {
+pub fn spk_raw_state_py(id: i64, jd: PyTime) -> PyResult<PyState> {
+    let jd = jd.jd();
     let spk = get_spk_singleton().try_read().unwrap();
     Ok(PyState(spk.try_get_raw_state(id, jd)?))
 }

--- a/src/neospy/rust/state.rs
+++ b/src/neospy/rust/state.rs
@@ -1,5 +1,6 @@
 use crate::elements::PyCometElements;
 use crate::frame::*;
+use crate::time::PyTime;
 use crate::vector::*;
 use neospy_core::prelude;
 use pyo3::prelude::*;
@@ -22,7 +23,7 @@ impl PyState {
     #[pyo3(signature = (desig, jd, pos, vel, frame=None, center_id=10))]
     pub fn new(
         desig: Option<String>,
-        jd: f64,
+        jd: PyTime,
         pos: VectorLike,
         vel: VectorLike,
         frame: Option<PyFrames>,
@@ -49,7 +50,7 @@ impl PyState {
         let vel = vel.into_vec(frame);
 
         let center_id = center_id.unwrap_or(10);
-        let state = prelude::State::new(desig, jd, pos, vel, frame.into(), center_id);
+        let state = prelude::State::new(desig, jd.jd(), pos, vel, frame.into(), center_id);
         Self(state)
     }
 

--- a/src/neospy/rust/state_transition.rs
+++ b/src/neospy/rust/state_transition.rs
@@ -2,24 +2,26 @@ use neospy_core::prelude::*;
 use neospy_core::propagation::compute_state_transition;
 use pyo3::pyfunction;
 
+use crate::time::PyTime;
+
 #[pyfunction]
 #[pyo3(name = "compute_stm")]
 pub fn compute_stm_py(
     state: [f64; 6],
-    jd_start: f64,
-    jd_end: f64,
+    jd_start: PyTime,
+    jd_end: PyTime,
     central_mass: f64,
 ) -> ([[f64; 3]; 2], [[f64; 6]; 6]) {
     let mut state = State::new(
         Desig::Empty,
-        jd_start,
+        jd_start.jd(),
         [state[0], state[1], state[2]].into(),
         [state[3], state[4], state[5]].into(),
         Frame::Ecliptic,
         10,
     );
 
-    let (final_state, stm) = compute_state_transition(&mut state, jd_end, central_mass);
+    let (final_state, stm) = compute_state_transition(&mut state, jd_end.jd(), central_mass);
 
     (final_state, stm.into())
 }

--- a/src/neospy/rust/vector.rs
+++ b/src/neospy/rust/vector.rs
@@ -56,6 +56,7 @@ impl VectorLike {
 #[pymethods]
 impl Vector {
     #[new]
+    #[pyo3(signature = (raw, frame=None))]
     pub fn py_new(raw: VectorLike, frame: Option<PyFrames>) -> PyResult<Self> {
         match raw {
             VectorLike::Arr(raw) => {
@@ -107,6 +108,7 @@ impl Vector {
     /// r :
     ///     Optional length of the vector, defaults to 1.
     #[staticmethod]
+    #[pyo3(signature = (lat, lon, r=None))]
     pub fn from_lat_lon(lat: f64, lon: f64, r: Option<f64>) -> Self {
         Self::from_el_az(lat, lon, r.unwrap_or(1.0), PyFrames::Ecliptic)
     }
@@ -122,6 +124,7 @@ impl Vector {
     /// r :
     ///     Optional length of the vector, defaults to 1.
     #[staticmethod]
+    #[pyo3(signature = (ra, dec, r=None))]
     pub fn from_ra_dec(ra: f64, dec: f64, r: Option<f64>) -> Self {
         Self::from_el_az(dec, ra, r.unwrap_or(1.0), PyFrames::Equatorial)
     }

--- a/src/neospy_core/Cargo.toml
+++ b/src/neospy_core/Cargo.toml
@@ -12,7 +12,7 @@ kdtree = "^0.7.0"
 lazy_static = "^1.5.0"
 nalgebra = {version = "^0.33.0"}
 pathfinding = "^4.10.0"
-pyo3 = { version =  "^0.21.2", optional=true }
+pyo3 = { version =  "^0.22.1", optional=true}
 rayon = "^1.10.0"
 serde = { version = "^1.0.203", features = ["derive"] }
 crossbeam = "^0.8.4"


### PR DESCRIPTION
I went in just to fix a documentation error on the Time class, but this ended up being a bit of a rabbit hole.

This bumps the version of Pyo3 up to a more recent one, which caused a lot of knock-on effects. These led to having to update a fairly large chunk of the interface code, which was a significant improvements.


### Details:

This also removed 2 intermediate enums on the rust side which only existed to allow polymorphic input support for the rust functions. These got replaced by custom `FromPyObject` pyo3 trait implementations, and I think overall made the code much cleaner.