### PR TITLE
Release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [v1.0.3]
 
 ### Added
 
@@ -311,6 +311,8 @@ Initial Release
 
 
 [Unreleased]: https://github.com/IPAC-SW/kete/tree/main
+[1.0.3]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.1
+[1.0.2]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.2
 [1.0.1]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.1
 [1.0.0]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.0
 [0.3.0]: https://github.com/IPAC-SW/kete/releases/tag/v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "_core"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "1.0.2"
+version = "1.0.3"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "ddahlen@ipac.caltech.edu"},

--- a/src/kete_core/Cargo.toml
+++ b/src/kete_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kete_core"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## [v1.0.3]

### Added

- Added support for loading orbit information from JPL Horizons
- Added quality of life function to `SimultaneousState` for computing the RA/Dec along
  with the projected on sky rates of motion.
- Added more complete testing for light delay computations in the various FOV checks.

### Changed

- Changed the return signature for `fov_static_check`, this now returns indices of
  the inputs, instead of the original inputs themselves.

### Fixed

- Sampling of JPL Horizons orbit fits was slightly off, and appears to be fixed by
  assuming that the epoch time of the covariance fits is in UTC. This assumption is
  now included in the covariance matrix sampling. This is different than their other
  data products.
- Field of View checks for SPK checks was not returning the correct light delayed time,
  it was returning the position/velocity at the observed position, but the time was
  the instantaneous time.

### Removed

- Removed several polar coordinate transformations in the rust backend which were all
  equivalent variations of latitude/longitude conversions. Nothing in the Python was
  impacted.
