### PR TITLE
Calculated v mags now NAN if phase>160 degrees

### DIFF
--- a/src/kete/rust/flux/reflected.rs
+++ b/src/kete/rust/flux/reflected.rs
@@ -97,7 +97,7 @@ pub fn hg_apparent_flux_py(
 ///
 /// The HG IAU model is not technically defined above 120 degrees phase, however this
 /// will continue to return values fit to the model until 160 degrees. Phases larger
-/// than 160 degrees will return an apparent magnitude of infinity.
+/// than 160 degrees will return nan.
 ///
 /// Parameters
 /// ----------

--- a/src/kete_core/src/flux/reflected.rs
+++ b/src/kete_core/src/flux/reflected.rs
@@ -214,7 +214,7 @@ impl HGParams {
     ///
     /// The IAU model is not technically defined above 120 degrees phase, however this will
     /// continue to return values fit to the model until 160 degrees. Phases larger than
-    /// 160 degrees will return an apparent magnitude of infinity.
+    /// 160 degrees will return nan.
     ///
     /// Note that this typically assumes that H/G have been fit in the V band, thus this
     /// will return a V band apparent magnitude.
@@ -232,7 +232,7 @@ impl HGParams {
 
         // 2.7925... == 160 degrees in radians
         if phase > 2.792526803190927 {
-            return f64::INFINITY;
+            return f64::NAN;
         }
 
         let correction = hg_phase_curve_correction(self.g_param, phase).log10();

--- a/src/kete_core/src/flux/reflected.rs
+++ b/src/kete_core/src/flux/reflected.rs
@@ -7,7 +7,14 @@ use crate::{
 use nalgebra::Vector3;
 use serde::{Deserialize, Serialize};
 
-///  This computes the phase curve correction using the IAU standard for the HG model.
+/// This computes the phase curve correction using the IAU standard for the HG model.
+/// 
+/// Specifically page Page 550 - Equation (A4):
+/// 
+///     Asteroids II. University of Arizona Press, Tucson, pp. 524–556.
+///     Bowell, E., Hapke, B., Domingue, D., Lumme, K., Peltoniemi, J., Harris,
+///     A.W., 1989. Application of photometric models to asteroids, in: Binzel,
+///     R.P., Gehrels, T., Matthews, M.S. (Eds.),
 ///
 /// # Arguments
 ///
@@ -30,6 +37,13 @@ pub fn hg_phase_curve_correction(g_param: f64, phase: f64) -> f64 {
 ///
 /// H, Albedo, and Diameter are all related by the relation:
 /// diameter = c_hg / albedo.sqrt() * (10f64).powf(-h_mag / 5.0);
+/// 
+/// Specifically page Page 549 - Equation (A1) of:
+/// 
+///     Asteroids II. University of Arizona Press, Tucson, pp. 524–556.
+///     Bowell, E., Hapke, B., Domingue, D., Lumme, K., Peltoniemi, J., Harris,
+///     A.W., 1989. Application of photometric models to asteroids, in: Binzel,
+///     R.P., Gehrels, T., Matthews, M.S. (Eds.),
 ///
 /// # Arguments
 /// * `desig` - Designation of the object.

--- a/src/kete_core/src/flux/reflected.rs
+++ b/src/kete_core/src/flux/reflected.rs
@@ -11,10 +11,10 @@ use serde::{Deserialize, Serialize};
 /// 
 /// Specifically page Page 550 - Equation (A4):
 /// 
-///     Asteroids II. University of Arizona Press, Tucson, pp. 524–556.
-///     Bowell, E., Hapke, B., Domingue, D., Lumme, K., Peltoniemi, J., Harris,
-///     A.W., 1989. Application of photometric models to asteroids, in: Binzel,
-///     R.P., Gehrels, T., Matthews, M.S. (Eds.),
+/// Asteroids II. University of Arizona Press, Tucson, pp. 524–556.
+/// Bowell, E., Hapke, B., Domingue, D., Lumme, K., Peltoniemi, J., Harris,
+/// A.W., 1989. Application of photometric models to asteroids, in: Binzel,
+/// R.P., Gehrels, T., Matthews, M.S. (Eds.)
 ///
 /// # Arguments
 ///
@@ -40,10 +40,10 @@ pub fn hg_phase_curve_correction(g_param: f64, phase: f64) -> f64 {
 /// 
 /// Specifically page Page 549 - Equation (A1) of:
 /// 
-///     Asteroids II. University of Arizona Press, Tucson, pp. 524–556.
-///     Bowell, E., Hapke, B., Domingue, D., Lumme, K., Peltoniemi, J., Harris,
-///     A.W., 1989. Application of photometric models to asteroids, in: Binzel,
-///     R.P., Gehrels, T., Matthews, M.S. (Eds.),
+/// Asteroids II. University of Arizona Press, Tucson, pp. 524–556.
+/// Bowell, E., Hapke, B., Domingue, D., Lumme, K., Peltoniemi, J., Harris,
+/// A.W., 1989. Application of photometric models to asteroids, in: Binzel,
+/// R.P., Gehrels, T., Matthews, M.S. (Eds.)
 ///
 /// # Arguments
 /// * `desig` - Designation of the object.

--- a/src/kete_core/src/frames/definitions.rs
+++ b/src/kete_core/src/frames/definitions.rs
@@ -38,6 +38,7 @@ pub enum Frame {
     /// - isize value represents the frame identifier.
     /// - array of 6 floats represent the euler angles and their derivatives to move to
     ///   this frame from the ecliptic frame.
+    ///
     /// Rotation is done with a ZXZ set of chained rotations.
     EclipticNonInertial(isize, [f64; 6]),
     // Other non inertial frames will require multi-step conversions


### PR DESCRIPTION
When the phase angle was exceeding 160 degrees, the returned v-mag values were returning infinity. This breaks plotting, and is a bit more correct to say NAN instead, as the calculation itself is poorly defined.


Old behavior:

![image](https://github.com/user-attachments/assets/3d359ea5-f73e-4448-836e-f42b012f18ea)

![image](https://github.com/user-attachments/assets/3a180081-3122-43c0-b5fe-fc0286e8c269)



New behavior:
![image](https://github.com/user-attachments/assets/ad3f54d5-4631-4460-9e1c-f553e331b2fa)
