### PR TITLE
Horizons Covariance sample has small residual error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the return signature for `fov_static_check`, this now returns indices of
   the inputs, instead of the original inputs themselves.
 
+### Fixed
+
+- Sampling of JPL Horizons orbit fits was slightly off, and appears to be fixed by
+  assuming that the epoch time of the covariance fits is in UTC. This assumption is
+  now included in the covariance matrix sampling. This is different than their other
+  data products.
+
 
 ## [v1.0.2]
 


### PR DESCRIPTION
Sampling the states from HorizonsProperties was leading to small residual errors.
This is almost entirely fixed by switching the epoch time to UTC, though the best fits are still around 100 ms off, so I suspect that it is actually UT1 time.