### PR TITLE
Add higher resolution Palomar position estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+- Added functions for estimating the position of Earth coordinates outside of the PCK
+  limits. This allows for estimating Palomar's position in 1950.
+
+
 ## [v1.0.6]
 
 ### Added


### PR DESCRIPTION
This adds a few example functions to the Palomar tutorial, allowing for a relatively accurate estimate of earth positions at any point in the past:

Here is a direct comparison to the high resolution PCK file from JPL (which ends in the early 1960s):
![image](https://github.com/user-attachments/assets/1b0e37b7-2d2a-43e5-bc82-d2d2e7995864)


This allows the palomar tutorial to have precision within about the PSF width of the asteroid:
![image](https://github.com/user-attachments/assets/7c09fe03-768e-4ea5-8085-27dd5ecea8b7)


This shows 2 points, when the exposure began and 22 minutes later, showing that the effective exposure time was about 22-23 minutes. The original exposure was 30 minutes, but reported clouds appearing at the end.