### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [v1.0.1]
 
 ### Added
 
@@ -270,6 +270,7 @@ Initial Release
 
 
 [Unreleased]: https://github.com/IPAC-SW/kete/tree/main
+[1.0.1]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.1
 [1.0.0]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.0
 [0.3.0]: https://github.com/IPAC-SW/kete/releases/tag/v0.3.0
 [0.2.5]: https://github.com/IPAC-SW/kete/releases/tag/v0.2.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "_core"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "1.0.0"
+version = "1.0.1"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "ddahlen@ipac.caltech.edu"},

--- a/src/kete_core/Cargo.toml
+++ b/src/kete_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kete_core"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
This release is primarily to add python 3.9 to the pre-built packages.
This is to catch the older python which anaconda is using.


## [v1.0.1]

### Added

- Added worked example of calculating if an object is an Earth Trojan.
- Add Earth obliquity calculation.
- Exposed WGS84 coordinate conversions in the python frontend.

### Fixed

- Epoch and Perihelion time conversion when loading JPL Horizons covariance matrices was
  not being done for UTC to TDB, leading to small residuals in covariance sampling.