### PR TITLE
V1.0.0 Release

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -67,3 +67,21 @@ jobs:
         with:
           name: wheel-cp${{ matrix.python }}-${{ matrix.platform_id }}
           path: ./wheelhouse/*.whl
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build_wheels
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/kete
+    permissions:
+      id-token: write
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: wheel-cp*.whl
+        path: wheelhouse/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [v1.0.0]
 
 ### Added
 
@@ -256,6 +256,7 @@ Initial Release
 
 
 [Unreleased]: https://github.com/IPAC-SW/kete/tree/main
+[1.0.0]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.0
 [0.3.0]: https://github.com/IPAC-SW/kete/releases/tag/v0.3.0
 [0.2.5]: https://github.com/IPAC-SW/kete/releases/tag/v0.2.5
 [0.2.4]: https://github.com/IPAC-SW/kete/releases/tag/v0.2.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "_core"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "0.3.0"
+version = "1.0.0"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "ddahlen@ipac.caltech.edu"},

--- a/src/kete_core/Cargo.toml
+++ b/src/kete_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kete_core"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Initial open source release.


## [v1.0.0]

### Added

- Added final SPICE kernels for the WISE mission, it now contains all positions from
  all phases of operation. There is a gap for the years it was not operating.
- Updated WISE mission phases to reflect the final data products about to be released.
- Updated ZTF for the current release 22.
- Added `kete.RectangleFOV.from_wcs`, allowing the construction of a FOV from a given
  Astropy WCS object.
- Added `kete.conversion.bin_data`, which allows for binning matrix data such as images.
- Added tutorial showing precovery of an asteroid from a 1950's glass plate observation
  done at the Palomar Observatory.
- Added sun-shield rotation calculation for NEO Surveyor.
- All FOV's now have the `.jd()` method which returns the JD of the observer state.

### Changed

- Building FOVs from corners, now will flip the corner ordering if the final FOV is
  pointing in the opposite direction of the input corners. This means Rectangle FOVs
  cannot be defined from corners with on sky angles greater than 180 degrees.

### Fixed

- Orbital elements calculations for True Anomaly and Eccentric Anomaly were numerically
  unstable with nearly parabolic orbits.
- Time scaling bugs when loading times from both Horizons and the MPC were fixed, these
  were causing offsets of about a minute in the loaded states. However it was shifting
  both the perihelion time and the epoch time by the same amount, leading to only minor
  effective errors.
- Fixed a time offset in the FOV's downloaded from IRSA WISE/NEOWISE. They were offset
  by 4.4 seconds.
- Fixed rotation approximation in WISE/NEOWISE field of views which was causing a small
  percentage of objects to not be found during FOV checks when they were close to the
  edge of the field.
- Constant for the sqrt of GMS was incorrect by a small amount, this value was fixed.
- IRSA username/password options are now being passed through correctly in WISE.

### Removed

- Removed `plot_frame` from ZTF, as a better version of this is available in kete.irsa.
- Removed `cache_WISE_frame` and `fetch_WISE_frame` deprecated functions in WISE.
