### PR TITLE
Add Earth precession calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for SPICE kernels of type 9, this allows reading SOHO spice files.
 - Added support for SPICE kernels of type 18, this allows reading Rosetta spice files.
+- Added Equatorial frame as observed calculation.
 
 ### Changed
 

--- a/src/kete/conversion.py
+++ b/src/kete/conversion.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.typing import NDArray
 from . import _core
 from . import constants
-from ._core import compute_obliquity
+from ._core import compute_obliquity, earth_precession_rotation
 
 __all__ = [
     "bin_data",
@@ -25,6 +25,7 @@ __all__ = [
     "compute_tisserand",
     "dec_degrees_to_dms",
     "dec_dms_to_degrees",
+    "earth_precession_rotation",
     "flux_to_mag",
     "mag_to_flux",
     "ra_degrees_to_hms",

--- a/src/kete/rust/frame.rs
+++ b/src/kete/rust/frame.rs
@@ -95,3 +95,42 @@ pub fn ecef_to_wgs_lat_lon(x: f64, y: f64, z: f64) -> (f64, f64, f64) {
 pub fn calc_obliquity_py(time: f64) -> f64 {
     calc_obliquity(time).to_degrees()
 }
+
+/// Calculate rotation matrix which transforms a vector from the J2000 Equatorial
+/// frame to the desired epoch.
+///
+/// Earth's north pole precesses at a rate of about 50 arcseconds per year.
+/// This means there was an approximately 20 arcminute rotation of the Equatorial
+/// axis from the year 2000 to 2025.
+///
+/// This implementation is valid for around 200 years on either side of 2000 to
+/// within sub micro-arcsecond accuracy.
+///
+/// This function is an implementation equation (21) from this paper:
+///     "Expressions for IAU 2000 precession quantities"
+///     Capitaine, N. ; Wallace, P. T. ; Chapront, J. 
+///     Astronomy and Astrophysics, v.412, p.567-586 (2003)
+/// 
+/// It is recommended to first look at the following paper, as it provides useful
+/// discussion to help understand the above model. This defines the model used
+/// by JPL Horizons:
+///     "Precession matrix based on IAU (1976) system of astronomical constants."
+///     Lieske, J. H.
+///     Astronomy and Astrophysics, vol. 73, no. 3, Mar. 1979, p. 282-284.
+/// 
+/// The IAU 2000 model paper improves accuracy by approximately ~300 mas/century over
+/// the 1976 model.
+///
+/// Parameters
+/// ----------
+/// tdb_time:
+///     Time in TDB scaled Julian Days.
+#[pyfunction]
+#[pyo3(name = "earth_precession_rotation")]
+pub fn calc_earth_precession(time: f64) -> Vec<Vec<f64>> {
+    earth_precession_rotation(time)
+        .matrix()
+        .row_iter()
+        .map(|x| x.iter().cloned().collect())
+        .collect()
+}

--- a/src/kete/rust/lib.rs
+++ b/src/kete/rust/lib.rs
@@ -85,6 +85,7 @@ fn _core(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(frame::wgs_lat_lon_to_ecef, m)?)?;
     m.add_function(wrap_pyfunction!(frame::ecef_to_wgs_lat_lon, m)?)?;
     m.add_function(wrap_pyfunction!(frame::calc_obliquity_py, m)?)?;
+    m.add_function(wrap_pyfunction!(frame::calc_earth_precession, m)?)?;
 
     m.add_function(wrap_pyfunction!(kepler::compute_eccentric_anomaly_py, m)?)?;
     m.add_function(wrap_pyfunction!(kepler::propagation_kepler_py, m)?)?;

--- a/src/kete_core/Cargo.toml
+++ b/src/kete_core/Cargo.toml
@@ -35,11 +35,11 @@ criterion = { version = "*", features = ["html_reports"] }
 # pprof is used for flame graphs, this is failing on windows currently so only
 # linux and mac are supported here.
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-pprof = { version = "0.13", features = ["flamegraph", "criterion"] }
+pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 
 # macos needs the frame-pointer flag, however this doesn't function on linux
 [target.'cfg(target_os = "macos")'.dev-dependencies]
-pprof = { version = "0.13", features = ["flamegraph", "criterion", "frame-pointer"] }
+pprof = { version = "0.14", features = ["flamegraph", "criterion", "frame-pointer"] }
 
 [[bench]]
 name = "propagation"


### PR DESCRIPTION
This fixes #168 


This is an implementation of equation 21 found in:
https://syrte.obspm.fr/iau2006/aa03_412_P03.pdf

This should accurately compute the rotation of the equatorial frame at J2000 to any "as observed" equatorial frame within 200 years of J2000.