### PR TITLE
NEOS chip gap calculation uneven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Horizons orbit table query now includes, M1/2, K1/2, PC, and rotation period.
 
+### Fixed
+
+- NEOS Chip size calculation was slightly incorrect with regard to the placement of the
+  gaps between the chips.
+- NEOS FOV rotation was being calculated in the ecliptic frame, whereas images will be
+  in the equatorial frame. Rotation is now defaulting to the equatorial frame.
+
 
 ## [v1.0.3]
 

--- a/src/kete/neos.py
+++ b/src/kete/neos.py
@@ -1,13 +1,21 @@
 import numpy as np
+from .fov import NeosCmos, NeosVisit
+
+
+__all__ = ["sunshield_rotation", "NeosCmos", "NeosVisit", "FOV_WIDTH", "FOV_HEIGHT"]
+
 
 BANDS: list[float] = [4700.0, 8000.0]
 """Effective wavelength of the NC1 and NC2 bands in nm."""
 
 FOV_WIDTH: float = 7.10
-"""Expected effective field of view width in degrees"""
+"""Expected effective field of view width in degrees. Approximate Value."""
 
 FOV_HEIGHT: float = 1.68
-"""Expected effective field of view height in degrees"""
+"""Expected effective field of view height in degrees. Approximate Value."""
+
+FOV_CHIP_GAP: float = 0.11
+"""Expected effective gap between individual chips in degrees. Approximate Value."""
 
 ZERO_MAGS: list[float] = [170.662, 64.13]
 """Zero point magnitude for nc1 and nc2"""

--- a/src/kete/rust/fovs/definitions.rs
+++ b/src/kete/rust/fovs/definitions.rs
@@ -1,4 +1,4 @@
-use kete_core::fov::{self, NeosBand};
+use kete_core::fov::{self};
 use kete_core::fov::{FovLike, SkyPatch};
 use nalgebra::Vector3;
 use pyo3::{exceptions, prelude::*};
@@ -607,7 +607,7 @@ impl PyNeosCmos {
             subloop_id,
             exposure_id,
             cmos_id,
-            band.into(),
+            band,
         ))
     }
 
@@ -677,11 +677,7 @@ impl PyNeosCmos {
     /// Band Number
     #[getter]
     pub fn band(&self) -> u8 {
-        match self.0.band {
-            NeosBand::NC1 => 1,
-            NeosBand::NC2 => 2,
-            NeosBand::Undefined => 0,
-        }
+        self.0.band
     }
 
     /// Rotation angle of the FOV in degrees.
@@ -738,22 +734,23 @@ impl PyNeosVisit {
         exposure_id: u8,
         band: u8,
     ) -> Self {
-        let pointing = pointing.into_vector(crate::frame::PyFrames::Ecliptic);
+        let pointing = pointing.into_vector(crate::frame::PyFrames::Equatorial);
         let pointing = pointing.raw.into();
+        let observer = observer.as_equatorial().unwrap().0;
         PyNeosVisit(fov::NeosVisit::from_pointing(
             x_width.to_radians(),
             y_width.to_radians(),
             gap_angle.to_radians(),
             pointing,
             rotation.to_radians(),
-            observer.0,
+            observer,
             side_id,
             stack_id,
             quad_id,
             loop_id,
             subloop_id,
             exposure_id,
-            band.into(),
+            band,
         ))
     }
 


### PR DESCRIPTION
### Fixed

- NEOS Chip size calculation was slightly incorrect with regard to the placement of the
  gaps between the chips.
- NEOS FOV rotation was being calculated in the ecliptic frame, whereas images will be
  in the equatorial frame. Rotation is now defaulting to the equatorial frame. Note that
  these can be trivially made mathematically equivalent, however for convenience it is
  much easier if we are consistently in the equatorial frame.

![image](https://github.com/user-attachments/assets/dec8f226-7471-4a83-90da-4f5a0ecbe725)
