### PR TITLE
Add RA/DEC + rates to `SimultaneousStates`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for loading orbit information from JPL Horizons
 - Added more complete testing for light delay computations in the various FOV checks.
+- Added quality of life function to `SimultaneousState` for computing the RA/Dec along
+  with the projected on sky rates of motion.
 
 ### Changed
 
@@ -27,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Field of View checks for SPK checks was not returning the correct light delayed time,
   it was returning the position/velocity at the observed position, but the time was
   the instantaneous time.
+
+### Removed
+
+- Removed several polar coordinate transformations in the rust backend which were all
+  equivalent variations of latitude/longitude conversions. Nothing in the Python was
+  impacted.
 
 
 ## [v1.0.2]

--- a/src/kete/rust/vector.rs
+++ b/src/kete/rust/vector.rs
@@ -185,8 +185,7 @@ impl Vector {
         if r < 1e-8 {
             return 0.0;
         }
-        ((FRAC_PI_2 - ((data.z / r).clamp(-1.0, 1.0)).acos()).to_degrees() + 180.0)
-            .rem_euclid(360.0)
+        ((FRAC_PI_2 - (data.z / r).clamp(-1.0, 1.0).acos()).to_degrees() + 180.0).rem_euclid(360.0)
             - 180.0
     }
 

--- a/src/kete_core/src/simult_states.rs
+++ b/src/kete_core/src/simult_states.rs
@@ -2,8 +2,11 @@
 //! These primarily exist to allow for easy read/write to binary formats.
 
 use crate::fov::FOV;
+use crate::frames::to_lat_lon;
 use crate::io::FileIO;
 use crate::prelude::{Error, Frame, KeteResult, State};
+use nalgebra::Vector3;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 
 /// Collection of [`State`] at the same time.
@@ -72,5 +75,47 @@ impl SimultaneousStates {
             frame,
             fov,
         })
+    }
+
+    /// Compute RA/Dec along with linearized rates.
+    ///
+    /// Returns a vector containing [ra, dec, ra' * cos(dec), dec'], all vectors
+    /// are automatically cast into the equatorial frame.
+    /// The returned RA rate is scaled by cos(dec) so that it is equivalent to a
+    /// linear projection onto the observing plane.
+    pub fn ra_dec_with_rates(&self) -> KeteResult<Vec<[f64; 4]>> {
+        if self.fov.is_none() {
+            return Err(Error::ValueError(
+                "Field of view must be specified for the ra/dec to be computed.".into(),
+            ));
+        }
+        let fov = self.fov.as_ref().unwrap();
+
+        let mut obs = fov.observer().clone();
+        obs.try_change_frame_mut(Frame::Equatorial)?;
+
+        let obs_pos = Vector3::from(obs.pos);
+        let obs_vel = Vector3::from(obs.vel);
+
+        Ok(self
+            .states
+            .par_iter()
+            .map(|state| {
+                let mut state = state.clone();
+                state.try_change_frame_mut(Frame::Equatorial).unwrap();
+                let pos_diff = Vector3::from(state.pos) - obs_pos;
+                let vel_diff = Vector3::from(state.vel) - obs_vel;
+
+                let d_ra = (pos_diff.x * vel_diff.y - pos_diff.y * vel_diff.x)
+                    / (pos_diff.x.powi(2) + pos_diff.y.powi(2));
+                let r2 = pos_diff.norm_squared();
+
+                let d_dec = (vel_diff.z - pos_diff.z * pos_diff.dot(&vel_diff) / r2)
+                    / (r2 - pos_diff.z.powi(2)).sqrt();
+                let (dec, ra) = to_lat_lon(pos_diff[0], pos_diff[1], pos_diff[2]);
+
+                [ra, dec, d_ra * dec.cos(), d_dec]
+            })
+            .collect())
     }
 }


### PR DESCRIPTION
Fixes #143 

This adds RA/Dec on sky rates as projected onto the tangent plane.

``` python

    import kete
    import numpy as np
    jd = kete.Time(2460324.0607406627, scaling='utc').jd
    
    
    state = kete.HorizonsProperties.fetch("Eros").state
    obs = kete.spice.get_state("Earth", jd)
    fov = kete.OmniDirectionalFOV(obs)
    
    vis = kete.fov_state_check([state], [fov])[0]
    radec_rates = np.array(vis.ra_dec_with_rates)
    radec_rates[:, 2:] *= 60 * 60 / 24
    radec_rates[0]
    # [349.05471178,   5.38827149,  91.84545114,  34.03329178]
    # Same query from horizons:
    # 349.05471   5.38827  91.83002  34.07774
```
The slight discrepancy between the horizons rates and these look to be because horizons computes in the JNOW frame, not the J2000.

