### PR TITLE
Add option to suppress impact error printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added definitions of classes of objects.
 - Added support for SPICE kernels of type 3, this allows reading satellites of Mars.
 - Added support for choosing to not load the DE440 file when reloading SPICE kernels.
+- Added optional suppression of impact warnings during propagation.
 
 ### Fixed
 


### PR DESCRIPTION
When there are many impactors (such as during a monte-carlo simulation), the current printing to stderr is very verbose. This leads to jupyter lab hanging and never completing. As a quality of life change, this PR adds optional suppression of these impact warnings. This allows for the MC runs to complete, and the impactor states will be NaN.