### PR TITLE
Adding several new columns to horizons query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Horizons orbit table query now includes, M1/2, K1/2, PC, and orbital period.
+- Horizons orbit table query now includes, M1/2, K1/2, PC, and rotation period.
 
 
 ## [v1.0.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for saving and loading `SimultaneousStates` as Parquet files.
 
+### Changed
+
+- Horizons orbit table query now includes, M1/2, K1/2, PC, and orbital period.
+
 
 ## [v1.0.3]
 

--- a/src/kete/horizons.py
+++ b/src/kete/horizons.py
@@ -466,7 +466,7 @@ def fetch_known_orbit_data(update_cache=False):
         res = requests.get(
             (
                 "https://ssd-api.jpl.nasa.gov/sbdb_query.api?fields="
-                "pdes,spkid,orbit_id,rms,H,diameter,epoch,e,i,q,w,tp,om,A1,A2,A3,DT"
+                "pdes,spkid,orbit_id,rms,H,diameter,epoch,e,i,q,w,tp,om,A1,A2,A3,DT,M1,M2,K1,K2,PC,rot_per"
                 "&full-prec=1&sb-xfrag=1"
             ),
             timeout=120,

--- a/src/kete_core/src/spice/pck_segments.rs
+++ b/src/kete_core/src/spice/pck_segments.rs
@@ -61,9 +61,6 @@ pub struct PckSegment {
     /// End time of the segment.
     pub jd_end: f64,
 
-    /// Type of the segment
-    pub segment_type: i32,
-
     /// Internal data representation.
     segment: PckSegmentType,
 }
@@ -94,7 +91,6 @@ impl TryFrom<DafArray> for PckSegment {
             jd_end,
             center_id,
             ref_frame,
-            segment_type,
             segment,
         })
     }
@@ -111,6 +107,11 @@ impl PckSegment {
         if jd < self.jd_start || jd > self.jd_end {
             Err(Error::DAFLimits(
                 "JD is not present in this record.".to_string(),
+            ))?;
+        }
+        if self.ref_frame != Frame::Ecliptic {
+            Err(Error::ValueError(
+                "Non ecltiptic frames are not supported for PCK queries.".into(),
             ))?;
         }
 


### PR DESCRIPTION
fixes #150 

This adds M, K, and PC slopes and magnitudes for comets, along with the rotation period if known.

At some later date this may be split up into some smaller chunks, but for now it is simpler to just carry a ~100mb file.
This took ~1.5 minutes to download from horizons.

A bit of a drive-by change, but this also removes an unused variable in the spice PCK files, and enforces some frame of reference checks. The static analysis tools I am using on this computer highlighted these (correctly) as issues, which are not visible on my work laptop, probably since we have a pinned older rust version which is primarily used for development on that machine. Static analysis tools are the best.