### PR TITLE
Updating Wheel construction

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -39,7 +39,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - run: cargo test --all-features
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -63,6 +63,6 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           CONDA_HOME: /usr/local/miniconda
         run: python3 -m cibuildwheel --output-dir wheelhouse
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         lfs: true
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.9"
     - name: Test with cargo
@@ -64,7 +64,7 @@ jobs:
           echo "::warning title=Invalid file permissions automatically fixed::$line"
         done
     - name: Upload Docs artifact
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v4
       with:
         name: "docs"
         path:


### PR DESCRIPTION
Updates github actions to have python 3.10, 3.11, 3.12 built for mac os arm chips, windows x64, and linux x64. For a total of 9 possible version combinations.
Compiled code is tested during construction to ensure it passes on each arch.

This is a necessary step for the eventual release on pypi.