### PR TITLE
Release v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [v1.0.4]
 
 ### Added
 
@@ -320,7 +320,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial Release
 
-
 - Initial version release of kete!
 - kete's primary goal is to enable simulations of NEOs, however it also supports any 
   asteroid or comet. Included are n-body orbit propagation tools, thermal and optical
@@ -329,7 +328,8 @@ Initial Release
 
 
 [Unreleased]: https://github.com/IPAC-SW/kete/tree/main
-[1.0.3]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.1
+[1.0.4]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.4
+[1.0.3]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.3
 [1.0.2]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.2
 [1.0.1]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.1
 [1.0.0]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "_core"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "1.0.3"
+version = "1.0.4"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "ddahlen@ipac.caltech.edu"},

--- a/src/kete_core/Cargo.toml
+++ b/src/kete_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kete_core"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
fixes #153 

### Added

- Added support for saving and loading `SimultaneousStates` as Parquet files.

### Changed

- Horizons orbit table query now includes, M1/2, K1/2, PC, and rotation period.

### Fixed

- NEOS Chip size calculation was slightly incorrect with regard to the placement of the
  gaps between the chips.
- NEOS FOV rotation was being calculated in the ecliptic frame, whereas images will be
  in the equatorial frame. Rotation is now defaulting to the equatorial frame.