### PR TITLE
Release Version 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for SPICE kernels of type 9, this allows reading SOHO spice files.
 - Added support for SPICE kernels of type 18, this allows reading Rosetta spice files.
-- Added Equatorial frame as observed calculation.
+- Added calculation of Earth's precession, allowing the computation of time dependent
+  equatorial vectors.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.0.5]
 
 ### Added
 
@@ -346,6 +346,7 @@ Initial Release
 
 
 [Unreleased]: https://github.com/IPAC-SW/kete/tree/main
+[1.0.5]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.5
 [1.0.4]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.4
 [1.0.3]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.3
 [1.0.2]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "_core"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "1.0.4"
+version = "1.0.5"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "ddahlen@ipac.caltech.edu"},

--- a/src/kete_core/Cargo.toml
+++ b/src/kete_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kete_core"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION

## [v1.0.5]

### Added

- Added support for SPICE kernels of type 9, this allows reading SOHO spice files.
- Added support for SPICE kernels of type 18, this allows reading Rosetta spice files.
- Added calculation of Earth's precession, allowing the computation of time dependent
  equatorial vectors.

### Changed

- Comet Magnitude estimates now accepts two phase correction values instead of 1.
- Restructured SPICE kernel memory management to make entire class of bugs impossible.

### Fixed

- Fixed a text case-sensitivity but on Horizons parameter parsing.
- Thermal model example had function arguments out of order.
