### PR TITLE
Add more thorough FOV tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for loading orbit information from JPL Horizons
+- Added more complete testing for light delay computations in the various FOV checks.
 
 ### Changed
 
@@ -23,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   assuming that the epoch time of the covariance fits is in UTC. This assumption is
   now included in the covariance matrix sampling. This is different than their other
   data products.
+- Field of View checks for SPK checks was not returning the correct light delayed time
+  for, it was returning the position/velocity at the observed position, but the time
+  was the instantaneous time.
 
 
 ## [v1.0.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   assuming that the epoch time of the covariance fits is in UTC. This assumption is
   now included in the covariance matrix sampling. This is different than their other
   data products.
-- Field of View checks for SPK checks was not returning the correct light delayed time
-  for, it was returning the position/velocity at the observed position, but the time
-  was the instantaneous time.
+- Field of View checks for SPK checks was not returning the correct light delayed time,
+  it was returning the position/velocity at the observed position, but the time was
+  the instantaneous time.
 
 
 ## [v1.0.2]

--- a/src/kete/rust/simult_states.rs
+++ b/src/kete/rust/simult_states.rs
@@ -14,6 +14,10 @@ use crate::{fovs::AllowedFOV, frame::PyFrames, state::PyState};
 /// The main value in this is that also includes an optional Field of View.
 /// If the FOV is provided, it is implied that the states which are present
 /// in this file were objects seen by the FOV.
+/// 
+/// In the case where the FOV is provided, it is expected that the states
+/// positions will include light delay, so an object which is ~1au away from
+/// the FOV observer will have a JD which is offset by about 8 minutes.
 ///
 #[pyclass(module = "kete", frozen, sequence, name = "SimultaneousStates")]
 #[derive(Debug)]

--- a/src/kete_core/src/flux/reflected.rs
+++ b/src/kete_core/src/flux/reflected.rs
@@ -8,9 +8,9 @@ use nalgebra::Vector3;
 use serde::{Deserialize, Serialize};
 
 /// This computes the phase curve correction using the IAU standard for the HG model.
-/// 
+///
 /// Specifically page Page 550 - Equation (A4):
-/// 
+///
 /// Asteroids II. University of Arizona Press, Tucson, pp. 524–556.
 /// Bowell, E., Hapke, B., Domingue, D., Lumme, K., Peltoniemi, J., Harris,
 /// A.W., 1989. Application of photometric models to asteroids, in: Binzel,
@@ -37,9 +37,9 @@ pub fn hg_phase_curve_correction(g_param: f64, phase: f64) -> f64 {
 ///
 /// H, Albedo, and Diameter are all related by the relation:
 /// diameter = c_hg / albedo.sqrt() * (10f64).powf(-h_mag / 5.0);
-/// 
+///
 /// Specifically page Page 549 - Equation (A1) of:
-/// 
+///
 /// Asteroids II. University of Arizona Press, Tucson, pp. 524–556.
 /// Bowell, E., Hapke, B., Domingue, D., Lumme, K., Peltoniemi, J., Harris,
 /// A.W., 1989. Application of photometric models to asteroids, in: Binzel,

--- a/src/kete_core/src/fov/fov_like.rs
+++ b/src/kete_core/src/fov/fov_like.rs
@@ -56,7 +56,7 @@ pub trait FovLike: Sync + Sized {
         let (idx, contains) = self.contains(&new_rel_pos);
         let new_state = State::new(
             state.desig.clone(),
-            obs.jd,
+            obs.jd + dt,
             new_pos,
             vel,
             obs.frame,
@@ -203,8 +203,8 @@ pub trait FovLike: Sync + Sized {
             .into_par_iter()
             .filter_map(|&obj_id| {
                 match spk.try_get_state(obj_id, obs.jd, obs.center_id, obs.frame) {
-                    Ok(state) => match self.check_linear(&state) {
-                        (idx, Contains::Inside, state) => Some((idx, state)),
+                    Ok(state) => match self.check_two_body(&state) {
+                        Ok((idx, Contains::Inside, state)) => Some((idx, state)),
                         _ => None,
                     },
                     _ => None,


### PR DESCRIPTION
### Added

- Added more complete testing for light delay computations in the various FOV checks.

### Fixed

- Field of View checks for SPK checks was not returning the correct light delayed time,
  it was returning the position/velocity at the observed position, but the time was
  the instantaneous time.

Tests now verify that:
- two-body checks are accurate to ~150km
- N-body accurate to 150m
- SPK checks accurate to 150 micron