### PR TITLE
Support for SPICE SPK kernels of Type 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for SPICE kernels of type 9, this allows reading SOHO spice files.
+- Added support for SPICE kernels of type 18, this allows reading Rosetta spice files.
 
 ### Changed
 


### PR DESCRIPTION
This adds support for SPICE kernels of type 18.

As type 18 is actually 2 different types in a trench-coat, and I only have a file containing "subtype 0", this has only been tested on this type, though I expect it to work on subtype 1 as well.

Matches cSPICE to the mm level, similar for velocity:
![image](https://github.com/user-attachments/assets/7dd4792b-4208-46f7-bfae-8abad6e8589a)


The spikey behavior is due to some minor interpolation differences, I may revisit this later to chase down those last few microns of error.