### PR TITLE
Update observatory codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Added functions for estimating the position of Earth coordinates outside of the PCK
   limits. This allows for estimating Palomar's position in 1950.
 
+### Changed
+
+- Switched to using the MPC Observatory code file for the source of observatory
+  locations.
+
+### Fixed
+
+- WGS84 conversion between ECEF and Lat/Lon/Alt was missing a square-root causing a
+  small offset (typically 10s to 100s of meters). This has been fixed.
 
 ## [v1.0.6]
 

--- a/src/kete/mpc.py
+++ b/src/kete/mpc.py
@@ -47,7 +47,7 @@ def find_obs_code(name: str):
     appropriate.
 
     >>> kete.mpc.find_obs_code("Palomar Mountain")
-    (33.35411714208074, -116.86254, 1.6960628760407417, 'Palomar Mountain', '675')
+    (33.35411714208074, -116.86253999999998, 1.6960628760407417, 'Palomar Mountain', '675')
 
     Parameters
     ----------

--- a/src/kete/mpc.py
+++ b/src/kete/mpc.py
@@ -47,7 +47,7 @@ def find_obs_code(name: str):
     appropriate.
 
     >>> kete.mpc.find_obs_code("Palomar Mountain")
-    (33.35412, 243.13746, 1.69615, 'Palomar Mountain', '675')
+    (33.35411714208074, 43.13746, 1.6960628760407417, 'Palomar Mountain', '675')
 
     Parameters
     ----------

--- a/src/kete/mpc.py
+++ b/src/kete/mpc.py
@@ -47,7 +47,7 @@ def find_obs_code(name: str):
     appropriate.
 
     >>> kete.mpc.find_obs_code("Palomar Mountain")
-    (33.35411714208074, 43.13746, 1.6960628760407417, 'Palomar Mountain', '675')
+    (33.35411714208074, -116.86254, 1.6960628760407417, 'Palomar Mountain', '675')
 
     Parameters
     ----------

--- a/src/kete/rust/frame.rs
+++ b/src/kete/rust/frame.rs
@@ -62,6 +62,22 @@ pub fn wgs_lat_lon_to_ecef(lat: f64, lon: f64, h: f64) -> (f64, f64, f64) {
     geodetic_lat_lon_to_ecef(lat.to_radians(), lon.to_radians(), h)
 }
 
+/// Compute geocentric latitude from geodetic latitude and height.
+///
+/// Inputs are in degrees and km.
+///
+/// Parameters
+/// ----------
+/// lat :
+///     Geodetic Latitude in degrees.
+/// h :
+///     Height above the surface of the Earth in km from the WGS ellipse.
+#[pyfunction]
+#[pyo3(name = "geodetic_lat_to_geocentric")]
+pub fn geodetic_lat_to_geocentric_py(lat: f64, h: f64) -> f64 {
+    geodetic_lat_to_geocentric(lat.to_radians(), h).to_degrees()
+}
+
 /// Compute WCS84 Geodetic latitude/longitude/height from a ECEF position.
 ///
 /// This returns the lat, lon, and height from the WGS84 oblate Earth.
@@ -77,7 +93,8 @@ pub fn wgs_lat_lon_to_ecef(lat: f64, lon: f64, h: f64) -> (f64, f64, f64) {
 #[pyfunction]
 #[pyo3(name = "ecef_to_wgs_lat_lon")]
 pub fn ecef_to_wgs_lat_lon(x: f64, y: f64, z: f64) -> (f64, f64, f64) {
-    ecef_to_geodetic_lat_lon(x, y, z)
+    let (lat, lon, alt) = ecef_to_geodetic_lat_lon(x, y, z);
+    (lat.to_degrees(), lon.to_degrees(), alt)
 }
 
 /// Calculate the obliquity angle of the Earth at the specified time.

--- a/src/kete/rust/lib.rs
+++ b/src/kete/rust/lib.rs
@@ -86,6 +86,7 @@ fn _core(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(frame::ecef_to_wgs_lat_lon, m)?)?;
     m.add_function(wrap_pyfunction!(frame::calc_obliquity_py, m)?)?;
     m.add_function(wrap_pyfunction!(frame::calc_earth_precession, m)?)?;
+    m.add_function(wrap_pyfunction!(frame::geodetic_lat_to_geocentric_py, m)?)?;
 
     m.add_function(wrap_pyfunction!(kepler::compute_eccentric_anomaly_py, m)?)?;
     m.add_function(wrap_pyfunction!(kepler::propagation_kepler_py, m)?)?;

--- a/src/kete/rust/propagation.rs
+++ b/src/kete/rust/propagation.rs
@@ -132,8 +132,7 @@ pub fn propagation_n_body_spk_py(
                                     eprintln!(
                                         "Impact detected between ({:?}) <-> ({}) at time {} ({})",
                                         desig,
-                                        spice::try_name_from_id(id)
-                                            .unwrap_or(id.to_string()),
+                                        spice::try_name_from_id(id).unwrap_or(id.to_string()),
                                         time,
                                         time_full.utc().to_iso().unwrap()
                                     );

--- a/src/kete_core/data/mpc_obs.tsv
+++ b/src/kete_core/data/mpc_obs.tsv
@@ -32,7 +32,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 030   11.25446  +43.750648    166.264 0.723534  +0.688012    Italy          Arcetri Observatory, Florence
  3 031   11.18985  +50.377394    627.921 0.639061  +0.766705    Germany        Sonneberg
  3 032   11.58295  +50.925259    151.114 0.631624  +0.772706    Germany        Jena
- 3 033   11.71124  +50.980139    347.894 0.630900  +0.773333    Germany        Karl Schwarzschild Observatory, Tautenburg
+ 3 033   11.71124  +50.980142    388.733 0.630904  +0.773338    Germany        Karl Schwarzschild Observatory, Tautenburg
  3 034   12.45246  +41.922451    102.548 0.745176  +0.664656    Italy          Monte Mario Observatory, Rome
  3 035   12.57592  +55.686868     10.378 0.565008  +0.822321    Denmark        Copenhagen
  3 036   12.65040  +41.747469    432.010 0.747247  +0.662420    Italy          Castel Gandolfo
@@ -72,7 +72,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 070   25.2865   +54.683110    100.911 0.57940   +0.81233     Lithuania      Vilnius (before 1939)
  3 071   24.73782  +41.693123   1740.173 0.74803   +0.66185     Bulgaria       NAO Rozhen, Smolyan
  3 072    7.17     +51.088915  -3965.065 0.629     +0.774       Germany        Scheuren Observatory
- 3 073   26.09391  +44.411999    169.667 0.715519  +0.696289    Romania        Bucharest
+ 3 073   26.09391  +44.411996    133.589 0.715515  +0.696285    Romania        Bucharest
  3 074   26.4058   -29.038138   1407.074 0.87518   -0.48263     South Africa   Boyden Observatory, Bloemfontein
  3 075   26.7216   +58.379715     65.646 0.52557   +0.84791     Estonia        Tartu
  3 076   27.8768   -25.772770   1232.957 0.90127   -0.43225     South Africa   Johannesburg-Hartbeespoort
@@ -87,7 +87,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 085   30.5023   +50.452956    174.404 0.63800   +0.76749     Ukraine        Kyiv
  3 086   30.7582   +46.476827     64.628 0.68987   +0.72152     Ukraine        Odesa
  3 087   31.3411   +29.858775    105.720 0.86799   +0.49495     Egypt          Helwan
- 3 088   31.8250   +29.931772    490.873 0.86741   +0.49608     Egypt          Kottomia
+ 3 088   31.82769  +29.934013    494.061 0.867391  +0.496114    Egypt          Kottomia
  3 089   31.9747   +46.971605     50.870 0.68359   +0.72743     Ukraine        Mykolaiv
  3 090    8.25     +49.943154   1853.099 0.645     +0.762       Germany        Mainz
  3 091    4.20919  +45.381384    467.050 0.703630  +0.708287    France         Observatoire de Nurol, Aurec sur Loire
@@ -125,7 +125,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 123   44.2917   +40.335211   1490.248 0.76352   +0.64398     Armenia        Byurakan
  3 124    2.2550   +43.600501    163.995 0.72534   +0.68612     France         Castres
  3 125   44.78950  +41.717322    410.872 0.747594  +0.662026    Georgia        Tbilisi
- 3 126    9.7903   +44.133169    346.558 0.71893   +0.69283     Italy          Monte Viseggi
+ 3 126    9.79015  +44.132567    397.186 0.718943  +0.692828    Italy          Monte Viseggi L. Zannoni Observatory
  3 127    6.9797   +50.760191     85.429 0.63385   +0.77088     Germany        Bornheim
  3 128   46.00661  +51.538322     76.861 0.623279  +0.779393    Russia         Saratov
  3 129   45.92     +39.134625   2454.983 0.777     +0.628       Azerbaijan     Ordubad
@@ -202,8 +202,8 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 200    4.3036   +50.760191     85.429 0.63385   +0.77088     Belgium        Beersel Hills Observatory
  3 201    7.6033   +45.785135   1433.610 0.69871   +0.71332     Italy          Jonathan B. Postel Observatory
  3 202    5.8997   +43.095279     68.434 0.73137   +0.67971     France         Tamaris Observatoire, La Seyne sur Mer
- 3 203    8.9955   +45.541407    172.794 0.70161   +0.71021     Italy          GiaGa Observatory
- 3 204    8.76972  +45.868329   1278.400 0.697653  +0.714313    Italy          Schiaparelli Observatory
+ 3 203    8.99548  +45.541445    213.425 0.701614  +0.710215    Italy          GiaGa Observatory
+ 3 204    8.76972  +45.868295   1228.727 0.697648  +0.714307    Italy          Schiaparelli Observatory
  3 205   11.2731   +44.472064    113.686 0.71478   +0.69703     Italy          Obs. Casalecchio di Reno, Bologna
  3 206   10.5667   +60.600925    758.276 0.4922    +0.8677      Norway         Haagaar Observatory, Eina
  3 207    9.3065   +45.545063    131.545 0.70156   +0.71025     Italy          Osservatorio Antonio Grosso
@@ -262,10 +262,10 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 260  149.0661   -31.276809   1185.198 0.85560   -0.51626     Australia/NSW  Siding Spring Observatory-DSS
  3 261  243.14022  +33.357340   1686.997 0.836325  +0.546877    US/California  Palomar Mountain-DSS
  3 262  289.26626  -29.258822   2345.440 0.873440  -0.486052    Chile          European Southern Observatory, La Silla-DSS
- 3 266  204.52344  +19.825588   4130.275 0.941701  +0.337237    US/Hawaii      New Horizons KBO Search-Subaru
- 3 267  204.53044  +19.825347   4147.785 0.941705  +0.337234    US/Hawaii      New Horizons KBO Search-CFHT
- 3 268  289.30803  -29.014271   2389.673 0.875516  -0.482342    Chile          New Horizons KBO Search-Magellan/Clay
- 3 269  289.30914  -29.014791   2377.862 0.875510  -0.482349    Chile          New Horizons KBO Search-Magellan/Baade
+ 3 266  204.52396  +19.825501   4194.602 0.941711  +0.337239    US/Hawaii      New Horizons KBO Search-Subaru
+ 3 267  204.53109  +19.825438   4232.766 0.941717  +0.337240    US/Hawaii      New Horizons KBO Search-CFHT
+ 3 268  289.30803  -29.014271   2389.673 0.875516  -0.482342    Chile          Magellan-Clay Telescope
+ 3 269  289.30914  -29.014791   2377.862 0.875510  -0.482349    Chile          Magellan-Baade Telescope
 -2 270    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Unistellar Network, Roving Observer
 -2 273    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Euclid
 -2 274    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  James Webb Space Telescope
@@ -295,7 +295,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 301  288.8467   +45.454905   1126.540 0.70279   +0.70926     Canada/Quebec  Mont Megantic
  3 302  288.88      +8.672755   8768.476 0.990     +0.150       Venezuela      University of the Andes station
  3 303  289.1296    +8.787722   3624.775 0.98890   +0.15185     Venezuela      OAN de Llano del Hato, Merida
- 3 304  289.2980   -29.003554   2270.438 0.87559   -0.48217     Chile          Las Campanas Observatory
+ 3 304  289.30858  -29.014556   2385.314 0.875513  -0.482346    Chile          Las Campanas Observatory
  3 305  109.5514   +34.945455    471.527 0.82066   +0.56963     China          Purple Mountain, Hainan Island station
  3 306  290.6769   +10.075583    591.394 0.98477   +0.17381     Venezuela      Observatorio Taya Beixo, Barquisimeto
  3 307  287.7166   +43.704047    209.115 0.72410   +0.68743     US/New Hampsh  Shattuck Observatory, Hanover
@@ -435,7 +435,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 458  355.9806   +40.647204    884.058 0.75992   +0.64805     Spain          Guadarrama Observatory
  3 459  288.1172   +43.540840    284.280 0.72607   +0.68538     US/New Hampsh  Smith River Observatory, Danbury
  3 460  265.9981   +33.982263    160.598 0.83010   +0.55579     US/Arkansas    Area 52 Observatory, Nashville
- 3 461   19.8943   +47.918047    932.619 0.67153   +0.73869     Hungary        University of Szeged, Piszkesteto Stn. (Konkoly)
+ 3 461   19.89367  +47.917455    983.456 0.671543  +0.738689    Hungary        University of Szeged, Piszkesteto Stn. (Konkoly)
  3 462  283.0842   +38.921254     81.407 0.77905   +0.62488     US/Maryland    Mount Belleview Observatory
  3 463  254.7375   +40.004026   1656.692 0.76726   +0.63959     US/Colorado    Sommers-Bausch Observatory, Boulder
  3 464  288.5013   +41.410715     15.737 0.75109   +0.65799     US/Rhode Isla  Toby Point Observatory, Narragansett
@@ -535,7 +535,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 558   21.0303   +52.217857    148.194 0.61396   +0.78672     Poland         Warsaw
  3 559   14.98     +37.618100   -696.944 0.793     +0.607       Italy          Serra La Nave
  3 560   10.93100  +45.407461     63.049 0.703262  +0.708561    Italy          Madonna di Dossobuono
- 3 561   19.8943   +47.918047    932.619 0.67153   +0.73869     Hungary        Piszkesteto Stn. (Konkoly)
+ 3 561   19.89367  +47.917455    983.456 0.671543  +0.738689    Hungary        Piszkesteto Stn. (Konkoly)
  3 562   15.9236   +48.083754    905.092 0.66938   +0.74062     Austria        Figl Observatory, Vienna
  3 563   13.60     +47.952529    135.713 0.671     +0.739       Austria        Seewalchen
  3 564   11.19     +48.029249   9614.117 0.671     +0.741       Germany        Herrsching
@@ -667,7 +667,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 690  248.3367   +35.201970   2220.750 0.81832   +0.57344     US/Arizona     Lowell Observatory, Flagstaff
  3 691  248.39966  +31.962189   2041.007 0.849466  +0.526479    US/Arizona     Steward Observatory, Kitt Peak-Spacewatch
  3 692  249.0513   +32.233024    735.163 0.84679   +0.53036     US/Arizona     Steward Observatory, Tucson
- 3 693  249.26745  +32.416847   2519.508 0.845317  +0.533211    US/Arizona     Catalina Station, Tucson
+ 3 693  249.26745  +32.416873   2491.132 0.845313  +0.533209    US/Arizona     Catalina Station, Tucson
  3 694  248.9943   +32.213449    950.016 0.84700   +0.53009     US/Arizona     Tumamoc Hill, Tucson
  3 695  248.40533  +31.958398   2064.325 0.849504  +0.526425    US/Arizona     Kitt Peak
  3 696  249.1154   +31.688954   2627.639 0.85205   +0.52249     US/Arizona     Whipple Observatory, Mt. Hopkins
@@ -677,7 +677,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 700  250.3817   +36.350510   1624.518 0.80656   +0.58960     US/Arizona     Chinle
  3 701  249.79716  +31.475562   1351.518 0.853823  +0.519224    US/Arizona     Junk Bond Observatory, Sierra Vista
  3 702  252.8117   +33.984187   3381.271 0.8305    +0.5561      US/New Mexico  Joint Obs. for cometary research, Socorro
- 3 703  249.26736  +32.417006   2515.577 0.845315  +0.533213    US/Arizona     Catalina Sky Survey
+ 3 703  249.26736  +32.417032   2487.202 0.845311  +0.533211    US/Arizona     Catalina Sky Survey
  3 704  253.34093  +33.818259   1528.504 0.831869  +0.553542    US/New Mexico  Lincoln Laboratory ETS, New Mexico
  3 705  254.17942  +32.780502   2791.253 0.841945  +0.538563    US/New Mexico  Apache Point
  3 706  253.9366   +38.582008   1664.614 0.78294   +0.62043     US/Colorado    Salida
@@ -877,7 +877,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 900  135.98994  +35.049756    102.190 0.819572  +0.571083    Japan          Moriyama
  3 901  137.0877   +35.342668    139.106 0.81664   +0.57525     Japan          Tajimi
  3 902  132.2208   +34.221330     15.051 0.82775   +0.55922     Japan          Ootake
- 3 903  135.1769   +35.267884     46.715 0.81738   +0.57418     Japan          Fukuchiyama and Kannabe
+ 3 903  135.17423  +35.270953     84.418 0.817354  +0.574227    Japan          Fukuchiyama and Kannabe
  3 904  135.12     +34.617319   1122.666 0.824     +0.565       Japan          Go-Chome and Kobe-Suma
  3 905  135.9246   +33.610193     13.370 0.83368   +0.55040     Japan          Nachi-Katsuura Observatory
  3 906  145.667    -35.916135   3851.883 0.8113    -0.5837      Australia/VIC  Cobram
@@ -906,7 +906,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 929  268.7758   +30.407442     11.532 0.86319   +0.50319     US/Louisiana   Port Allen
  3 930  210.41224  -17.551379     98.541 0.953752  -0.299638    Tahiti         S. S. Observatory, Pamatai
  3 931  210.3842   -17.634072    -23.897 0.95330   -0.30100     Tahiti         Puna'auia
- 3 932  286.57394  +41.525724     76.872 0.749771  +0.659497    US/Connecticu  John J. McCarthy Obs., New Milford
+ 3 932  286.57401  +41.525747     45.086 0.749767  +0.659494    US/Connecticu  John J. McCarthy Obs., New Milford
  3 933  249.7342   +31.476137   1442.880 0.85383   +0.51924     US/Arizona     Rockland Observatory, Sierra Vista
  3 934  242.9572   +32.967432    282.660 0.83985   +0.54108     US/California  Poway Valley
  3 935  282.3394   +38.855930    132.138 0.77977   +0.62400     US/Virginia    Wyrick Observatory, Haymarket
@@ -932,7 +932,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 955  350.6739   +38.700163     66.570 0.78146   +0.62188     Portugal       Sassoeiros
  3 956  356.1908   +40.440581    727.178 0.76224   +0.64530     Spain          Observatorio Pozuelo
  3 957  359.3506   +44.823124      9.039 0.71047   +0.70137     France         Merignac
- 3 958  358.96961  +43.693327      6.101 0.724206  +0.687273    France         Observatoire de Dax
+ 3 958  358.96947  +43.693384     82.648 0.724214  +0.687282    France         Observatoire de Dax
  3 959    1.4653   +43.549352    215.147 0.72596   +0.68548     France         Ramonville Saint Agne
  3 960    0.6108   +51.032485     40.027 0.63016   +0.77387     UK/England     Rolvenden
  3 961  356.8206   +55.956698    109.992 0.56112   +0.82498     UK/Scotland    City Observatory, Calton Hill, Edinburgh
@@ -948,7 +948,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 971  350.81249  +38.711792     87.532 0.781336  +0.622040    Portugal       Lisbon
  3 972  357.5833   +57.160100    125.068 0.54359   +0.83656     UK/Scotland    Dun Echt
  3 973  359.6671   +51.579445      3.680 0.62271   +0.77983     UK/England     Harrow
- 3 974    8.9220   +44.419297     80.212 0.71542   +0.69637     Italy          Genoa
+ 3 974    8.84431  +44.434647    171.397 0.715243  +0.696571    Italy          Genoa Observatory
  3 975  359.6333   +39.478187     56.428 0.77292   +0.63239     Spain          Observatorio Astronomico de Valencia
  3 976  358.4669   +52.317598    108.710 0.61258   +0.78778     UK/England     Leamington Spa
  3 977  351.5483   +54.175554     44.465 0.58660   +0.80717     Ireland        Markree
@@ -991,7 +991,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 A14    5.1864   +44.021537    320.799 0.72028   +0.69143     France         Les Engarouines Observatory
  3 A15    6.7972   +51.848743     79.681 0.61903   +0.78275     Germany        Josef Bresser Sternwarte, Borken
  3 A16    7.1922   +46.770495    719.330 0.68622   +0.72511     Switzerland    Tentlingen
- 3 A17    8.68152  +49.545393    181.130 0.650125  +0.757317    Germany        Guidestar Observatory, Weinheim
+ 3 A17    8.68147  +49.545453    267.623 0.650133  +0.757328    Germany        Guidestar Observatory, Weinheim
  3 A18    7.1761   +51.527963     71.984 0.62342   +0.77928     Germany        Herne
  3 A19    7.0744   +50.923246     37.189 0.63164   +0.77267     Germany        Koln
  3 A20    7.51887  +52.844412     44.392 0.605274  +0.793357    Germany        Sogel
@@ -1239,7 +1239,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 C62   11.3467   +46.494235    250.158 0.68967   +0.72175     Italy          Eurac Observatory, Bolzano
  3 C63    9.9797   +46.188865   1259.638 0.69363   +0.71819     Italy          Giuseppe Piazzi Observatory, Ponte in Valtellina
  3 C64   15.28439  +47.929391    902.213 0.671380  +0.738819    Austria        Puchenstuben
- 3 C65    0.72965  +42.051655   1564.582 0.743841  +0.666482    Spain          Observatori Astronomic del Montsec
+ 3 C65    0.72965  +42.051680   1618.630 0.743847  +0.666488    Spain          Observatori Astronomic del Montsec
  3 C66    2.8050   +39.666780    150.906 0.77084   +0.63493     Spain          Observatorio El Cielo de Consell
  3 C67   12.2199   +53.403828     88.922 0.59747   +0.79922     Germany        Gnevsdorf
  3 C68   23.89339  +37.997695    168.912 0.789058  +0.612302    Greece         Ellinogermaniki Agogi Observatory, Pallini
@@ -1256,7 +1256,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 C79    2.7855   +41.677592     33.057 0.74801   +0.66147     Spain          Roser Observatory, Blanes
  3 C80   39.7651   +47.284989     81.957 0.67959   +0.73115     Russia         Don Astronomical Observatory, Rostov-on-Don
  3 C81   10.84098  +46.241077   1721.080 0.693023  +0.718872    Italy          Dolomites Astronomical Observatory
- 3 C82   14.35763  +40.618683    275.595 0.760171  +0.647611    Italy          Osservatorio Astronomico Nastro Verde, Sorrento
+ 3 C82   14.35759  +40.618777    292.893 0.760172  +0.647614    Italy          Osservatorio Astronomico Nastro Verde, Sorrento
  3 C83   91.8425   +56.084127    392.094 0.55930   +0.82626     Russia         Badalozhnyj Observatory
  3 C84    2.24372  +41.445592     31.514 0.750690  +0.658447    Spain          Badalona
  3 C85    1.2408   +38.891102    166.624 0.77939   +0.62448     Spain          Observatorio Cala d'Hort, Ibiza
@@ -1269,7 +1269,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 C92   13.60995  +43.426292    124.923 0.727425  +0.683915    Italy          Valdicerro Observatory, Loreto
  3 C93   13.4064   +42.334904    640.455 0.74042   +0.67004     Italy          Bellavista Observatory, L'Aquila
  3 C94  103.0670   +51.810111    700.423 0.61962   +0.78241     Russia         MASTER-II Observatory, Tunka
- 3 C95    5.71239  +43.932042    660.800 0.721401  +0.690345    France         SATINO Remote Observatory, Haute Provence
+ 3 C95    5.71239  +43.932050    705.892 0.721406  +0.690350    France         SATINO Remote Observatory, Haute Provence
  3 C96   13.8786   +42.753689    225.199 0.73544   +0.67537     Italy          OACL Observatory, Mosciano Sant Angelo
  3 C97   57.97633  +23.629468     43.382 0.916656  +0.398354    Oman           Al-Fulaij Observatory, Oman
  3 C98   11.1764   +43.764918     59.705 0.72335   +0.68818     Italy          Osservatorio Casellina, Scandicci
@@ -1277,7 +1277,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 D00   42.6536   +43.740151   2104.520 0.72388   +0.68809     Russia         ASC-Kislovodsk Observatory
  3 D01   23.93061  +60.352767     79.288 0.495920  +0.865471    Finland        Andean Northern Observatory, Nummi-Pusula
  3 D02    2.05189  +41.383634    119.250 0.751414  +0.657647    Spain          Observatori Petit Sant Feliu
- 3 D03   10.5889   +44.440858    642.710 0.71522   +0.69670     Italy          Rantiga Osservatorio, Tincana
+ 3 D03   10.58892  +44.441106    696.564 0.715223  +0.696709    Italy          Rantiga Osservatorio, Tincana
  3 D04   38.8569   +44.894146     34.666 0.70960   +0.70225     Russia         Krasnodar
  3 D05   42.50005  +43.274569   3110.076 0.729580  +0.682314    Russia         ISON-Terskol Observatory
  3 D06   12.77017  +41.750270    581.475 0.747232  +0.662472    Italy          Associazione Tuscolana di Astronomia, Domatore
@@ -1304,6 +1304,8 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 D27    3.80361  +43.626682    125.173 0.725021  +0.686446    France         Observatoire de Fontcaude, Juvignac
  3 D28    2.18286  +41.619802    282.425 0.748708  +0.660744    Spain          Escaldarium Observatory,Caldes de Montbui
  3 D29  118.4639   +32.734366    218.979 0.84204   +0.53767     China          Purple Mountain Observatory, XuYi Station
+ 3 D30   11.08350  +50.942811    340.480 0.631405  +0.772922    Germany        Sternwarte Silbergraben, Erfurt
+ 3 D31   10.09797  +44.504353    920.531 0.714476  +0.697520    Italy          Osservatorio Aldebaran, Rivalba
  3 D32  119.59975  +30.469432    942.861 0.862770  +0.504193    China          JiangNanTianChi Observatory, Mt. Getianling
  3 D33  120.6982   +22.049959     38.416 0.92730   +0.37308     Taiwan         Kenting Observatory, Checheng
  3 D34  120.7839   +21.950269    118.573 0.92796   +0.37148     Taiwan         Kenting Observatory, Hengchun
@@ -1312,17 +1314,44 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 D37  120.87325  +23.468778   2860.725 0.918176  +0.395972    Taiwan         Lulin Widefield Telescope, Mt. Lulin
  3 D38    8.43764  +44.912897    157.438 0.709383  +0.702495    Italy          Tecnosky Astropark, Felizzano
  3 D39  122.04961  +37.535927    100.091 0.793971  +0.605943    China          Shandong University Observatory, Weihai
+ 3 D40   13.33772  +41.653222    254.016 0.748318  +0.661176    Italy          Frosinone
+ 3 D41   10.71704  +43.429224    485.944 0.727431  +0.683991    Italy          Osservatorio Astronomico Orciatico
+ 3 D42   11.19084  +43.747676    123.853 0.723565  +0.687970    Italy          Piero Angela Observatory, Scandicci
+ 3 D43    7.77039  +45.044600    555.431 0.707805  +0.704162    Italy          45th Parallel Observatory, Pino Torinese
  3 D44  124.13928  +24.372862    196.762 0.911427  +0.410157    Japan          Ishigakijima Astronomical Observatory
+ 3 D45   21.49325  +50.334547    203.712 0.639594  +0.766177    Poland         Kamyk, Trzesn
+ 3 D46    9.90265  +47.906000    724.482 0.671664  +0.738525    Germany        Observatory Bad Wurzach
+ 3 D47   11.56366  +42.479972    199.693 0.738665  +0.671859    Italy          BigBang Observatory, Manciano
+ 3 D48    7.26381  +49.330851    296.849 0.652979  +0.754898    Germany        Niederbexbach Observatory
+ 3 D49    0.79444  +40.876687     58.241 0.757213  +0.650992    Spain          L'Ametlla de Mar
+ 3 D50    5.21519  +44.039478    314.126 0.720062  +0.691654    France         Vaucluse Observatoire Celeste, Blauvac
+ 3 D51    1.94844  +44.082999    352.160 0.719539  +0.692203    France         Plateau Astronomique La Couronne
+ 3 D52    9.79750  +45.098032     87.240 0.707094  +0.704768    Italy          ULU Observatory, Caselle Landi
  3 D53  127.4820   +50.318536    214.305 0.63981   +0.76600     Russia         ISON-Blagoveschensk Observatory
  3 D54  127.4830   +50.318902    263.392 0.63981   +0.76601     Russia         MASTER-II Observatory, Blagoveshchensk
  3 D55  127.9747   +37.372831    205.007 0.79571   +0.60370     South Korea    Kangwon Science High School Observatory, Ksho
+ 3 D56   11.67408  +45.607803     93.456 0.700775  +0.711011    Italy          Osservatorio Sideris Oculus, San Pietro in Gu
  3 D57  128.88744  +35.252875    369.150 0.817572  +0.573996    South Korea    Gimhae Astronomical Observatory, Uhbang-dong
  3 D58  129.02500  +35.165619    149.564 0.818419  +0.572736    South Korea    KSA SEM Observatory, Danggam-dong
+ 3 D59    7.15617  +43.747770    398.800 0.723595  +0.688001    France         MARIAMIR, Saint-Jeannet
+ 3 D60   13.55146  +46.183670    832.667 0.693649  +0.718079    Italy          Sparky's Stars, Masseris
  3 D61  134.9131   +34.327701     29.273 0.82671   +0.56075     Japan          Suntopia Marina, Sumoto
  3 D62  130.4494   +33.289452     56.396 0.83676   +0.54575     Japan          Miyaki-Argenteus
+ 3 D63   10.46138  +44.081326    296.499 0.719553  +0.692176    Italy          G. Pascoli Observatory, Barga (since June 2023)
+ 3 D64   14.10967  +42.305528    179.161 0.740711  +0.669613    Italy          Fucama, Casalincontrada
+ 3 D65   11.53480  +45.497415    227.692 0.702163  +0.709679    Italy          G. Beltrame, Arcugnano Vicenza
+ 3 D66    9.14839  +45.376776    165.993 0.703654  +0.708197    Italy          Civico Osservatorio Astronomico di Rozzano
  3 D67   37.62472  +54.209185    175.117 0.586136  +0.807530    Russia         Tula Rooftop Observatory, Tula
+ 3 D68   11.73622  +45.465410     67.007 0.702543  +0.709270    Italy          Osservatorio Galileo, Padova
+ 3 D69    9.97013  +49.782617    342.740 0.646988  +0.760014    Germany        JMU Space-Observatory
  3 D70  133.4686   +33.467927     37.268 0.83505   +0.54834     Japan          Tosa
+ 3 D71   15.89225  +46.822401    304.705 0.685516  +0.725682    Austria        ObservaSTYRium, Stainz bei Straden
+ 3 D72   16.36131  -23.236603   1856.060 0.919630  -0.392207    Namibia        WAA Remote Observatory, Hakos
+ 3 D73   16.36139  -23.236611   1870.298 0.919632  -0.392208    Namibia        SNX-NET, Hakos
  3 D74  134.6819   +33.948936     54.371 0.83041   +0.55530     Japan          Nakagawa
+ 3 D75   16.95608  +39.488772     74.321 0.772805  +0.632534    Italy          Cariati
+ 3 D76    2.00702  +41.564599    349.351 0.749354  +0.660032    Spain          AAT-Terrassa, Terrassa
+ 3 D77   10.71736  +43.429020    482.054 0.727433  +0.683988    Italy          TD-TRO (Tuscany Remote Observatory)
  3 D78  136.13281  +34.768568    156.708 0.822378  +0.567077    Japan          Iga-Ueno
  3 D79  138.63092  -34.884487     43.798 0.821212  -0.568722    Australia/SA   YSVP Observatory, Vale Park
  3 D80  138.9728   +36.596424    861.621 0.80392   +0.59297     Japan          Gumma Astronomical Observatory
@@ -1343,6 +1372,8 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 D95  141.0680   +38.801469     14.706 0.78035   +0.62325     Japan          Kurihara
  3 D96  140.34216  -34.268869     32.525 0.827287  -0.559905    Australia/SA   Tzec Maun Observatory, Moorook
  3 D97  140.5700   -34.244932     22.177 0.82752   -0.55956     Australia/SA   Berri
+ 3 D98   11.33409  +44.259208    745.434 0.717444  +0.694448    Italy          Loiano TANDEM
+ 3 D99    0.39122  +44.261624    232.292 0.717357  +0.694422    France         AstroKoT, Port-Ste-Marie
  3 E00  144.2089   -37.059619    313.796 0.79902   -0.59937     Australia/VIC  Castlemaine
  3 E01  144.54142  -37.098948    398.631 0.798618  -0.599924    Australia/VIC  Barfold
  3 E03  145.3822   -38.136178     71.609 0.78756   -0.61419     Australia/VIC  RAS Observatory, Officer
@@ -1370,6 +1401,8 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 E26  153.3971   -27.933917     13.334 0.88414   -0.46566     Australia/QLD  RAS Observatory, Biggera Waters
  3 E27  153.2667   -27.566288    -87.610 0.8871    -0.4600      Australia/QLD  Thornlands
  3 E28  150.64105  -33.664388    305.021 0.833196  -0.551210    Australia/NSW  Kuriwa Observatory, Hawkesbury Heights
+ 3 E29  115.95533  -32.309798    -13.625 0.845978  -0.531426    Australia/WA   Mardella Observatory
+ 3 E62  149.08135  -31.281739    838.174 0.855509  -0.516305    Australia/NSW  Slooh.com Australia, Coonabarabran
  3 E81  173.2617   -41.274462    124.363 0.75267   -0.65622     New Zealand    Nelson
  3 E83  173.95703  -41.535738     13.963 0.749648  -0.659621    New Zealand    Wither Observatory, Witherlea
  3 E85  174.89400  -36.895808      6.601 0.800696  -0.597064    New Zealand    Farm Cove
@@ -1397,7 +1430,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 G10  354.45055  +37.667863    131.547 0.792574  +0.607765    Spain          Clavier Observatory, Lora Del Rio
  3 G11    7.18379  +50.993278    247.233 0.630712  +0.773465    Germany        Breitenweg Observatory, Herkenrath
  3 G12    8.3306   +51.676397    167.423 0.62140   +0.78090     Germany        Sternwarte EG, Lippstadt
- 3 G13    9.77169  +63.213826     69.766 0.451874  +0.889103    Norway         Astronomihagen, Fannrem
+ 3 G13    9.77164  +63.214082     69.656 0.451870  +0.889105    Norway         Astronomihagen, Fannrem
  3 G14    7.00520  +43.609130    257.941 0.725247  +0.686239    France         Novaloop Observatory, Mougins
  3 G15    9.1183   +44.772008    570.316 0.71116   +0.70080     Italy          Magroforte Observatory, Alessandria
  3 G16   13.34869  +38.100310     93.304 0.787948  +0.613701    Italy          OmegaLab Observatory, Palermo
@@ -1418,10 +1451,10 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 G31   13.7253   +45.714674    248.590 0.69946   +0.71233     Italy          CCAT Trieste
  3 G32  291.82040  -22.953233   2399.446 0.921639  -0.387713    Chile          Elena Remote Observatory, San Pedro de Atacama
  3 G33    7.60879  +51.528831    101.188 0.623411  +0.779293    Germany        Wickede
- 3 G34   13.7015   +50.860063    490.669 0.63254   +0.77203     Germany        Oberfrauendorf
+ 3 G34   13.70150  +50.860005    553.479 0.632547  +0.772037    Germany        Oberfrauendorf
  3 G35  249.15789  +31.945051    930.571 0.849476  +0.526134    US/Arizona     Elephant Head Obsevatory, Sahuarita
  3 G36  357.45250  +37.222887   2182.977 0.797538  +0.601812    Spain          Calar Alto-CASADO
- 3 G37  248.57749  +34.744284   2238.541 0.822887  +0.566916    US/Arizona     Lowell Discovery Telescope
+ 3 G37  248.57779  +34.744378   2346.659 0.822900  +0.566927    US/Arizona     Lowell Discovery Telescope
  3 G38  356.76842  +40.641132    700.225 0.759967  +0.647951    Spain          Observatorio La Senda, Cabanillas del Campo
  3 G39  291.82039  -22.953105   2400.344 0.921640  -0.387711    Chile          ROAD, San Pedro de Atacama
  3 G40  343.49174  +28.299720   2370.113 0.881470  +0.471441    Canary Island  Slooh.com Canary Islands Observatory
@@ -1480,7 +1513,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 G93  249.3726   +31.662445   1562.811 0.85215   +0.52201     US/Arizona     Sonoita Research Observatory, Sonoita
  3 G94  249.9267   +31.928464   1542.600 0.84971   +0.52594     US/Arizona     Sonoran Skies Observatory, St. David
  3 G95  249.7622   +31.452173   1386.852 0.85404   +0.51888     US/Arizona     Hereford Arizona Observatory, Hereford
- 3 G96  249.21128  +32.442754   2788.927 0.845111  +0.533614    US/Arizona     Mt. Lemmon Survey
+ 3 G96  249.21128  +32.442732   2757.131 0.845107  +0.533611    US/Arizona     Mt. Lemmon Survey
  3 G97  250.8694   +31.933218   1420.219 0.84965   +0.52600     US/Arizona     Astronomical League Alpha Observatory, Portal
  3 G98  251.34354  +35.525435   2022.028 0.815037  +0.578012    US/New Mexico  Calvin-Rehoboth Observatory, Rehoboth
  3 G99  251.8104   +32.770984   1921.735 0.84192   +0.53835     US/New Mexico  NF Observatory, Silver City
@@ -1617,7 +1650,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 I30  299.3417   -32.984475     64.497 0.83966   -0.54131     Argentina      Observatorio Geminis Austral
  3 I31  299.3649   -32.953687     54.393 0.83995   -0.54086     Argentina      Observatorio Astronomico del Colegio Cristo Rey
  3 I32  299.3464   -32.980641     16.675 0.83969   -0.54125     Argentina      Observatorio Beta Orionis, Rosario
- 3 I33  289.2608   -30.238025   2693.948 0.86504   -0.50086     Chile          SOAR, Cerro Pachon
+ 3 I33  289.26631  -30.237926   2776.132 0.865052  -0.500865    Chile          SOAR, Cerro Pachon
  3 I34  284.1297   +40.146752    155.206 0.76548   +0.64134     US/Pennsylvan  Morgantown
  3 I35  301.5572   -34.807262     47.885 0.82198   -0.56762     Argentina      Sidoli
  3 I36  301.28271  -35.008112     26.061 0.819978  -0.570483    Argentina      Observatorio Los Campitos, Canuelas
@@ -1625,7 +1658,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 I38  302.02141  -31.392540     37.679 0.854400  -0.517885    Uruguay        Observatorio Los Algarrobos, Salto
  3 I39  301.42661  -34.669660     33.927 0.823342  -0.565652    Argentina      Observatorio Cruz del Sur, San Justo
  3 I40  289.26061  -29.254610   2317.774 0.873472  -0.485986    Chile          La Silla--TRAPPIST
- 3 I41  243.14022  +33.357340   1686.997 0.836325  +0.546877    US/California  Palomar Mountain--ZTF
+ 3 I41  243.14022  +33.357339   1664.000 0.836322  +0.546875    US/California  Palomar Mountain--ZTF
  3 I42  288.9081   +41.596233     21.932 0.74895   +0.66041     US/Massachuse  Westport Observatory
  3 I43  261.90237  +32.216192    395.386 0.846901  +0.530084    US/Texas       Tarleton State University Obs., Stephenville
  3 I44  273.5176   +30.542034     59.200 0.86201   +0.50521     US/Florida     Northwest Florida State College, Niceville
@@ -1636,7 +1669,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 I49  253.98617  +35.709179   2085.219 0.813183  +0.580617    US/New Mexico  Sunflower Observatory, Santa Fe
  3 I50  254.47142  +32.903277   2223.377 0.840712  +0.540309    US/New Mexico  P2 Observatory, Mayhill
  3 I51  283.0547   +38.711560     17.782 0.78133   +0.62203     US/Maryland    Clinton
- 3 I52  249.21108  +32.442547   2789.427 0.845113  +0.533611    US/Arizona     Steward Observatory, Mt. Lemmon Station
+ 3 I52  249.21108  +32.442573   2761.053 0.845109  +0.533609    US/Arizona     Steward Observatory, Mt. Lemmon Station
  3 I53  356.3783   +37.140060    668.536 0.79822   +0.60052     Spain          Armilla
  3 I54  353.03081  +38.849002    192.307 0.779853  +0.623912    Spain          Observatorio Las Vaguadas, Badajoz
  3 I55  359.64214  +39.491506     26.918 0.772769  +0.632566    Spain          Valencia
@@ -1677,7 +1710,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 I90  351.59760  +51.900379     13.729 0.618315  +0.783298    Ireland        Blackrock Castle Observatory
  3 I91  357.69250  +36.848496     22.977 0.801192  +0.596407    Spain          Retamar
  3 I92  353.95289  +37.345585    119.226 0.795987  +0.603315    Spain          Astreo Observatory, Mairena del Aljarafe
- 3 I93  359.79700  +44.558710     18.715 0.713711  +0.698096    France         St Pardon de Conques
+ 3 I93  359.79704  +44.558673     68.359 0.713717  +0.698101    France         St Pardon de Conques
  3 I94  356.1367   +40.495586    740.648 0.76162   +0.64603     Spain          Observatorio Rho Ophiocus, Las Rozas de Madrid
  3 I95  356.81394  +39.568615    674.998 0.771993  +0.633666    Spain          Observatorio de la Hita
  3 I96  356.50384  +40.793540    676.395 0.758233  +0.649960    Spain          Hyperion Observatory, Urbanizacion Caraquiz
@@ -1688,7 +1721,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 J01  354.28450  +42.377689    813.776 0.739938  +0.670609    Spain          Observatorio Cielo Profundo, Leon
  3 J02  359.5550   +38.475838    187.428 0.78391   +0.61884     Spain          Busot
  3 J03  355.13250  +50.394175    142.538 0.638787  +0.766833    UK/England     Gothers Observatory, St. Dennis
- 3 J04  343.48817  +28.300924   2391.279 0.881463  +0.471461    Canary Island  ESA Optical Ground Station, Tenerife
+ 3 J04  343.48817  +28.300959   2451.325 0.881471  +0.471466    Canary Island  ESA Optical Ground Station, Tenerife
  3 J05  355.29639  +41.545557    716.135 0.749617  +0.659822    Spain          Bootes Observatory, Boecillo
  3 J06  358.81247  +52.909132     48.265 0.604374  +0.794039    UK/England     Trent Astronomical Observatory, Clifton
  3 J07  353.89543  +39.935161    414.738 0.767881  +0.638546    Spain          Observatorio SPAG Monfrague, Palazuelo-Empalme
@@ -1835,7 +1868,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 K48   10.83881  +45.209185     25.648 0.705714  +0.706127    Italy          Keyhole Observatory, San Giorgio di Mantova
  3 K49   11.18581  +43.681117    253.729 0.724381  +0.687146    Italy          Carpione Observatory, Spedaletto
  3 K50   11.13300  +49.790115    489.515 0.646903  +0.760116    Germany        Sternwarte Feuerstein, Ebermannstadt
- 3 K51   11.6579   +46.029412   1232.191 0.69563   +0.71626     Italy          Osservatorio del Celado, Castello Tesino
+ 3 K51   11.65789  +46.029483   1295.483 0.695636  +0.716268    Italy          Osservatorio del Celado, Castello Tesino
  3 K52    7.6478   +45.230562    300.858 0.70548   +0.70642     Italy          Gwen Observatory, San Francesco al Campo
  3 K53   12.04564  +41.981365      7.018 0.744479  +0.665409    Italy          Marina di Cerveteri
  3 K54   11.33678  +43.312669    290.262 0.728803  +0.682494    Italy          Astronomical Observatory University of Siena
@@ -1847,7 +1880,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 K60   13.51069  +55.435949     40.994 0.568623  +0.819848    Sweden         Lindby
  3 K61   13.6026   +49.751403    406.207 0.64741   +0.75967     Czech Republi  Rokycany Observatory
  3 K62   13.84675  +50.638321    277.939 0.635514  +0.769557    Czech Republi  Teplice Observatory
- 3 K63   10.4620   +44.082410    208.868 0.71953   +0.69218     Italy          G. Pascoli Observatory, Castelvecchio Pascoli
+ 3 K63   10.46252  +44.082789    302.917 0.719536  +0.692195    Italy          G. Pascoli Observatory, Barga (before June 2023)
  3 K64   11.74397  +49.935479    471.055 0.644963  +0.761748    Germany        Waizenreuth
  3 K65   12.2339   +44.141649     16.634 0.71879   +0.69290     Italy          Cesena
  3 K66   12.62861  +41.463359     80.963 0.750491  +0.658684    Italy          Osservatorio Astronomico di Anzio
@@ -1872,7 +1905,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 K85    6.03161  +50.723994    238.039 0.634354  +0.770499    Belgium        Kelmis
  3 K86   10.18189  +45.549196    199.075 0.701516  +0.710308    Italy          Brescia
  3 K87   10.17011  +49.807693    273.486 0.646647  +0.760288    Germany        Dettelbach Vineyard Observatory
- 3 K88   19.8936   +47.917622    975.365 0.67154   +0.73869     Hungary        GINOP-KHK, Piszkesteto
+ 3 K88   19.89367  +47.917455    983.456 0.671543  +0.738689    Hungary        GINOP-KHK, Piszkesteto
  3 K89   11.56339  +42.480015    204.001 0.738665  +0.671860    Italy          Digital Stargate Observatory, Manciano
  3 K90   20.54577  +44.530241    323.499 0.714093  +0.697776    Serbia         Sopot Astronomical Observatory
  3 K91   20.81019  -32.380542   1806.975 0.845561  -0.532618    South Africa   Sutherland-LCO A
@@ -1938,7 +1971,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 L51   34.0164   +44.729400    636.020 0.71169   +0.70028     Ukraine        MARGO, Nauchnyi
  3 L52   34.01694  +44.730130    617.598 0.711679  +0.700287    Ukraine        MASTER-Tavrida
  3 L53    9.03381  +45.705208    348.311 0.699589  +0.712226    Italy          Lomazzo Observatory, Como
- 3 L54   22.88878  +45.616534    446.607 0.700705  +0.711157    Romania        Berthelot Observatory, Hunedoara
+ 3 L54   22.88878  +45.616535    437.587 0.700704  +0.711156    Romania        Berthelot Observatory, Hunedoara
  3 L55   35.08750  +48.320586    142.581 0.666222  +0.743283    Ukraine        Sura Gardens, Dnipro
  3 L56    8.05858  +50.381562    177.816 0.638960  +0.766697    Germany        Sternwarte Limburg, Limburg
  3 L57   26.90419  +46.565635    204.987 0.688762  +0.722601    Romania        Bacau Observatory, Bacau
@@ -1984,6 +2017,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 L97  357.99161  +51.437018    120.565 0.624666  +0.778298    UK/England     Castle Fields Observatory, Calne
  3 L98  357.43425  +37.982643   1583.074 0.789394  +0.612232    Spain          La Sagra Observatory, Puebla de Don Fadrique
  3 L99   30.60281  +50.607688    137.300 0.635913  +0.769201    Ukraine        Novosilky
+ 3 M00   26.21154  +60.734470    107.531 0.490116  +0.868754    Finland        Viestikallio, Artjarvi
  3 M02    0.86386  +41.123329    425.965 0.754439  +0.654271    Spain          Astropriorat Observatory
  3 M03    2.25822  +41.456428     56.282 0.750568  +0.658591    Spain          Badalona Boreal
  3 M04    1.4256   +41.717450    816.625 0.74764   +0.66207     Spain          Pujalt Observatory, Barcelona
@@ -1994,6 +2028,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 M09    5.60094  +51.032739    115.579 0.630164  +0.773882    Belgium        Observatory Gromme - Oudsbergen
  3 M10    6.85411  +43.692307    771.080 0.724305  +0.687343    France         CPF Observatory, St Vallier de Thiey
  3 M11    5.64718  +43.999389    683.567 0.720589  +0.691192    France         Novaastro Observatory, Banon
+ 3 M12   47.8639   +56.109697    169.230 0.55891   +0.82648     Russia         Puschino
  3 M13    7.74250  +48.578160    188.268 0.662866  +0.746267    France         Lucie Berger Observatory, Strasbourg
  3 M14    8.78939  +45.673318    296.649 0.699981  +0.711832    Italy          Schiaparelli Gallarate Station
  3 M15    9.1506   +45.640009    240.683 0.70039   +0.71142     Italy          Virgo Oservatory, Seveso
@@ -2019,14 +2054,14 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 M35   26.61669  +46.575381    347.485 0.688654  +0.722734    Romania        PS Observatory, Parjol
  3 M36   13.79647  +45.693884    364.517 0.699732  +0.712090    Italy          Opicina, Trieste
  3 M37   13.91243  +45.920164    836.096 0.696956  +0.714892    Slovenia       Astronomsko drustvo Nanos, Ajdovscina
- 3 M38   21.76719  +47.945779    151.244 0.671089  +0.738923    Hungary        Harsona Observatory, Nyiregyhaza
+ 3 M38   21.76719  +47.945818    155.979 0.671089  +0.738924    Hungary        Harsona Observatory, Nyiregyhaza
  3 M39   22.95888  +40.630651     87.966 0.760013  +0.647750    Greece         AUTH Observatory, Thessaloniki
  3 M40   31.82708  +29.936004    481.345 0.867372  +0.496143    Egypt          OSTS-NRIAG, Kottamia
  3 M41   39.25827  +21.521802     59.001 0.930706  +0.364567    Saudi Arabia   Jeddah
  3 M42   54.6708   +24.580820    -18.052 0.90990   +0.41343     United Arab E  Emirates Observatory, Al Rahba
  3 M43   54.68478  +24.176308     19.886 0.912805  +0.407034    United Arab E  Al Sadeem Observatory, Abu Dhabi
  3 M44   54.92031  +24.219597     55.781 0.912502  +0.407722    United Arab E  Al-Khatim Observatory, Abu Dhabi
- 3 M45   25.7689   +45.865585    570.140 0.69761   +0.71420     Romania        Starhopper Observatory, Sfantu Gheorghe
+ 3 M45   25.76889  +45.865496    624.117 0.697617  +0.714205    Romania        Starhopper Observatory, Sfantu Gheorghe
  3 M46   55.45033  +25.213476     21.599 0.905280  +0.423399    United Arab E  Althuraya Astronomy Center, Dubai
  3 M47   55.46205  +25.282675     -9.122 0.904763  +0.424484    United Arab E  Sharjah Observatory, Sharjah
  3 M48   15.09222  +37.506621     63.111 0.794277  +0.605535    Italy          GAC - Via L. Sturzo Observatory, Catania
@@ -2045,6 +2080,13 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 M61    6.58581  +51.420052     75.819 0.624893  +0.778108    Germany        Observatory Moers Kapellen
  3 M62    7.13417  +47.281115   1035.212 0.679741  +0.731214    Switzerland    Lajoux Observatory
  3 M63   18.36969  +39.842607    179.302 0.768886  +0.637286    Italy          RPF Observatory, Gagliano del Capo
+ 3 M64    0.23964  +50.966907    202.917 0.631065  +0.773170    UK/England     Holbrook, Heathfield
+ 3 M65   28.32494  +61.064799     88.046 0.485072  +0.871558    Finland        Mustola Observatory, Lappeenranta
+ 3 M66   32.84019  +34.932094   1435.382 0.820917  +0.569526    Cyprus         SNX-NET, Prodromos
+ 3 M68   37.83052  +55.760259    176.189 0.563964  +0.823064    Russia         School 1502 Rooftop Obs., Moscow
+ 3 M70   26.40409  -29.039088   1414.479 0.875173  -0.482645    South Africa   BOOTES-6, Bloemfontein
+ 3 M75   39.51155  +45.742940     44.995 0.699085  +0.712651    Russia         Online observatory, Peschany
+ 3 M77   39.96553  +44.204621    768.124 0.718110  +0.693769    Russia         Mezmay Comet Search Center
  3 M90   65.4286   +56.946120     63.640 0.54672   +0.83452     Russia         Chervishevo
  3 N27   73.7253   +54.748119     58.759 0.57847   +0.81298     Russia         Omsk-Yogik Observatory
  3 N30   74.3694   +31.472983    181.794 0.85369   +0.51909     Pakistan       Zeds Astronomical Observatory, Lahore
@@ -2054,6 +2096,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 N44   77.13931  +38.384471   1201.281 0.785023  +0.617693    China          Shache Station, Langan Village
  3 N50   78.96383  +32.779547   4475.445 0.842176  +0.538692    India          Himalayan Chandra Telescope, IAO, Hanle
  3 N51   78.96461  +32.779243   4468.905 0.842178  +0.538687    India          GROWTH India Telescope, IAO, Hanle
+ 3 N54   80.02674  +32.324939   5026.316 0.846505  +0.532071    China          Purple Mountain Observatory, Jiama'erdeng
  3 N55   80.02623  +32.326059   5044.589 0.846497  +0.532089    China          Corona Borealis Observatory, Ngari, Tibet
  3 N56   80.02675  +32.325098   5022.358 0.846503  +0.532073    China          Jiama'erdeng Tianwentai, Ali, Tibet
  3 N57   80.04600  +32.306021   5350.969 0.846724  +0.531820    China          YLT, NAOC
@@ -2063,12 +2106,17 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 N87   87.17503  +43.473613   2039.957 0.727076  +0.684720    China          Nanshan Station, Xinjiang Observatory
  3 N88   87.17322  +43.471787   2040.858 0.727098  +0.684697    China          Xingming Observatory #3, Nanshan
  3 N89   87.17906  +43.470806   2016.695 0.727107  +0.684682    China          Xingming Observatory #2, Nanshan
+ 3 N94   88.72792  +47.588448    971.591 0.675788  +0.734831    China          Altay Astronomical Observatory
  3 O02   90.52614  +30.103182   4283.753 0.866434  +0.498958    China          Galaxy Tibet YBJ Observatory,Yangbajing
  3 O17   93.88669  +38.588778   3790.308 0.783127  +0.620730    China          Purple Mountain Observatory, Lenghu-1
  3 O18   93.89522  +38.607604   4145.658 0.782966  +0.621021    China          WFST, Lenghu
  3 O37   98.48553  +18.589868   2514.131 0.948521  +0.316891    Thailand       TRT-NEO, Chiangmai
+ 3 O39  100.03105  +26.695553   3195.334 0.894458  +0.446769    China          BOOTES-4, Lijiang
+ 3 O40  100.22861  +29.013063   3854.266 0.875727  +0.482435    China          Xingyuan, Daocheng
+ 3 O41   99.46556  +18.336971    212.998 0.949569  +0.312613    Thailand       Choakanan Observatory, Lampang
+ 3 O42  100.02900  +26.722495   3134.381 0.894239  +0.447183    China          Gaomeigu Gemini Observatory, LiJiang
  3 O43   99.78111   +6.307021    111.299 0.994005  +0.109127    Malaysia       Observatori Negara, Langkawi
- 3 O44  100.0310   +26.709191   3184.696 0.89435   +0.44698     China          Lijiang Station, Yunnan Observatories
+ 3 O44  100.02973  +26.695089   3240.856 0.894468  +0.446765    China          Lijiang Station, Yunnan Observatories
  3 O45  100.03261  +26.697920   3227.314 0.894444  +0.446808    China          Yunnan-HK Observatory, Gaomeigu
  3 O46  100.22664  +29.011750   3853.753 0.875738  +0.482415    China          Daocheng Glacier Observatory
  3 O47  101.13415  +25.624399   2274.672 0.902535  +0.429998    China          Yunling Observatory, Yunnan
@@ -2077,11 +2125,17 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 O50  101.43942   +3.033412     56.171 0.998617  +0.052565    Malaysia       Hin Hua Observatory, Klang
  3 O51  101.27869  +12.734700    -25.562 0.975556  +0.218996    Thailand       Akin Observatory, Rayong
  3 O52  100.72972  +13.578635    -26.336 0.972224  +0.233250    Thailand       Astro820, Samut Prakan
+ 3 O53  101.40403  +14.669313    288.411 0.967655  +0.251610    Thailand       Pakchong, Nachonratchasima
+ 3 O54  100.94939  +13.294693    -16.278 0.973370  +0.228460    Thailand       TSky Observatory, Chonburi
+ 3 O55  101.85450   +2.445334     28.907 0.999100  +0.042381    Malaysia       Telok Kemang Observatory, Port Dickson
+ 3 O56  101.45455  +14.698323    292.205 0.967528  +0.252097    Thailand       Jaichalad-Pailin Observatory
  3 O68  105.33090  +37.629648   1265.425 0.793121  +0.607347    China          LW-2, NAOC-Zhongwei
  3 O72  106.33476  +47.886134   1637.802 0.672017  +0.738399    Mongolia       OWL-Net, Songino
  3 O75  107.05180  +47.865238   1606.859 0.672284  +0.738151    Mongolia       ISON-Hureltogoot Observatory
  3 O85  109.21300  +34.352281    911.138 0.826583  +0.561181    China          LiShan Observatory, Lintong
  3 P07  114.08987  -21.895687     51.267 0.928304  -0.370597    Australia/WA   Space Surveillance Telescope, HEH Station
+ 3 P13  115.57333  +39.837556   1140.146 0.769058  +0.637315    China          Baihuashan Observatory, Beijing
+ 3 P14  115.81167  -31.984472     -2.817 0.848989  -0.526638    Australia/WA   Nedlands Observatory, Perth
  3 P18  116.61083  +40.898907    482.210 0.757010  +0.651328    China          Birch Forest Observatory, LaBaGouMen
  3 P21  117.28146  -31.820553    334.732 0.850540  -0.524246    Australia/WA   6R-AUS1, Youndegin
  3 P22  117.57588  +40.394252    886.203 0.762782  +0.644702    China          LW-3, NAOC-Xinglong
@@ -2092,6 +2146,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 P35  120.55699  +24.093399     49.897 0.913398  +0.405722    Taiwan         Cuteip Remote Observatory, Changhua
  3 P36  120.62669  +31.302952     13.767 0.855207  +0.516553    China          ULTRA Observatory,Suzhou
  3 P37  120.63972  +24.153164     93.083 0.912980  +0.406672    Taiwan         HuiWen High School Observatory, Taichung City
+ 3 P38  120.71429  +22.074678     26.008 0.927137  +0.373477    Taiwan         Checheng Elementary School Observatory
  3 P40  121.53958  +25.134642    399.145 0.905916  +0.422185    Taiwan         Chinese Culture University, Taipei
  3 P48  123.32403  -75.100395   3232.597 0.258064  -0.963413    Antarctica     ASTEP, Concordia Station
  3 P61  126.33047  +43.824408    335.644 0.722664  +0.688958    China          Jilin Observatory
@@ -2100,6 +2155,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 P65  127.37568  +36.397627    160.714 0.805889  +0.590124    South Korea    OWL-Net, Daedeok
  3 P66  127.44675  +34.526296     73.809 0.824763  +0.563603    South Korea    Deokheung Optical Astronomy Observatory
  3 P67  127.7415   +37.871793    128.603 0.79040   +0.61057     South Korea    Kangwon National University Observatory
+ 3 P68  127.47440  +36.333148    175.243 0.806556  +0.589222    South Korea    DDSHS Biryong Observatory
  3 P71  128.76108  +35.502785    142.020 0.815026  +0.577520    South Korea    Miryang Arirang Astronomical Observatory
  3 P72  128.97595  +36.163884   1168.629 0.808423  +0.586939    South Korea    OWL-Net, Mt. Bohyun
  3 P73  129.0820   +35.263076    138.223 0.81744   +0.57412     South Korea    BSH Byulsem Observatory, Busan
@@ -2111,7 +2167,9 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 Q11  137.52069  +34.984299    185.236 0.820236  +0.570158    Japan          Shinshiro
  3 Q12  137.82536  +36.476962    777.994 0.805147  +0.591292    Japan          Nagano Observatory
  3 Q19  139.4390   +35.573820     81.308 0.81430   +0.57852     Japan          Machida
+ 3 Q20  139.57008  -34.544081     53.375 0.824585  -0.563856    Australia/SA   Swan Reach Imaging, Glenalta
  3 Q21  139.85335  +36.507360    100.066 0.804747  +0.591654    Japan          Southern Utsunomiya
+ 3 Q22  140.34192  -34.269187     48.802 0.827286  -0.559911    Australia/SA   SNX-NET, Moorook
  3 Q23  140.3864   +37.295470    314.028 0.79654   +0.60264     Japan          Sukagawa
  3 Q24  140.52350  +35.898994     41.108 0.810991  +0.583108    Japan          Katori
  3 Q33  142.48278  +44.373646    192.283 0.715989  +0.695814    Japan          Nayoro Observatory, Hokkaido University
@@ -2133,6 +2191,8 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 Q68  150.33742  -33.702135    957.276 0.832917  -0.551813    Australia/NSW  Blue Mountains Observatory, Leura
  3 Q69  150.44933  -33.712916    681.680 0.832777  -0.551945    Australia/NSW  Hazelbrook
  3 Q70  150.50044  -23.269456    108.324 0.919153  -0.392623    Australia/QLD  Glenlee Observatory, Glenlee
+ 3 Q71  149.06980  -31.273329   1144.816 0.855626  -0.516205    Australia/NSW  SNX-NET, Siding Spring
+ 3 Q73  151.64894  -32.765687     41.676 0.841722  -0.538113    Australia/NSW  Buckthorn, Thornton
  3 Q78  152.94789  -27.605675     84.314 0.886807  -0.460619    Australia/QLD  Woogaroo Observatory, Forest Lake
  3 Q79  152.8481   -27.368290     80.362 0.88871   -0.45696     Australia/QLD  Samford Valley Observatory
  3 Q80  153.2160   -27.503454     22.748 0.88762   -0.45904     Australia/QLD  Birkdale
@@ -2142,22 +2202,24 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 R58  170.49039  -45.864384    148.645 0.697579  -0.714138    New Zealand    Beverly-Begg Observatory, Dunedin
  3 R65  172.34981  -43.498734    116.431 0.726556  -0.684830    New Zealand    R. F. Joyce Observatory, Christchurch
  3 R66  172.58761  -43.495302     27.181 0.726587  -0.684777    New Zealand    Mooray Observatory, Christchurch
+ 3 R78  175.09104  -38.094331    164.569 0.788021  -0.613626    New Zealand    Crystal Lake Observatory, Ngutunui
+ 3 T02  203.49572  +20.900636    104.174 0.934614  +0.354517    US/Hawaii      SNX-NET, Wailuku
  3 T03  203.74247  +20.706986   3050.490 0.936240  +0.351538    US/Hawaii      Haleakala-LCO Clamshell #3
  3 T04  203.74249  +20.706966   3056.456 0.936241  +0.351538    US/Hawaii      Haleakala-LCO OGG B #2
- 3 T05  203.74299  +20.707573   3040.957 0.936235  +0.351547    US/Hawaii      ATLAS-HKO, Haleakala
+ 3 T05  203.74299  +20.707553   3046.923 0.936236  +0.351547    US/Hawaii      ATLAS-HKO, Haleakala
  3 T07  204.42387  +19.536152   3426.958 0.943290  +0.332467    US/Hawaii      ATLAS-MLO Auxiliary Camera, Mauna Loa
  3 T08  204.42395  +19.536152   3426.958 0.943290  +0.332467    US/Hawaii      ATLAS-MLO, Mauna Loa
- 3 T09  204.52398  +19.825490   4160.275 0.941706  +0.337237    US/Hawaii      Subaru Telescope, Maunakea
+ 3 T09  204.52396  +19.825501   4194.602 0.941711  +0.337239    US/Hawaii      Subaru Telescope, Maunakea
  3 T10  204.52241  +19.824136   4106.197 0.941706  +0.337212    US/Hawaii      Submillimeter Array, Maunakea (SMA)
- 3 T11  204.53036  +19.822889   4225.920 0.941731  +0.337198    US/Hawaii      United Kingdom Infrared Telescope, Maunakea
- 3 T12  204.53057  +19.822983   4216.082 0.941729  +0.337199    US/Hawaii      University of Hawaii 88-inch telescope, Maunakea
- 3 T13  204.52771  +19.827191   4126.519 0.941691  +0.337263    US/Hawaii      NASA Infrared Telescope Facility, Maunakea
- 3 T14  204.53113  +19.825280   4206.113 0.941714  +0.337236    US/Hawaii      Canada-France-Hawaii Telescope, Maunakea
- 3 T15  204.53094  +19.823834   4236.527 0.941727  +0.337214    US/Hawaii      Gemini North Observatory, Maunakea
- 3 T16  204.52570  +19.826253   4170.397 0.941703  +0.337250    US/Hawaii      W. M. Keck Observatory, Keck 1, Maunakea
- 3 T17  204.52580  +19.826636   4165.376 0.941700  +0.337256    US/Hawaii      W. M. Keck Observatory, Keck 2, Maunakea
+ 3 T11  204.52965  +19.822452   4228.780 0.941734  +0.337191    US/Hawaii      United Kingdom Infrared Telescope, Maunakea
+ 3 T12  204.53054  +19.823013   4244.409 0.941733  +0.337201    US/Hawaii      University of Hawaii 88-inch telescope, Maunakea
+ 3 T13  204.52797  +19.826229   4196.560 0.941707  +0.337251    US/Hawaii      NASA Infrared Telescope Facility, Maunakea
+ 3 T14  204.53109  +19.825438   4232.766 0.941717  +0.337240    US/Hawaii      Canada-France-Hawaii Telescope, Maunakea
+ 3 T15  204.53093  +19.823815   4242.527 0.941728  +0.337214    US/Hawaii      Gemini North Observatory, Maunakea
+ 3 T16  204.52526  +19.825938   4191.744 0.941708  +0.337246    US/Hawaii      W. M. Keck Observatory, Keck 1, Maunakea
+ 3 T17  204.52574  +19.826558   4189.377 0.941704  +0.337256    US/Hawaii      W. M. Keck Observatory, Keck 2, Maunakea
  3 T35  210.39020  -17.563461     80.078 0.953686  -0.299837    Tahiti         Astronomical Society of Tahiti
- 3 U52  237.45111  +41.579167    812.665 0.749240  +0.660270    US/California  Shasta Valley Observatory, Grenada
+ 3 U52  237.45100  +41.579167    812.665 0.749240  +0.660270    US/California  Shasta Valley Observatory, Grenada
  3 U53  237.1603   +45.450107    130.091 0.70274   +0.70909     US/Oregon      Murray Hill Observatory, Beaverton
  3 U54  237.31286  +38.565903    336.505 0.782952  +0.620081    US/California  Hume Observatory, Santa Rosa
  3 U55  237.41456  +49.253279     29.265 0.653977  +0.753984    Canada/BritCo  Golden Ears Observatory, Maple Ridge
@@ -2183,18 +2245,20 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 U81  243.61514  +34.272551    928.274 0.827367  +0.560037    US/California  CS3-Trojan Station, Landers
  3 U82  243.61519  +34.272471    929.953 0.827368  +0.560036    US/California  CS3-Palmer Divide Station, Landers
  3 U83  243.57311  +32.842004   1824.998 0.841238  +0.539380    US/California  Mount Laguna Observatory
+ 3 U86  244.53556  +31.044836   2771.394 0.857900  +0.512937    Mexico         BOOTES-5, Bajo California
  3 U93  246.28761  +37.762811   1557.743 0.791740  +0.609209    US/Utah        Skygems Dreamscope Utah, Beryl Junction
  3 U94  246.30250  +37.737783   1552.042 0.792006  +0.608864    US/Utah        iTelescope Observatory, Beryl Junction
  3 U96  246.68600  +54.713670    567.954 0.579007  +0.812698    Canada/Albert  Athabasca University Geophysical Observatory
  3 U97  248.33292  +35.202997   2191.908 0.818306  +0.573452    US/Arizona     JPL SynTrack Robotic Telescope 3, Flagstaff
  3 U98  249.74300  +31.941291   1068.944 0.849529  +0.526090    US/Arizona     NAC Observatory, Benson
+ 3 U99  247.8537   +34.064734    595.944 0.829354  +0.557017    US/Arizona     BCC Observatory, Black Canyon City
  3 V00  248.39981  +31.963127   2030.788 0.849456  +0.526492    US/Arizona     Kitt Peak-Bok
  3 V01  248.23911  +40.448904   1540.295 0.762243  +0.645493    US/Utah        Mountainville Observatory, Alpine
  3 V02  248.05794  +33.399758    341.737 0.835743  +0.547377    US/Arizona     Command Module, Tempe
  3 V03  248.3314   +37.083379   1267.045 0.79889   +0.59979     US/Utah        Big Water
  3 V04  248.46331  +35.095868   2182.756 0.819378  +0.571927    US/Arizona     FRoST, Anderson Mesa
  3 V05  248.63195  +33.310395    597.819 0.836631  +0.546101    US/Arizona     Rusty Mountain Observatory, Gold Canyon
- 3 V06  249.26745  +32.416847   2519.508 0.845317  +0.533211    US/Arizona     Catalina Sky Survey-Kuiper
+ 3 V06  249.26745  +32.416873   2491.132 0.845313  +0.533209    US/Arizona     Catalina Sky Survey-Kuiper
  3 V07  249.1219   +31.680709   2287.949 0.85208   +0.52234     US/Arizona     Whipple Observatory, Mount Hopkins-PAIRITEL
  3 V08  249.33900  +32.079598   1029.734 0.848249  +0.528126    US/Arizona     Mountain Creek Ranch, Vail
  3 V09  249.74202  +31.940560   1078.500 0.849537  +0.526080    US/Arizona     Moka Observatory, Benson
@@ -2222,17 +2286,20 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 V31  254.4750   +32.913751   2200.449 0.84061   +0.54046     US/New Mexico  Hazardous Observatory, Mayhill
  3 V32  254.47131  +32.903322   2203.848 0.840709  +0.540308    US/New Mexico  Canvas View New Mexico Skies, Mayhill
  3 V33  254.72039  +36.380357   2654.159 0.806382  +0.590114    US/New Mexico  Finlaystone Observatory, Angel Fire
- 3 V34  255.36992  +39.004636   2245.136 0.778401  +0.626222    US/Colorado    Black Forest
+ 3 V34  255.36992  +39.004636   2245.136 0.778401  +0.626222    US/Colorado    Baker Observatory, Black Forest
  3 V35  255.91881  +30.588443   1831.571 0.861839  +0.506046    US/Texas       Deep Sky Observatory Collaborative, Pier 5
  3 V36  255.61742  +32.638535    992.561 0.843042  +0.536333    US/New Mexico  The Ranch Observatory, Lakewood
  3 V37  255.98483  +30.679870   2009.519 0.861053  +0.507428    US/Texas       McDonald Observatory-LCO ELP
  3 V38  255.98493  +30.680077   2008.312 0.861051  +0.507431    US/Texas       McDonald Observatory-LCO ELP Aqawan A #1
- 3 V39  255.98452  +30.680028   2005.057 0.861051  +0.507430    US/Texas       McDonald Observatory-LCO ELP B
+ 3 V39  255.98483  +30.679821   2006.265 0.861053  +0.507427    US/Texas       McDonald Observatory-LCO ELP B
  3 V40  255.91873  +30.588443   1831.571 0.861839  +0.506046    US/Texas       Divine Creation Observatory, Fort Davis
  3 V41  256.72578  +44.052007   1039.702 0.719992  +0.691890    US/South Dako  Rapid City
  3 V42  254.47472  +32.913047   2180.278 0.840614  +0.540448    US/New Mexico  Dimension Point, Mayhill
  3 V43  250.4842   +31.866835   1420.236 0.85026   +0.52502     US/Arizona     Chiricahua Skies Observatory, Sunizona
+ 3 V44  251.82983  +34.321865   2267.069 0.827057  +0.560864    US/New Mexico  Coyote Watcher, Pie Town
  3 V54  259.69219  +20.600867   2007.698 0.936737  +0.349756    Mexico         Observatoire LAURIER, El Marques
+ 3 V56  260.30403  +31.937385    618.497 0.849505  +0.525995    US/Texas       Stonehenge Observatory, Novice
+ 3 V57  260.61773  +31.547099    431.894 0.853050  +0.520209    US/Texas       Starfront Observatories, Rockwood
  3 V58  260.73497  +29.778158    460.527 0.868735  +0.493762    US/Texas       Medina Dome, Medina
  3 V59  261.0734   +30.046447    537.153 0.86642   +0.49781     US/Texas       Millwood Observatory, Comfort
  3 V60  261.09473  +30.534071    501.120 0.862140  +0.505126    US/Texas       Putman Mountain Observatory
@@ -2242,6 +2309,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 V70  263.33572  +29.619051    100.577 0.870056  +0.491332    US/Texas       Starry Night Observatory, Columbus
  3 V72  263.89011  +41.274124    312.106 0.752696  +0.656235    US/Nebraska    JDP Observatory, Omaha
  3 V74  264.15689  +29.703308     17.315 0.869320  +0.492598    US/Texas       Katy Observatory, Katy
+ 3 V75  264.56578  +29.044439    -21.654 0.874931  +0.482617    US/Texas       Live Oak Observatory, Lake Jackson
  3 V78  265.10780  +45.660977    352.840 0.700141  +0.711688    US/Minnesota   Spirit Marsh Observatory. Sauk Centre
  3 V81  265.7604   +36.095422    336.783 0.80902   +0.58590     US/Arkansas    Fayetteville
  3 V83  266.25728  +38.677354    269.491 0.781733  +0.621590    US/Missouri    Rolling Hills Observatory, Warrensburg
@@ -2251,6 +2319,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 V93  268.61611  +40.653352    167.239 0.759765  +0.648058    US/Iowa        Pin Oak Observatory, Fort Madison
  3 V94  268.66169  +40.643752    185.038 0.759876  +0.647933    US/Iowa        Cherokeeridge Observatory, Fort Madison
  3 W04  271.00944  +40.491610    246.144 0.761606  +0.645927    US/Illinois    Mark Evans Observatory, Bloomington
+ 3 W05  271.26719  +33.347638     62.313 0.836205  +0.546596    US/Mississipp  Tree Gate Farm Observatory, Starkville
  3 W08  271.88331  +41.758980    196.856 0.747086  +0.662545    US/Illinois    Jimginny Observatory, Naperville
  3 W09  272.14753  +41.256136    171.344 0.752886  +0.655985    US/Illinois    Willowed Plains Observatory, Manteno
  3 W11  272.6247   +41.270841    195.755 0.75272   +0.65618     US/Indiana     Northwest Indiana Robotic Telescope, Lowell
@@ -2274,17 +2343,21 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 W34  277.8453   +35.225393    307.927 0.81784   +0.57360     US/North Caro  Squirrel Valley Observatory, Columbus
  3 W35  278.03910  +31.146836    -14.806 0.856610  +0.514230    US/Georgia     Buffalo Creek Observatory, Nahunta
  3 W38  278.58531  +36.252691    922.142 0.807479  +0.588163    US/North Caro  Dark Sky Observatory, Boone
- 3 W42  279.46569  +27.764539    -13.702 0.885511  +0.463056    US/Florida     Mind's Eye Observatory, Vero Beach
+ 3 W42  279.46571  +27.764566    -19.346 0.885510  +0.463056    US/Florida     Mind's Eye Observatory, Vero Beach
+ 3 W44  286.22016  +41.014860     46.725 0.755635  +0.652808    US/New York    Duo Ursi de Saltu, Scarsdale
+ 3 W45  283.93827  +36.728937    -30.935 0.802431  +0.594736    US/Virginia    Benito Loyola Observatory, Virginia Beach
  3 W46  280.41192  +35.145627    108.744 0.818614  +0.572448    US/North Caro  Foxfire Village
+ 3 W47  289.23501  -30.470470   1602.574 0.862850  -0.504261    Chile          SNX-NET, Rio Hurtado
  3 W48  280.88700  +35.831005    112.194 0.811693  +0.582156    US/North Caro  BKH Observatory, Chapel Hill
  3 W49  281.06757  +38.952839    815.574 0.778794  +0.625380    US/West Virgi  CBA-MM Observatory, Mountain Meadows
  3 W50  281.25404  +35.690054    120.319 0.813127  +0.580167    US/North Caro  Apex
+ 3 W51  287.56544  +41.051862    -21.217 0.755204  +0.653287    US/New York    Custer Institute and Observatory
  3 W52  283.51419  +38.985324    -32.572 0.778335  +0.625736    US/Maryland    US Naval Academy Hopper Hall Observatory
  3 W53  282.31524  +39.639374    114.090 0.771140  +0.634559    US/Maryland    Hagerstown
  3 W54  282.28944  +38.333748     63.391 0.785431  +0.616890    US/Virginia    Mark Slade Remote Observatory, Wilderness
  3 W55  282.58389  +39.407774     92.019 0.773703  +0.631447    US/Maryland    Natelli Observatory, Frederick
  3 W56  282.52583  +39.459533    193.547 0.773143  +0.632153    US/Maryland    Pineapple Observatory, Frederick
- 3 W57  289.26094  -29.255188   2412.162 0.873480  -0.486002    Chile          ESA TBT La Silla Observatory
+ 3 W57  289.26094  -29.255228   2378.105 0.873475  -0.486000    Chile          ESA TBT La Silla Observatory
  3 W58  283.14964  +39.046892     21.886 0.777667  +0.626574    US/Maryland    ALPHA Observatory, South Laurel
  3 W59  284.10758  +40.897966    349.531 0.757005  +0.651302    US/Pennsylvan  The Dark Side Observatory, Weatherly
  3 W60  286.36626   +5.610983   2137.204 0.995574  +0.097155    Colombia       AstroExplor Observatory, Tinjaca
@@ -2344,6 +2417,10 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 X14  295.83222  -31.389999    426.088 0.854475  -0.517879    Argentina      Observatorio Orbis Tertius, Cordoba
  3 X15  291.82053  -22.952948   2441.456 0.921647  -0.387711    Chile          ABYO, San Pedro de Atacama
  3 X16  293.8497   -17.364775   2681.834 0.95511   -0.29667     Bolivia        Astronomia Sigma Octante, Cochabamba
+ 3 X17  289.26208  -29.257419   2375.243 0.873456  -0.486033    Chile          BlackGEM
+ 3 X18  291.82053  -22.952949   2434.588 0.921646  -0.387710    Chile          6R-POL2, San Pedro de Atacama
+ 3 X19  290.67383  -31.802446   2451.588 0.850988  -0.524154    Argentina      Santel Observatory, El Leoncito
+ 3 X20  291.82051  -22.953076   2440.558 0.921646  -0.387713    Chile          BOOTES-7, San Pedro Atacama
  3 X31  299.47934  -31.823022     91.816 0.850485  -0.524263    Argentina      Galileo Galilei Observatory, Oro Verde
  3 X33  299.99039   -2.997379     37.888 0.998647  -0.051941    Brazil         OARU, Manaus
  3 X38  301.13711  -34.435686     18.196 0.825648  -0.562299    Argentina      Observatorio Pueyrredon, La Lonja
@@ -2356,10 +2433,12 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 X72  308.87889  -29.766926     42.220 0.868775  -0.493560    Brazil         Waccobs, Sao Leopoldo
  3 X74  309.49422  -21.394146    417.328 0.931569  -0.362525    Brazil         Observatorio Campo dos Amarais
  3 X77  309.92475  -25.908604    825.865 0.900184  -0.434346    Brazil         Centro Astron. Nevoeiro, Antonio Olinto
+ 3 X86  312.21833  -23.393035    552.060 0.918367  -0.394621    Brazil         Ottoservatorio, Tatui
  3 X87  312.0889   -15.891703   1044.874 0.96218   -0.27210     Brazil         Dogsheaven Observatory, Brasilia
  3 X88  312.49131  -23.445389    596.163 0.918012  -0.395458    Brazil         Observatorio Adhara, Sorocaba
  3 X89  312.21786  -15.844483   1024.765 0.962401  -0.271311    Brazil         Rocca Observatory, Brasilia
  3 X90  312.13208  -15.656914   1273.159 0.963322  -0.268189    Brazil         Carina Observatory, Brasilia
+ 3 X91  312.78881  -23.569491    878.799 0.917193  -0.397452    Brazil         Orion-Colesanti observatory, Mairinque
  3 X93  313.6047   -22.628914   1078.766 0.92363   -0.38244     Brazil         Munhoz Observatory
  3 Y00  315.21504  -20.715082   1111.997 0.935906  -0.351562    Brazil         SONEAR Observatory, Oliveira
  3 Y01  316.01580  -19.881969    885.335 0.940890  -0.337985    Brazil         SONEAR 2 Observatory, Belo Horizonte
@@ -2367,10 +2446,26 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 Y16  318.68794  -21.745265      5.455 0.929268  -0.368170    Brazil         ROCG, Campos dos Goytacazes
  3 Y28  321.3126    -8.788707    414.679 0.98840   -0.15179     Brazil         OASI, Nova Itacuruba
  3 Y40  324.03889   -8.288643    533.510 0.989706  -0.143217    Brazil         Discovery Observatory, Caruaru
- 3 Y64  343.48961  +28.298933   2424.545 0.881484  +0.471433    Canary Island  ATLAS-TDO, Teide
+ 3 Y63  352.13368  +31.206605   2780.551 0.856447  +0.515346    Morocco        SNX-NET, Oukaimeden
+ 3 Y64  343.48961  +28.298933   2424.545 0.881484  +0.471433    Canary Island  Transient Survey Telescope (TST), Teide
  3 Y65  343.49042  +28.298730   2412.450 0.881484  +0.471429    Canary Island  Two-Meter Twin Telescope, TTT1, Teide
  3 Y66  343.49053  +28.298730   2412.450 0.881484  +0.471429    Canary Island  Two-Meter Twin Telescope, TTT2, Teide
+ 3 Y67  352.13292  +31.205945   2766.021 0.856451  +0.515335    Morocco        High Atlas Window to the Kosmos,Oukaimeden
+ 3 Y70  353.37238  +38.215823    580.687 0.786766  +0.615329    Spain          ApolloIV5, Fregenal de la Sierra
+ 3 Y71  353.37251  +38.215662    582.818 0.786768  +0.615327    Spain          Makroskooppi, Fregenal de la Sierra
+ 3 Y75  354.58128  +38.262300    659.345 0.786275  +0.615972    Spain          Abraham Zacut, Salamanca
+ 3 Y76  359.79189  +39.686387     83.941 0.770614  +0.635186    Spain          Observatorio NovaCanet, Canet de Berenguer
+ 3 Y77  356.38858  +40.789626    975.196 0.758313  +0.649939    Spain          Cotos de Monterrey, Venturada
+ 3 Y78  359.46617  +39.400889    198.638 0.773792  +0.631365    Spain          Tros Alt
+ 3 Y79  359.99270  +45.517182    170.471 0.701911  +0.709914    France         Observatoire de la grande vallee
+ 3 Y80  357.16642  +47.738795    123.965 0.673761  +0.736498    France         Brenehuen, Grand-Champ
+ 3 Y81  356.5733   +55.913325    141.593 0.56175   +0.82456     UK/Scotland    Forthimage, Edinburgh
+ 3 Y82  358.06548  +51.025953    135.613 0.630258  +0.773810    UK/England     LPMR Observatory, Broad Chalke
+ 3 Y83  359.04761  +41.621176    341.185 0.748699  +0.660768    Spain          Observatorio Arcosur, Zaragoza
+ 3 Y84  358.11972  +48.375264     78.112 0.665503  +0.743909    France         Observatoire de Saint Domineuc
  3 Y85  351.85389  +43.456675    326.337 0.727084  +0.684321    Spain          Magalofes Observatory, Fene
+ 3 Y86  357.48003  +37.351818    831.730 0.796010  +0.603469    Spain          Observatorio de Seron
+ 3 Y87  353.01194  +42.222005   1313.434 0.741821  +0.668656    Spain          Trevinca Skies-Amalthea, Trevinca
  3 Y88  353.01194  +42.222210   1316.846 0.741819  +0.668659    Spain          ASERO, Valdin
  3 Y89  353.01189  +42.222446   1392.333 0.741825  +0.668670    Spain          Proxima Centauri Observatory, Valdin
  3 Y90  354.5553   +43.203490    672.706 0.73015   +0.68115     Spain          Observatorio ESTELIA, Ladines
@@ -2379,6 +2474,8 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 Y93  355.43322  +41.798064    765.592 0.746699  +0.663112    Spain          Observatorio Azahar, Valoria la Buena
  3 Y94  354.58571  +42.983624   1251.218 0.732833  +0.678415    Spain          LCB Lugueros observatory, Valdelugueros
  3 Y95  357.99864  +38.348453    744.617 0.785356  +0.617157    Spain          Pradillos Ferez
+ 3 Y96  358.08932  +40.417289   1590.036 0.762606  +0.645079    Spain          Observatorio de Vega del Codorno
+ 3 Y97  359.64303  +44.550028     62.301 0.713822  +0.697993    France         Bommes Observatory, Bommes
  3 Y98  358.68692  +51.927850    170.859 0.617953  +0.783613    UK/England     Southside Observatory, Steeple Aston
  3 Y99  359.07299  +41.642025    308.796 0.748454  +0.661036    Spain          Observatorio del Lucero del Alba
  3 Z00  353.26586  +37.104084    110.091 0.798528  +0.599968    Spain          BOOTES-1, Mazagon
@@ -2402,7 +2499,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 Z18  342.10811  +28.756590   2325.350 0.877671  +0.478415    Canary Island  Gran Telescopio Canarias, Roque de los Muchachos
  3 Z19  342.11094  +28.753995   2385.706 0.877701  +0.478380    Canary Island  La Palma-TNG
  3 Z20  342.1217   +28.762012   2356.944 0.87763   +0.47850     Canary Island  La Palma-MERCATOR
- 3 Z21  343.48830  +28.300332   2392.143 0.881468  +0.471452    Canary Island  Tenerife-LCO Aqawan A #1
+ 3 Z21  343.48830  +28.300293   2440.525 0.881475  +0.471455    Canary Island  Tenerife-LCO Aqawan A #1
  3 Z22  343.4894   +28.298890   2393.011 0.88148   +0.47143     Canary Island  MASTER-IAC Observatory, Tenerife
  3 Z23  342.11492  +28.757277   2425.315 0.877679  +0.478433    Canary Island  Nordic Optical Telescope, La Palma
  3 Z24  343.48848  +28.300546   2455.645 0.881475  +0.471460    Canary Island  Tenerife Observatory-LCO B, Tenerife
@@ -2412,7 +2509,7 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 Z28  357.67331  +38.165719   1658.217 0.787438  +0.614748    Spain          Northern Skygems Observatory, Nerpio
  3 Z29  354.11944  +41.372224    872.813 0.751634  +0.657576    Spain          Observatorio Astronomico Sobradillo
  3 Z30  355.52500  +54.178411    168.928 0.586571  +0.807215    UK/Isle of Ma  Glyn Marsh Observatory, Douglas
- 3 Z31  343.48835  +28.300417   2455.213 0.881476  +0.471458    Canary Island  Tenerife Observatory-LCO A, Tenerife
+ 3 Z31  343.48835  +28.300421   2440.957 0.881474  +0.471457    Canary Island  Tenerife Observatory-LCO A, Tenerife
  3 Z32  358.98372  +40.041843   2010.717 0.766879  +0.640130    Spain          Observatorio Astrofisico de Javalambre
  3 Z33  357.67331  +38.165746   1660.581 0.787438  +0.614748    Spain          6ROADS Observatory 2, Nerpio
  3 Z34  359.11233  +52.302083    169.150 0.612800  +0.787622    UK/England     NNHS Drummonds Observatory
@@ -2465,11 +2562,11 @@ Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         n
  3 Z81  355.73240  +36.720606     67.080 0.802530  +0.594629    Spain          Observatorio Estrella de Mar
  3 Z82  355.95903  +36.759241    123.686 0.802135  +0.595173    Spain          BOOTES-2 Observatory, Algarrobo
  3 Z83  356.2881   +40.610079    792.156 0.76033   +0.64755     Spain          Chicharronian 3C Observatory, Tres Cantos
- 3 Z84  357.45179  +37.224049   2160.811 0.797523  +0.601826    Spain          Calar Alto-Schmidt
+ 3 Z84  357.45184  +37.224009   2261.560 0.797536  +0.601835    Spain          Calar Alto-Schmidt
  3 Z85  356.75028  +36.877254   1347.963 0.801058  +0.596932    Spain          Observatorio Sierra Contraviesa
  3 Z86  356.8900   +51.523936     20.726 0.62347   +0.77923     UK/Wales       St. Mellons
  3 Z87  357.10210  +52.648212    110.278 0.608005  +0.791293    UK/England     Stanley Laver Observatory, Pontesbury
- 3 Z88  357.5101   +51.254536    204.251 0.62716   +0.77632     UK/England     Fosseway Observatoy, Stratton-on-the-Fosse
+ 3 Z88  357.5101   +51.254536    204.251 0.62716   +0.77632     UK/England     Fosseway Observatory, Stratton-on-the-Fosse
  3 Z89  357.8281   +53.264567     97.494 0.59942   +0.79777     UK/England     Macclesfield
  3 Z90  357.8482   +37.405564    493.072 0.79540   +0.60418     Spain          Albox
  3 Z91  358.74999  +50.916485     31.749 0.631731  +0.772595    UK/England     Curdridge

--- a/src/kete_core/data/mpc_obs.tsv
+++ b/src/kete_core/data/mpc_obs.tsv
@@ -1,2580 +1,2583 @@
-Pl Code Longitude  Latitude     Altitude rho_cos   rho_sin_phi  region         name
- 3 000    0.0000   +51.477379     65.985 0.62411   +0.77873     UK/England     Greenwich
- 3 001    0.1542   +51.051835    267.895 0.62992   +0.77411     UK/England     Crowborough
- 3 002    0.62     +51.652979   3041.392 0.622     +0.781       UK/England     Rayleigh
- 3 003    3.90     +43.650525   2466.725 0.725     +0.687       France         Montpellier
- 3 004    1.4625   +43.612279    177.272 0.72520   +0.68627     France         Toulouse
- 3 005    2.23100  +48.805069    157.735 0.659891  +0.748875    France         Meudon
- 3 006    2.12417  +41.418524    372.605 0.751042  +0.658129    Spain          Fabra Observatory, Barcelona
- 3 007    2.33675  +48.836384     60.339 0.659470  +0.749223    France         Paris
- 3 008    3.0355   +36.801463    321.739 0.80172   +0.59578     Algeria        Algiers-Bouzareah
- 3 009    7.4417   +46.953793   -107.241 0.6838    +0.7272      Switzerland    Berne-Uecht
- 3 010    6.92124  +43.750945   1266.252 0.723655  +0.688135    France         Caussols
- 3 011    8.7975   +47.319327    551.394 0.67920   +0.73161     Switzerland    Wetzikon
- 3 012    4.35821  +50.798599    105.369 0.633333  +0.771306    Belgium        Uccle
- 3 013    4.48397  +52.154947      1.963 0.614813  +0.786029    Netherlands    Leiden
- 3 014    5.39509  +43.305869     68.916 0.728859  +0.682384    France         Marseilles
- 3 015    5.12929  +52.085463      4.290 0.615770  +0.785285    Netherlands    Utrecht
- 3 016    5.9893   +47.250002    289.019 0.68006   +0.73076     France         Besancon
- 3 017    6.84924  +50.161388    504.202 0.641946  +0.764282    Germany        Hoher List
- 3 018    6.7612   +51.206991     35.055 0.62779   +0.77578     Germany        Dusseldorf-Bilk
- 3 019    6.9575   +46.997440    511.411 0.68331   +0.72779     Switzerland    Neuchatel
- 3 020    7.3004   +43.721542    390.994 0.72391   +0.68767     France         Nice
- 3 021    8.3855   +49.024024    124.234 0.65701   +0.75138     Germany        Karlsruhe
- 3 022    7.7748   +45.037805    656.589 0.70790   +0.70409     Italy          Pino Torinese
- 3 023    8.2625   +50.081187    211.801 0.64299   +0.76335     Germany        Wiesbaden
- 3 024    8.7216   +49.398618    569.103 0.65211   +0.75570     Germany        Heidelberg-Konigstuhl
- 3 025    9.19650  +48.782528    335.024 0.660205  +0.748637    Germany        Stuttgart
- 3 026    7.46511  +46.877102    898.201 0.684884  +0.726402    Switzerland    Berne-Zimmerwald
- 3 027    9.1912   +45.466337    144.519 0.70254   +0.70929     Italy          Milan
- 3 028    9.9363   +49.791035    185.813 0.64686   +0.76009     Germany        Wurzburg
- 3 029   10.2406   +53.479709     20.053 0.59640   +0.80000     Germany        Hamburg-Bergedorf
- 3 030   11.25446  +43.750648    166.264 0.723534  +0.688012    Italy          Arcetri Observatory, Florence
- 3 031   11.18985  +50.377394    627.921 0.639061  +0.766705    Germany        Sonneberg
- 3 032   11.58295  +50.925259    151.114 0.631624  +0.772706    Germany        Jena
- 3 033   11.71124  +50.980142    388.733 0.630904  +0.773338    Germany        Karl Schwarzschild Observatory, Tautenburg
- 3 034   12.45246  +41.922451    102.548 0.745176  +0.664656    Italy          Monte Mario Observatory, Rome
- 3 035   12.57592  +55.686868     10.378 0.565008  +0.822321    Denmark        Copenhagen
- 3 036   12.65040  +41.747469    432.010 0.747247  +0.662420    Italy          Castel Gandolfo
- 3 037   13.7333   +42.657470    427.798 0.73660   +0.67416     Italy          Collurania Observatory, Teramo
- 3 038   13.7704   +45.643273     64.334 0.70033   +0.71144     Italy          Trieste
- 3 039   13.1874   +55.697864     16.642 0.56485   +0.82243     Sweden         Lund
- 3 040   13.7298   +51.031147    160.361 0.63019   +0.77387     Germany        Lohrmann Institute, Dresden
- 3 041   11.38083  +47.268155    612.371 0.679862  +0.731012    Austria        Innsbruck
- 3 042   13.06428  +52.379654     89.789 0.611721  +0.788439    Germany        Potsdam
- 3 043   11.52643  +45.866447   1090.301 0.697656  +0.714269    Italy          Asiago Astrophysical Observatory, Padua
- 3 044   14.2559   +40.862941    145.865 0.75738   +0.65082     Italy          Capodimonte Observatory, Naples
- 3 045   16.3390   +48.231915    278.342 0.66739   +0.74227     Austria        Vienna (since 1879)
- 3 046   14.2881   +48.863293   1061.815 0.65922   +0.74965     Czech Republi  Klet Observatory, Ceske Budejovice
- 3 047   16.8782   +52.398536     89.404 0.61146   +0.78864     Poland         Poznan
- 3 048   15.84080  +50.177332    270.684 0.641709  +0.764432    Czech Republi  Hradec Kralove
- 3 049   17.6067   +59.500336      9.188 0.5088    +0.8580      Sweden         Uppsala-Kvistaberg
- 3 050   18.0582   +59.342247     43.972 0.51118   +0.85660     Sweden         Stockholm (before 1931)
- 3 051   18.4766   -33.933947     11.697 0.83055   -0.55508     South Africa   Royal Observatory, Cape of Good Hope
- 3 052   18.3083   +59.271649     39.628 0.51224   +0.85597     Sweden         Stockholm-Saltsjobaden
- 3 053   18.9642   +47.499604    492.032 0.67688   +0.73373     Hungary        Konkoly Observatory, Budapest (since 1933)
- 3 054   11.6654   +55.621918     77.196 0.56595   +0.82169     Denmark        Brorfelde
- 3 055   19.9596   +50.064521    183.069 0.64321   +0.76316     Poland         Cracow
- 3 056   20.23418  +49.189565   1812.541 0.655001  +0.753470    Slovakia       Skalnate Pleso
- 3 057   20.5133   +44.803652    286.690 0.71074   +0.70116     Serbia         Belgrade
- 3 058   20.4950   +54.712819     25.539 0.57897   +0.81262     Russia         Kaliningrad
- 3 059   20.2201   +49.195978   2629.080 0.65500   +0.75364     Slovakia       Lomnicky Stit
- 3 060   21.4200   +52.090014    135.419 0.61572   +0.78535     Poland         Warsaw-Ostrowik
- 3 061   22.29850  +48.633469    182.711 0.662142  +0.746904    Ukraine        Uzhhorod
- 3 062   22.2293   +60.452429     -0.512 0.49440   +0.86632     Finland        Turku
- 3 063   22.4450   +60.415790     42.113 0.49496   +0.86601     Finland        Turku-Tuorla
- 3 064   22.7500   +60.420405     43.576 0.49489   +0.86605     Finland        Turku-Kevola
- 3 065   12.6318   +47.862150    618.812 0.67222   +0.73800     Germany        Traunstein
- 3 066   23.71817  +37.972271     93.569 0.789321  +0.611946    Greece         Athens
- 3 067   24.0297   +49.832821    350.781 0.64632   +0.76058     Ukraine        Lviv University Observatory
- 3 068   24.0142   +49.836492    340.051 0.64627   +0.76062     Ukraine        Lviv Polytechnic Institute
- 3 069   24.4042   +56.773119     73.404 0.54925   +0.83287     Latvia         Baldone
- 3 070   25.2865   +54.683110    100.911 0.57940   +0.81233     Lithuania      Vilnius (before 1939)
- 3 071   24.73782  +41.693123   1740.173 0.74803   +0.66185     Bulgaria       NAO Rozhen, Smolyan
- 3 072    7.17     +51.088915  -3965.065 0.629     +0.774       Germany        Scheuren Observatory
- 3 073   26.09391  +44.411996    133.589 0.715515  +0.696285    Romania        Bucharest
- 3 074   26.4058   -29.038138   1407.074 0.87518   -0.48263     South Africa   Boyden Observatory, Bloemfontein
- 3 075   26.7216   +58.379715     65.646 0.52557   +0.84791     Estonia        Tartu
- 3 076   27.8768   -25.772770   1232.957 0.90127   -0.43225     South Africa   Johannesburg-Hartbeespoort
- 3 077   28.0292   -26.187261   1762.339 0.89819   -0.43876     South Africa   Yale-Columbia Station, Johannesburg
- 3 078   28.0750   -26.181859   1823.363 0.89824   -0.43868     South Africa   Johannesburg
- 3 079   28.2288   -25.787998   1552.165 0.90120   -0.43251     South Africa   Radcliffe Observatory, Pretoria
- 3 080   28.9667   +41.012704     49.844 0.75566   +0.65278     Turkey         Istanbul
- 3 081   27.8768   -25.772770   1232.957 0.90127   -0.43225     South Africa   Leiden Station, Johannesburg
- 3 082   15.7561   +48.087978    569.092 0.66929   +0.74063     Austria        St. Polten
- 3 083   30.5056   +50.365008    154.101 0.63918   +0.76651     Ukraine        Holosiivskyi district-Kyiv
- 3 084   30.3274   +59.772118     85.607 0.50471   +0.86041     Russia         Pulkovo
- 3 085   30.5023   +50.452956    174.404 0.63800   +0.76749     Ukraine        Kyiv
- 3 086   30.7582   +46.476827     64.628 0.68987   +0.72152     Ukraine        Odesa
- 3 087   31.3411   +29.858775    105.720 0.86799   +0.49495     Egypt          Helwan
- 3 088   31.82769  +29.934013    494.061 0.867391  +0.496114    Egypt          Kottomia
- 3 089   31.9747   +46.971605     50.870 0.68359   +0.72743     Ukraine        Mykolaiv
- 3 090    8.25     +49.943154   1853.099 0.645     +0.762       Germany        Mainz
- 3 091    4.20919  +45.381384    467.050 0.703630  +0.708287    France         Observatoire de Nurol, Aurec sur Loire
- 3 092   18.5546   +53.096304     93.800 0.60177   +0.79601     Poland         Torun-Piwnice
- 3 093   20.3647   +69.349331   -136.036 0.3537    +0.9322      Norway         Skibotn
- 3 094   33.9974   +44.403089    369.338 0.71565   +0.69620     Ukraine        Crimea-Simeiz
- 3 095   34.0160   +44.726558    592.420 0.71172   +0.70024     Ukraine        Crimea-Nauchnyi
- 3 096    9.4283   +45.698835    362.184 0.69967   +0.71215     Italy          Merate
- 3 097   34.7625   +30.595660    904.252 0.86165   +0.50608     Israel         Wise Observatory, Mitzpeh Ramon
- 3 098   11.56900  +45.848591   1425.941 0.697916  +0.714090    Italy          Asiago Observatory, Cima Ekar
- 3 099   25.53529  +61.130238    112.982 0.484073  +0.872114    Finland        Lahti
- 3 100   24.14145  +62.617163    173.539 0.461165  +0.884370    Finland        Ahtari
- 3 101   36.2322   +50.002702    120.706 0.64403   +0.76246     Ukraine        Kharkiv
- 3 102   36.75953  +55.699517    184.510 0.564841  +0.822468    Russia         Zvenigorod
- 3 103   14.52774  +46.043781    453.667 0.695365  +0.716346    Slovenia       Ljubljana
- 3 104   10.80375  +44.064181   1017.461 0.719842  +0.692040    Italy          San Marcello Pistoiese
- 3 105   37.5706   +55.755715    181.063 0.56403   +0.82302     Russia         Moscow
- 3 106   14.0711   +45.945908    711.299 0.69662   +0.71519     Slovenia       Crni Vrh
- 3 107   11.0030   +44.862896     -3.071 0.70998   +0.70186     Italy          Cavezzo
- 3 108   11.0278   +43.738117     34.381 0.72367   +0.68784     Italy          Montelupo
- 3 109    3.0705   +36.733068    143.991 0.80241   +0.59481     Algeria        Algiers-Kouba
- 3 110   39.4150   +57.189178     85.484 0.54316   +0.83683     Russia         Rostov
- 3 111   10.9721   +43.678850     92.617 0.72439   +0.68710     Italy          Piazzano Observatory, Florence
- 3 112   10.9039   +45.483789    115.500 0.70232   +0.70950     Italy          Pleiade Observatory, Verona
- 3 113   13.0166   +50.676689    514.971 0.63502   +0.77001     Germany        Volkssternwarte Drebach, Schoenbrunn
- 3 114   41.4277   +43.655713   2047.154 0.72489   +0.68702     Russia         Engelhardt Observatory, Zelenchukskaya Station
- 3 115   41.44067  +43.646713   2097.774 0.725004  +0.686912    Russia         Zelenchukskaya
- 3 116   11.5958   +48.115221    507.416 0.66893   +0.74094     Germany        Giesing
- 3 117   11.5385   +48.112747    582.784 0.66897   +0.74092     Germany        Sendling
- 3 118   17.2740   +48.373144    552.140 0.66558   +0.74394     Slovakia       Astronomical and Geophysical Observatory, Modra
- 3 119   42.8200   +41.753627   1581.216 0.74731   +0.66262     Georgia        Abastuman
- 3 120   13.7261   +45.277637    233.860 0.70489   +0.70699     Croatia        Visnjan
- 3 121   36.93403  +49.640838    165.265 0.648856  +0.758394    Ukraine        Kharkiv University, Chuguevskaya Station
- 3 122    3.5035   +44.039542   1279.287 0.72017   +0.69176     France         Pises Observatory
- 3 123   44.2917   +40.335211   1490.248 0.76352   +0.64398     Armenia        Byurakan
- 3 124    2.2550   +43.600501    163.995 0.72534   +0.68612     France         Castres
- 3 125   44.78950  +41.717322    410.872 0.747594  +0.662026    Georgia        Tbilisi
- 3 126    9.79015  +44.132567    397.186 0.718943  +0.692828    Italy          Monte Viseggi L. Zannoni Observatory
- 3 127    6.9797   +50.760191     85.429 0.63385   +0.77088     Germany        Bornheim
- 3 128   46.00661  +51.538322     76.861 0.623279  +0.779393    Russia         Saratov
- 3 129   45.92     +39.134625   2454.983 0.777     +0.628       Azerbaijan     Ordubad
- 3 130   10.23963  +45.665020    876.729 0.700148  +0.711796    Italy          Lumezzane
- 3 131    4.725    +44.677036    350.459 0.7123    +0.6996      France         Observatoire de l'Ardeche
- 3 132    5.2461   +44.113303    515.659 0.71919   +0.69260     France         Bedoin
- 3 133    5.0906   +43.361706     55.403 0.72819   +0.68309     France         Les Tardieux
- 3 134   11.48245  +50.928437    414.528 0.631607  +0.772773    Germany        Groszschwabhausen
- 3 135   49.1210   +55.789708     74.812 0.56353   +0.82334     Russia         Kasan
- 3 136   48.8156   +55.839125    115.679 0.56282   +0.82383     Russia         Engelhardt Observatory, Kasan
- 3 137   34.8147   +32.069775     53.507 0.84821   +0.52790     Israel         Givatayim Observatory
- 3 138    7.5717   +47.604863    246.243 0.67550   +0.73494     France         Village-Neuf
- 3 139    7.1108   +43.606163     58.431 0.72526   +0.68618     France         Antibes
- 3 140    3.6294   +45.718290    569.343 0.69945   +0.71241     France         Augerolles
- 3 141    7.3672   +49.067017    281.551 0.65646   +0.75189     France         Hottviller
- 3 142    7.1874   +51.663869     49.824 0.62156   +0.78075     Germany        Sinsen
- 3 143    9.02406  +46.231419    258.878 0.692986  +0.718590    Switzerland    Gnosca
- 3 144    1.6660   +49.138729     39.745 0.65549   +0.75268     France         Bray et Lu
- 3 145    4.5597   +51.240029     27.570 0.62734   +0.77614     Belgium        's-Gravenwezel
- 3 146   10.6673   +44.288328   1281.741 0.71715   +0.69487     Italy          Frignano
- 3 147    8.57391  +45.637244    291.382 0.700430  +0.711392    Italy          Osservatorio Astronomico di Suno
- 3 148    2.0375   +43.644347    137.070 0.72481   +0.68667     France         Guitalens
- 3 149    4.2236   +49.250078    133.950 0.65403   +0.75396     France         Beine-Nauroy
- 3 150    2.1572   +48.943583     43.733 0.65806   +0.75045     France         Maisons Laffitte
- 3 151    8.7440   +47.476030    558.718 0.67719   +0.73346     Switzerland    Eschenberg Observatory, Winterthur
- 3 152   25.5633   +55.316042    205.539 0.57036   +0.81868     Lithuania      Moletai Astronomical Observatory
- 3 153    9.1747   +48.738079    453.064 0.66080   +0.74814     Germany        Stuttgart-Hoffeld
- 3 154   12.1043   +46.542158   1789.969 0.68923   +0.72250     Italy          Cortina
- 3 155   10.1971   +56.127647     56.419 0.55864   +0.82664     Denmark        Ole Romer Observatory, Aarhus
- 3 156   15.0858   +37.503415     55.339 0.79431   +0.60549     Italy          Catania Astrophysical Observatory
- 3 157   12.8117   +42.227537    484.433 0.74166   +0.66864     Italy          Frasso Sabino
- 3 158    7.6033   +45.785535   1479.324 0.69871   +0.71333     Italy          Promiod
- 3 159   10.5153   +43.995223    777.373 0.72065   +0.69115     Italy          Monte Agliale
- 3 160   10.84144  +43.823061     77.081 0.722651  +0.688913    Italy          Castelmartini
- 3 161    8.1605   +45.087720    346.964 0.70725   +0.70467     Italy          Cerrina Tololo Observatory
- 3 162   15.7805   +40.650008    815.135 0.75988   +0.64808     Italy          Potenza
- 3 163    6.1492   +49.543169    333.391 0.65017   +0.75731     Luxembourg     Roeser Observatory, Luxembourg
- 3 164    6.8861   +48.315558    358.631 0.66631   +0.74325     France         St. Michel sur Meurthe
- 3 165    1.7553   +41.521506    249.915 0.74984   +0.65946     Spain          Piera Observatory, Barcelona
- 3 166   16.0117   +50.506901    432.968 0.63730   +0.76812     Czech Republi  Upice
- 3 167    8.5727   +47.520289    547.703 0.67662   +0.73398     Switzerland    Bulach Observatory
- 3 168   59.5472   +57.036807    272.229 0.54541   +0.83541     Russia         Kourovskaya
- 3 169    8.4016   +45.077171    255.076 0.70737   +0.70453     Italy          Airali Observatory
- 3 170    1.9206   +41.331805   1475.405 0.75217   +0.65711     Spain          Observatorio de Begues
- 3 171   14.4697   +35.909942    125.254 0.81089   +0.58327     Malta          Flarestar Observatory, San Gwann
- 3 172    7.0364   +46.793619    754.195 0.68593   +0.72539     Switzerland    Onnens
- 3 173   55.5061   -20.897572    152.160 0.93464   -0.35447     France (Reuni  St. Clotilde, Reunion
- 3 174   25.5131   +62.346623    204.446 0.46536   +0.88219     Finland        Nyrola Observatory, Jyvaskyla
- 3 175    7.6083   +46.230887   2170.299 0.6932    +0.7188      Switzerland    F.-X. Bagnoud Observatory, St-Luc
- 3 176    2.8225   +39.653687    105.596 0.77098   +0.63475     Spain          Observatorio Astronomico de Consell
- 3 177    3.9414   +43.646763     40.498 0.72477   +0.68669     France         Le Cres
- 3 178    6.1344   +46.134629    505.835 0.69423   +0.71745     France         Collonges
- 3 179    9.0175   +45.927927   1580.735 0.69694   +0.71507     Switzerland    Monte Generoso
- 3 180    3.9519   +43.568393     26.579 0.72571   +0.68570     France         Mauguio
- 3 181   55.4100   -21.199551    992.033 0.93288   -0.35941     France (Reuni  Observatoire des Makes, Saint-Louis
- 3 182   55.2586   -21.012592    248.320 0.93394   -0.35634     France (Reuni  St. Paul, Reunion
- 3 183   41.4200   +43.650034   2061.998 0.72496   +0.68695     Russia         Starlab Observatory, Karachay-Cherkessia
- 3 184    6.0361   +43.981412    714.261 0.72081   +0.69097     France         Valmeca Observatory, Puimichel
- 3 185    7.4219   +47.353048    478.669 0.67876   +0.73200     Switzerland    Observatoire Astronomique Jurassien-Vicques
- 3 186   66.8821   +39.133773    651.201 0.77679   +0.62781     Uzbekistan     Kitab
- 3 187   17.0733   +52.277129    123.134 0.61314   +0.78735     Poland         Astronomical Observatory, Borowiec
- 3 188   66.89555  +38.673365   2578.325 0.782059  +0.621762    Uzbekistan     Majdanak
- 3 189    6.1514   +46.199977    428.303 0.69340   +0.71823     Switzerland    Geneva (before 1967)
- 3 190   68.6819   +38.490299    730.333 0.78382   +0.61909     Tajikistan     Gissar
- 3 191   68.7811   +38.561092    791.624 0.78306   +0.62006     Tajikistan     Dushanbe
- 3 192   69.2936   +41.325129    483.550 0.75213   +0.65692     Uzbekistan     Tashkent
- 3 193   69.2178   +38.260781   2191.556 0.78648   +0.61610     Tajikistan     Sanglok
- 3 194   18.0094   -23.461596   1778.323 0.91807   -0.39579     Namibia        Tivoli
- 3 195   11.4492   +48.183860    520.893 0.66804   +0.74174     Germany        Untermenzing Observatory, Munich
- 3 196    7.3331   +49.331752    227.550 0.65296   +0.75490     Germany        Homburg-Erbach
- 3 197   12.1836   +44.256931     18.025 0.71739   +0.69434     Italy          Bastia
- 3 198    8.75674  +48.631946    501.852 0.662195  +0.746924    Germany        Wildberg
- 3 199    2.4380   +48.291739     70.213 0.66659   +0.74294     France         Telescope Jean-Marc Salomon, Buthiers
- 3 200    4.3036   +50.760191     85.429 0.63385   +0.77088     Belgium        Beersel Hills Observatory
- 3 201    7.6033   +45.785135   1433.610 0.69871   +0.71332     Italy          Jonathan B. Postel Observatory
- 3 202    5.8997   +43.095279     68.434 0.73137   +0.67971     France         Tamaris Observatoire, La Seyne sur Mer
- 3 203    8.99548  +45.541445    213.425 0.701614  +0.710215    Italy          GiaGa Observatory
- 3 204    8.76972  +45.868295   1228.727 0.697648  +0.714307    Italy          Schiaparelli Observatory
- 3 205   11.2731   +44.472064    113.686 0.71478   +0.69703     Italy          Obs. Casalecchio di Reno, Bologna
- 3 206   10.5667   +60.600925    758.276 0.4922    +0.8677      Norway         Haagaar Observatory, Eina
- 3 207    9.3065   +45.545063    131.545 0.70156   +0.71025     Italy          Osservatorio Antonio Grosso
- 3 208    9.5875   +44.949339    116.489 0.70893   +0.70294     Italy          Rivalta
- 3 209   11.56883  +45.849484   1418.392 0.697904  +0.714100    Italy          Asiago Observatory, Cima Ekar-ADAS
- 3 210   76.9573   +43.188278   1447.907 0.73042   +0.68104     Kazakhstan     Alma-Ata
- 3 211   11.1764   +43.762483     65.543 0.72338   +0.68815     Italy          Scandicci
- 3 212  355.35747  +36.653332    255.472 0.803253  +0.593708    Spain          Observatorio La Dehesilla
- 3 213    2.38539  +41.519715     99.350 0.749843  +0.659421    Spain          Observatorio Montcabre
- 3 214   11.6569   +48.256592    479.063 0.66709   +0.74258     Germany        Garching Observatory
- 3 215   10.7328   +48.017293    601.552 0.67021   +0.73981     Germany        Buchloe
- 3 216    5.6914   +49.001576    265.577 0.65732   +0.75114     France         Observatoire des Cote de Meuse
- 3 217   77.87114  +43.225527   2658.450 0.730114  +0.681643    Kazakhstan     Assah
- 3 218   78.4541   +17.431847    530.207 0.95444   +0.29768     India          Hyderabad
- 3 219   78.7283   +17.098328    678.825 0.95618   +0.29216     India          Japal-Rangapur
- 3 220   78.8263   +12.576280    706.361 0.97627   +0.21634     India          Vainu Bappu Observatory, Kavalur
- 3 221   16.36170  -23.236369   1851.855 0.919631  -0.392203    Namibia        IAS Observatory, Hakos
- 3 222    2.4939   +48.709856     67.997 0.66113   +0.74777     France         Yerres-Canotiers
- 3 223   80.2464   +13.068995     31.205 0.97427   +0.22465     India          Madras
- 3 224    7.50171  +47.784762    221.518 0.673178  +0.737048    France         Ottmarsheim
- 3 225  288.8250   +43.227708    137.660 0.7298    +0.6814      US/New Hampsh  Northwood Ridge Observatory
- 3 226   11.8858   +45.433882     25.977 0.70293   +0.70888     Italy          Guido Ruggieri Observatory, Padua
- 3 227  281.2853   +42.638389    469.728 0.73683   +0.67392     US/New York    OrbitJet Observatory, Colden
- 3 228   13.8750   +45.642425    424.101 0.70038   +0.71147     Italy          Bruno Zugna Observatory, Trieste
- 3 229   14.9743   +40.690815    336.337 0.75936   +0.64857     Italy          G. C. Gloriosi Astronomical Observatory, Salerno
- 3 230   12.0133   +47.704038   1931.411 0.6744    +0.7363      Germany        Mt. Wendelstein Observatory
- 3 231    5.3983   +50.005282    462.741 0.64403   +0.76253     Belgium        Vesqueville
- 3 232    1.3317   +41.508536    337.643 0.7500    +0.6593      Spain          Masquefa Observatory
- 3 233   10.5403   +43.855044     32.130 0.72226   +0.68931     Italy          Sauro Donati Astronomical Observatory, San Vito
- 3 234    1.12833  +52.145254     48.480 0.614951  +0.785931    UK/England     Coddenham Observatory
- 3 235   13.11352  +45.936027     25.686 0.696669  +0.714993    Italy          CAST Observatory, Talmassons
- 3 236   84.9465   +56.468260    136.940 0.55370   +0.82995     Russia         Tomsk
- 3 237    2.7333   +47.083528    401.129 0.6822    +0.7288      France         Baugy
- 3 238   10.9094   +59.949148    139.680 0.50204   +0.86197     Norway         Grorudalen Optical Observatory
- 3 239    8.4114   +49.925391     98.118 0.64506   +0.76159     Germany        Trebur
- 3 240    8.83317  +48.623595    537.872 0.662308  +0.746832    Germany        Herrenberg Sternwarte
- 3 241   13.4700   +48.443494    430.733 0.66465   +0.74474     Austria        Schaerding
- 3 242    1.6956   +43.479120    282.196 0.72681   +0.68460     France         Varennes
- 3 243    9.4130   +53.528078      4.148 0.59572   +0.80050     Germany        Umbrella Observatory, Fredenbeck
- 3 244    0.00000   +0.000000      0.000 0.000000  +0.000000                   Geocentric Occultation Observation
--2 245    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Spitzer Space Telescope
- 3 246   14.28476  +48.863994   1112.283 0.659216  +0.749664    Czech Republi  Klet Observatory-KLENOT
--2 247    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Roving Observer
- 3 248    0.00000   +0.000000      0.000 0.000000  +0.000000                   Hipparcos
--2 249    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  SOHO
--2 250    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Hubble Space Telescope
- 3 251  293.24692  +18.343444    504.271 0.949577  +0.312734    US/Puerto Ric  Arecibo
- 3 252  243.20512  +35.247200   1072.243 0.817719  +0.573979    US/California  Goldstone DSS 13, Fort Irwin
- 3 253  243.11047  +35.425917   1012.269 0.815913  +0.576510    US/California  Goldstone DSS 14, Fort Irwin
- 3 254  288.51128  +42.623198    155.872 0.736973  +0.673692    US/Massachuse  Haystack, Westford
- 3 255   33.18689  +45.189218     63.033 0.705965  +0.705886    Ukraine        Yevpatoriya
- 3 256  280.16017  +38.433112    826.992 0.784451  +0.618320    US/West Virgi  Green Bank
- 3 257  243.12461  +35.337575    958.130 0.816796  +0.575252    US/California  Goldstone DSS 25, Fort Irwin
--2 258    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Gaia
- 3 259   19.22586  +69.586488     90.019 0.349828  +0.933688    Norway         EISCAT Tromso UHF
- 3 260  149.0661   -31.276809   1185.198 0.85560   -0.51626     Australia/NSW  Siding Spring Observatory-DSS
- 3 261  243.14022  +33.357340   1686.997 0.836325  +0.546877    US/California  Palomar Mountain-DSS
- 3 262  289.26626  -29.258822   2345.440 0.873440  -0.486052    Chile          European Southern Observatory, La Silla-DSS
- 3 266  204.52396  +19.825501   4194.602 0.941711  +0.337239    US/Hawaii      New Horizons KBO Search-Subaru
- 3 267  204.53109  +19.825438   4232.766 0.941717  +0.337240    US/Hawaii      New Horizons KBO Search-CFHT
- 3 268  289.30803  -29.014271   2389.673 0.875516  -0.482342    Chile          Magellan-Clay Telescope
- 3 269  289.30914  -29.014791   2377.862 0.875510  -0.482349    Chile          Magellan-Baade Telescope
--2 270    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Unistellar Network, Roving Observer
--2 273    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Euclid
--2 274    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  James Webb Space Telescope
--2 275    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Non-geocentric Occultation Observation
- 3 276   20.38279  +52.627454    132.677 0.608295  +0.791076    Poland         Plonsk
- 3 277  356.8175   +55.924922    115.095 0.56158   +0.82467     UK/Scotland    Royal Observatory, Blackford Hill, Edinburgh
- 3 278  116.4494   +39.904051     10.977 0.76818   +0.63809     China          Peking, Transit of Venus site
- 3 279   10.72822  +50.933993    356.325 0.631526  +0.772827    Germany        Seeberg Observatory, Gotha (1787-1857)
- 3 280    8.9118   +53.140662    -22.008 0.60114   +0.79646     Germany        Lilienthal
- 3 281   11.3522   +44.496414     89.328 0.71448   +0.69733     Italy          Bologna
- 3 282    4.3603   +43.839623     66.606 0.72245   +0.68912     France         Nimes
- 3 283    8.8163   +53.076358      6.202 0.60204   +0.79579     Germany        Bremen
- 3 284   15.8311   +52.838165     35.140 0.60536   +0.79329     Poland         Driesen
- 3 285    2.3708   +48.693563    131.551 0.66135   +0.74759     France         Flammarion Observatory, Juvisy
- 3 286  102.7883   +25.025449   1948.274 0.90694   +0.42057     China          Yunnan Observatory
- 3 290  250.10799  +32.701295   3191.620 0.842743  +0.537438    US/Arizona     Mt. Graham-VATT
- 3 291  248.40024  +31.961598   2037.677 0.849471  +0.526470    US/Arizona     LPL/Spacewatch II
- 3 292  285.1058   +40.072036      5.048 0.76630   +0.64033     US/New Jersey  Burlington, New Jersey
- 3 293  285.5899   +39.798433     26.128 0.76936   +0.63668     US/New Jersey  Burlington remote site
- 3 294  285.8467   +40.603851     31.100 0.76031   +0.64739     US/New York    Astrophysical Obs., College of Staten Island
- 3 295  283.0000   +38.936501    218.851 0.7789    +0.6251      US/Dist. of C  Catholic University Observatory, Washington
- 3 296  286.2200   +42.653670     38.839 0.73660   +0.67407     US/New York    Dudley Observatory, Albany (after 1893)
- 3 297  286.819    +44.015373   -163.642 0.7203    +0.6913      US/Vermont     Middlebury
- 3 298  287.3408   +41.555172     68.909 0.74943   +0.65988     US/Connecticu  Van Vleck Observatory
- 3 299  107.6160    -6.825509   1287.049 0.99316   -0.11808     Indonesia      Bosscha Observatory, Lembang
- 3 300  133.54444  +34.671960    427.526 0.823370  +0.565720    Japan          Bisei Spaceguard Center-BATTeRS
- 3 301  288.8467   +45.454905   1126.540 0.70279   +0.70926     Canada/Quebec  Mont Megantic
- 3 302  288.88      +8.672755   8768.476 0.990     +0.150       Venezuela      University of the Andes station
- 3 303  289.1296    +8.787722   3624.775 0.98890   +0.15185     Venezuela      OAN de Llano del Hato, Merida
- 3 304  289.30858  -29.014556   2385.314 0.875513  -0.482346    Chile          Las Campanas Observatory
- 3 305  109.5514   +34.945455    471.527 0.82066   +0.56963     China          Purple Mountain, Hainan Island station
- 3 306  290.6769   +10.075583    591.394 0.98477   +0.17381     Venezuela      Observatorio Taya Beixo, Barquisimeto
- 3 307  287.7166   +43.704047    209.115 0.72410   +0.68743     US/New Hampsh  Shattuck Observatory, Hanover
- 3 309  289.59569  -24.627212   2637.192 0.909943  -0.414336    Chile          Cerro Paranal
- 3 310  288.87164  +42.381468     22.543 0.739802  +0.670574    US/Massachuse  Minor Planet Center Test Code
- 3 312  112.334    +16.831966   -178.875 0.9574    +0.2877      China          Tsingtao field station, Xisha Islands
- 3 318  115.691    -31.649985     36.499 0.85206   -0.52170     Australia/WA   Quinns Rock
- 3 319  116.1350   -32.007951    428.106 0.84883   -0.52702     Australia/WA   Perth Observatory, Perth-Lowell Telescope
- 3 320  116.4381   -30.929884    249.212 0.85859   -0.51102     Australia/WA   Chiro Observatory
- 3 321  115.7571   -31.790469     67.146 0.85078   -0.52378     Australia/WA   Craigie
- 3 322  116.1340   -32.008744    407.828 0.84882   -0.52703     Australia/WA   Perth Observatory, Bickley-MCT
- 3 323  116.1350   -32.008744    407.828 0.84882   -0.52703     Australia/WA   Perth Observatory, Bickley
- 3 324  116.3277   +40.101011     45.324 0.76598   +0.64072     China          Peking Observatory, Shaho Station
- 3 327  117.5750   +40.394239    868.221 0.76278   +0.64470     China          Peking Observatory, Xinglong Station
- 3 330  118.8209   +32.066662    364.126 0.84828   +0.52788     China          Purple Mountain Observatory, Nanking
- 3 333  249.5236   +31.962537   1268.217 0.84936   +0.52642     US/Arizona     Desert Eagle Observatory
- 3 334  120.3196   +36.069984     94.902 0.80925   +0.58552     China          Tsingtao
- 3 337  121.1843   +31.095926     79.051 0.85708   +0.51348     China          Sheshan, formerly Zo-Se
- 3 340  135.4853   +34.806934    100.255 0.82199   +0.56762     Japan          Toyonaka
- 3 341  137.9486   +36.328956    894.002 0.80669   +0.58923     Japan          Akashina
- 3 342  134.3189   +33.551342     43.512 0.83425   +0.54955     Japan          Shishikui
- 3 343  127.1258   +38.200078    130.275 0.78688   +0.61507     South Korea    Younchun
- 3 344  128.9767   +36.164835   1143.090 0.80841   +0.58695     South Korea    Bohyunsan Optical Astronomy Observatory
- 3 345  128.4575   +36.934554   1354.511 0.80046   +0.59773     South Korea    Sobaeksan Optical Astronomy Observatory
- 3 346  127.3854   +36.507876     86.947 0.80474   +0.59166     South Korea    KNUE Astronomical Observatory
- 3 347  139.9086   +36.563401    127.540 0.80417   +0.59244     Japan          Utsunomiya-Imaizumi
- 3 348  135.2669   +35.307915     64.425 0.81698   +0.57475     Japan          Ayabe
- 3 349  139.56622  +35.956470     22.983 0.810402  +0.583916    Japan          Ageo
- 3 350  139.2635   +36.481912    335.424 0.80504   +0.59132     Japan          Kurohone
- 3 351  135.8678   +35.068331    130.204 0.81939   +0.57135     Japan          Sakamoto
- 3 352  136.1778   +34.947102    210.123 0.82061   +0.56963     Japan          Konan
- 3 353  135.0648   +34.741373    174.938 0.82265   +0.56669     Japan          Nishi Kobe
- 3 354  140.0206   +36.867325    776.436 0.80109   +0.59674     Japan          Kawachi
- 3 355  139.2133   +35.388445    146.092 0.81618   +0.57590     Japan          Hadano
- 3 356  141.0867   +38.540262      9.110 0.78319   +0.61970     Japan          Kogota
- 3 357  140.0064   +36.184257     32.570 0.80807   +0.58712     Japan          Shimotsuma
- 3 358  140.1586   +38.045106    251.726 0.78856   +0.61296     Japan          Nanyo
- 3 359  135.1719   +34.214312     25.571 0.82782   +0.55912     Japan          Wakayama
- 3 360  132.9442   +33.674308    608.887 0.83314   +0.55138     Japan          Kuma Kogen
- 3 361  134.8933   +34.349555    -14.049 0.82649   +0.56106     Japan          Sumoto
- 3 362  140.6550   +42.644812    259.786 0.73673   +0.67398     Japan          Ray Observatory
- 3 363  130.7703   +33.559953    -11.798 0.83416   +0.54967     Japan          Yamada
- 3 364  130.5747   +31.644934    215.782 0.85213   +0.52164     Japan          YCPM Kagoshima Station
- 3 365  135.9579   +34.409143    490.065 0.82597   +0.56196     Japan          Uto Observatory
- 3 366  138.3003   +35.862459    879.148 0.81147   +0.58267     Japan          Miyasaka Observatory
- 3 367  133.1670   +35.499977     29.518 0.81504   +0.57747     Japan          Yatsuka
- 3 368  138.8117   +35.804841   1454.109 0.81213   +0.58191     Japan          Ochiai
- 3 369  139.1500   +35.989182    277.439 0.8101    +0.5844      Japan          Chichibu
- 3 370  133.5273   +33.552139     25.609 0.83424   +0.54956     Japan          Kochi
- 3 371  133.5965   +34.573894    356.529 0.82433   +0.56431     Japan          Tokyo-Okayama
- 3 372  133.8276   +33.526623    139.191 0.83450   +0.54920     Japan          Geisei
- 3 373  135.3397   +34.132477    338.181 0.82866   +0.55797     Japan          Oishi
- 3 374  134.7196   +35.094608    307.187 0.81915   +0.57174     Japan          Minami-Oda Observatory
- 3 375  134.8708   +34.950729    413.602 0.8206    +0.5697      Japan          Uzurano
- 3 376  139.0392   +35.689745    747.491 0.81321   +0.58022     Japan          Uenohara
- 3 377  135.7933   +34.994623    239.527 0.82014   +0.57031     Japan          Kwasan Observatory, Kyoto
- 3 378  136.0142   +34.570222    385.641 0.82437   +0.56426     Japan          Murou
- 3 379  137.6279   +34.703448    -24.724 0.82300   +0.56613     Japan          Hamamatsu-Yuto
- 3 380  137.0349   +34.814608     -6.942 0.82190   +0.56772     Japan          Ishiki
- 3 381  137.62542  +35.797229   1175.148 0.812172  +0.581777    Japan          Tokyo-Kiso
- 3 382  137.5553   +36.113770   2848.305 0.80915   +0.58639     Japan          Tokyo-Norikura
- 3 383  137.8959   +36.761699    685.718 0.80218   +0.59526     Japan          Chirorin
- 3 384  138.1792   +34.818384    284.385 0.8219    +0.5678      Japan          Shimada
- 3 385  138.4680   +34.970368    302.676 0.82039   +0.56997     Japan          Nihondaira Observatory
- 3 386  138.3217   +35.890776   1105.346 0.81121   +0.58309     Japan          Yatsugatake-Kobuchizawa
- 3 387  139.1944   +36.006046    848.562 0.81000   +0.58469     Japan          Tokyo-Dodaira
- 3 388  139.5421   +35.672253     60.506 0.81330   +0.57991     Japan          Tokyo-Mitaka
- 3 389  139.7447   +35.654413    -25.394 0.81347   +0.57965     Japan          Tokyo (before 1938)
- 3 390  139.8725   +36.556046    157.471 0.80425   +0.59234     Japan          Utsunomiya
- 3 391  140.77843  +38.265246    121.171 0.786177  +0.615960    Japan          Sendai Observatory, Ayashi Station
- 3 392  141.3667   +42.913350    231.180 0.73355   +0.67741     Japan          JCPM Sapporo Station
- 3 393  140.1292   +36.091454   -142.034 0.8090    +0.5858      Japan          JCPM Sakura Station
- 3 394  142.3208   +45.111668     35.893 0.70692   +0.70493     Japan          JCPM Hamatonbetsu Station
- 3 395  142.3583   +43.840783   -251.770 0.7224    +0.6891      Japan          Tokyo-Asahikawa
- 3 396  142.4208   +43.743384    -23.593 0.7236    +0.6879      Japan          Asahikawa
- 3 397  141.4761   +43.033526     29.531 0.73210   +0.67892     Japan          Sapporo Science Center
- 3 398  139.1080   +36.124836    191.439 0.80870   +0.58630     Japan          Nagatoro
- 3 399  144.5900   +43.078239    131.675 0.73158   +0.67950     Japan          Kushiro
- 3 400  143.7827   +43.758443    165.479 0.72344   +0.68811     Japan          Kitami
- 3 401  139.4208   +36.112161    -45.263 0.8088    +0.5861      Japan          Oosato
- 3 402  136.3078   +35.208347    222.127 0.81800   +0.57335     Japan          Dynic Astronomical Observatory
- 3 403  137.0556   +35.413171    139.539 0.81593   +0.57625     Japan          Kani
- 3 404  140.9292   +37.823762     24.848 0.7909    +0.6099      Japan          Yamamoto
- 3 405  139.3292   +36.297262    -28.584 0.8069    +0.5887      Japan          Kamihoriguchi
- 3 406  141.8233   +43.255299     43.550 0.72946   +0.68174     Japan          Bibai
- 3 407  140.3099   +38.442185     71.027 0.78426   +0.61837     Japan          Kahoku
- 3 408  138.1747   +35.899622   1815.857 0.81121   +0.58328     Japan          Nyukasa
- 3 409  139.5211   +35.766543     41.786 0.81234   +0.58124     Japan          Kiyose and Mizuho
- 3 410  134.8910   +35.127762    398.440 0.81883   +0.57222     Japan          Sengamine
- 3 411  139.4170   +36.250478     38.179 0.80739   +0.58805     Japan          Oizumi
- 3 412  140.5991   +36.960421    720.585 0.80011   +0.59803     Japan          Iwaki
- 3 413  149.06608  -31.277057   1164.565 0.855595  -0.516262    Australia/NSW  Siding Spring Observatory
- 3 414  149.0077   -35.320502    741.112 0.81694   -0.57499     Australia/NSW  Mount Stromlo
- 3 415  149.0636   -35.396942    581.160 0.81615   -0.57606     Australia/NSW  Kambah
- 3 416  149.1336   -35.311609    589.224 0.81701   -0.57485     Australia/NSW  Barton
- 3 417  137.1371   +37.334673    181.999 0.79611   +0.60317     Japan          Yanagida Astronomical Observatory
- 3 418  150.94034  -31.081447    444.175 0.857259  -0.513294    Australia/NSW  Tamworth
- 3 419  150.8329   -33.608598     48.999 0.83370   -0.55038     Australia/NSW  Windsor
- 3 420  151.2050   -33.861540     71.035 0.83126   -0.55404     Australia/NSW  Sydney
- 3 421  133.7650   +33.755950   1285.060 0.83244   +0.55262     Japan          Mt. Kajigamori, Otoyo
- 3 422  151.0461   -31.334632    829.679 0.85503   -0.51709     Australia/NSW  Loomberah
- 3 423  151.12473  -33.804956     64.195 0.831807  -0.553222    Australia/NSW  North Ryde
- 3 424  149.0658   -35.255144    609.617 0.81758   -0.57405     Australia/NSW  Macquarie
- 3 425  152.9316   -27.463275    151.075 0.88796   -0.45843     Australia/QLD  Taylor Range Observatory, Brisbane
- 3 426  136.8217   -31.196556    114.586 0.85618   -0.51498     Australia/SA   Woomera
- 3 427  138.7283   -34.333272    142.325 0.82667   -0.56084     Australia/SA   Stockport
- 3 428  153.3970   -28.110269     82.437 0.88271   -0.46837     Australia/QLD  Reedy Creek
- 3 429  149.0400   -35.252741    655.425 0.81761   -0.57402     Australia/NSW  Hawker
- 3 430  149.2123   -31.278320    540.740 0.85550   -0.51623     Australia/NSW  Rainbow Observatory, near Coonabarabran
- 3 431  149.7578   -33.434627    884.088 0.83548   -0.54793     Australia/NSW  Mt. Tarana Observatory, Bathurst
- 3 432  153.08222  -30.339159     10.784 0.863790  -0.502166    Australia/NSW  Boambee
- 3 433  152.1078   -32.738478    -18.612 0.84197   -0.53771     Australia/NSW  Bagnall Beach Observatory
- 3 434   10.9206   +45.052013    -18.677 0.70765   +0.70419     Italy          S. Benedetto Po
- 3 435   11.8936   +45.404256     46.996 0.70330   +0.70852     Italy          G. Colombo Astronomical Observatory, Padua
- 3 436   11.3356   +44.328016    506.823 0.71658   +0.69528     Italy          Osservatorio di Livergnano
- 3 437  284.6971   +40.010986    140.462 0.76700   +0.63953     US/Pennsylvan  Haverford
- 3 438  287.3621   +42.317295    325.467 0.74059   +0.66978     US/Massachuse  Smith College Observatory, Northampton
- 3 439  253.2539   +35.869209   2129.084 0.81156   +0.58288     US/New Mexico  ROTSE-III, Los Alamos
- 3 440  278.6842   +43.192028    351.797 0.73025   +0.68097     Canada/Ontari  Elginfield Observatory
- 3 441  357.1697   +56.337515      7.181 0.55559   +0.82867     UK/Scotland    Swilken Brae, St. Andrews
- 3 442  357.4822   +41.707871    380.821 0.7477    +0.6619      Spain          Gualba Observatory
- 3 443  301.4656   -34.633268     19.256 0.82370   -0.56513     Argentina      Obs. Astronomico Plomer, Buenos Aires
- 3 444  243.2794   +33.483600   1339.817 0.83507   +0.54868     US/California  Star Cruiser Observatory
- 3 445  359.4200   +38.818062    268.553 0.7802    +0.6235      Spain          Observatorio d'Ontinyent
- 3 446  262.1666   +29.569093    138.886 0.87049   +0.49058     US/Texas       Kingsnake Observatory, Seguin
- 3 447  255.2056   +39.621225   1757.619 0.77154   +0.63448     US/Colorado    Centennial Observatory
- 3 448  253.2801   +32.387587   1313.181 0.84543   +0.53268     US/New Mexico  Desert Moon Observatory, Las Cruces
- 3 449  279.6503   +34.383671    101.404 0.82617   +0.56156     US/South Caro  Griffin Hunter Observatory, Bethune
- 3 450  279.3339   +35.151408    217.090 0.81857   +0.57254     US/North Caro  Carla Jane Observatory, Charlotte
- 3 451  262.7569   +37.491891    360.251 0.79447   +0.60536     US/Kansas      West Skies Observatory, Mulvane
- 3 452  279.1063   +26.178656    -56.873 0.8980    +0.4385      US/Florida     Big Cypress Observatory, Fort Lauderdale
- 3 453  242.1331   +34.984639    709.839 0.82030   +0.57021     US/California  Edwards Raven Observatory
- 3 454  283.37678  +39.331812     94.098 0.774542  +0.630425    US/Maryland    Maryland Space Grant Consortium Observatory
- 3 455  237.9636   +37.989977      1.552 0.78912   +0.61218     US/California  CBA Concord
- 3 456  358.8278   +52.252596    138.847 0.61348   +0.78709     UK/England     Daventry Observatory
- 3 457   18.3403   +48.628495    210.879 0.66221   +0.74685     Slovakia       Partizanske
- 3 458  355.9806   +40.647204    884.058 0.75992   +0.64805     Spain          Guadarrama Observatory
- 3 459  288.1172   +43.540840    284.280 0.72607   +0.68538     US/New Hampsh  Smith River Observatory, Danbury
- 3 460  265.9981   +33.982263    160.598 0.83010   +0.55579     US/Arkansas    Area 52 Observatory, Nashville
- 3 461   19.89367  +47.917455    983.456 0.671543  +0.738689    Hungary        University of Szeged, Piszkesteto Stn. (Konkoly)
- 3 462  283.0842   +38.921254     81.407 0.77905   +0.62488     US/Maryland    Mount Belleview Observatory
- 3 463  254.7375   +40.004026   1656.692 0.76726   +0.63959     US/Colorado    Sommers-Bausch Observatory, Boulder
- 3 464  288.5013   +41.410715     15.737 0.75109   +0.65799     US/Rhode Isla  Toby Point Observatory, Narragansett
- 3 465  174.7801   -36.803529     15.319 0.80166   -0.59578     New Zealand    Takapuna
- 3 466  174.8487   -36.942156    -85.941 0.8002    -0.5977      New Zealand    Mount Molehill Observatory, Auckland
- 3 467  174.7766   -36.907900     88.989 0.80058   -0.59724     New Zealand    Auckland Observatory
- 3 468   13.3296   +41.821092   1521.887 0.74652   +0.66349     Italy          Astronomical Observatory, Campo Catino
- 3 469    7.3820   +47.356257    583.617 0.67873   +0.73205     Switzerland    Courroux
- 3 470   13.32756  +41.570282    175.948 0.749268  +0.660088    Italy          Ceccano
- 3 471    8.2389   +55.781599     -5.378 0.56364   +0.82325     Denmark        Houstrup
- 3 472    6.3203   +44.694558   1828.109 0.71225   +0.69998     France         Merlette
- 3 473   13.31661  +46.086367    108.636 0.694793  +0.716822    Italy          Remanzacco
- 3 474  170.46496  -43.987388   1027.261 0.720773  -0.691079    New Zealand    Mount John Observatory, Lake Tekapo
- 3 475    7.6965   +45.069054    253.925 0.70747   +0.70443     Italy          Turin (before 1913)
- 3 476    7.14074  +45.142174    521.467 0.706597  +0.705359    Italy          Grange Observatory, Bussoleno
- 3 477    0.4856   +51.702635     55.727 0.62103   +0.78117     UK/England     Galleywood
- 3 478    3.0896   +43.588723    150.986 0.72548   +0.68597     France         Lamalou-les-Bains
- 3 479    6.0505   +43.193574     75.641 0.73020   +0.68096     France         Sollies-Pont
- 3 480    0.7733   +52.166479     63.177 0.61466   +0.78616     UK/England     Cockfield
- 3 481    7.93067  +53.553670     48.805 0.595365  +0.800771    Germany        Moorwarfen
- 3 482  357.1854   +56.336721    -10.550 0.55560   +0.82866     UK/Scotland    St. Andrews
- 3 483  173.8036   -41.749054   1384.191 0.74734   -0.66254     New Zealand    Carter Observatory, Black Birch Station
- 3 484  174.7594   -41.339510     19.626 0.75191   -0.65706     New Zealand    Happy Valley, Wellington
- 3 485  174.7654   -41.284240    144.134 0.75256   -0.65635     New Zealand    Carter Observatory, Wellington
- 3 486  175.47     -40.237349   4649.362 0.765     -0.643       New Zealand    Palmerston North
- 3 487  355.4444   +55.439342    106.009 0.56858   +0.81989     UK/Scotland    Macnairston Observatory
- 3 488  358.3664   +55.001347    113.380 0.57486   +0.81553     UK/England     Newcastle-upon-Tyne
- 3 489  359.87     +52.351623  -1041.000 0.612     +0.788       UK/England     Hemingford Abbots
- 3 490  358.00     +50.838529   2194.665 0.633     +0.772       UK/England     Wimborne Minster
- 3 491  356.9000   +40.525053    936.076 0.76131   +0.64644     Spain          Centro Astronomico de Yebes
- 3 492  358.47     +52.913724   7345.507 0.605     +0.795       UK/England     Mickleover
- 3 493  357.4542   +37.223531   2173.213 0.79753   +0.60182     Spain          Calar Alto
- 3 494  357.8361   +52.412865     69.244 0.61126   +0.78879     UK/England     Stakenbridge
- 3 495  357.66247  +53.376319    106.921 0.597857  +0.798936    UK/England     Altrincham
- 3 496  358.6860   +50.962820     -3.290 0.6311    +0.7731      UK/England     Bishopstoke
- 3 497  359.29449  +51.608582    119.644 0.622323  +0.780160    UK/England     Loudwater
- 3 498  359.2581   +52.262099     46.191 0.61334   +0.78718     UK/England     Earls Barton
- 3 499  359.79078  +51.369834     80.441 0.625578  +0.777562    UK/England     Cheam
- 3 500    0.00000   +0.000000      0.000 0.000000  +0.000000                   Geocentric
- 3 501    0.3475   +50.869432     53.683 0.63237   +0.77208     UK/England     Herstmonceux
- 3 502    0.84793  +51.915842     99.518 0.618111  +0.783475    UK/England     Colchester
- 3 503    0.0948   +52.214289     52.465 0.61400   +0.78667     UK/England     Cambridge
- 3 504    4.3944   +46.822521    449.527 0.68553   +0.72570     France         Le Creusot
- 3 505    4.5639   +51.566280    107.303 0.6229    +0.7797      Netherlands    Simon Stevin
- 3 506    9.96     +53.303447  -9254.030 0.598     +0.797       Germany        Bendestorf
- 3 507    5.22     +51.949210  -6654.872 0.617     +0.783       Netherlands    Nyenheim
- 3 508    5.29     +51.949210  -6654.872 0.617     +0.783       Netherlands    Zeist
- 3 509    5.8725   +43.099337     53.460 0.73132   +0.67976     France         La Seyne sur Mer
- 3 510    8.0256   +50.910286    386.527 0.63185   +0.77257     Germany        Siegen
- 3 511    5.7157   +43.931875    634.080 0.72140   +0.69034     France         Haute Provence
- 3 512    4.4893   +52.157984    -10.159 0.61477   +0.78606     Netherlands    Leiden (before 1860)
- 3 513    4.7855   +45.694788    266.506 0.69971   +0.71209     France         Lyons
- 3 514    8.438    +49.456279    115.728 0.6513    +0.7563      Germany        Mundenheim (1907-1913)
- 3 515    7.4956   +49.814908    363.668 0.64656   +0.76038     Germany        Volkssternwarte Dhaun, near Kirn
- 3 516    9.97321  +53.551081     23.720 0.595399  +0.800741    Germany        Hamburg (before 1909)
- 3 517    6.1358   +46.310753    472.602 0.69201   +0.71957     Switzerland    Geneva (from 1967)
- 3 518    9.9727   +53.547675     57.940 0.59545   +0.80071     Germany        Marine Observatory, Hamburg
- 3 519    8.2867   +51.342097    326.624 0.62598   +0.77729     Germany        Meschede
- 3 520    7.0966   +50.728847     51.951 0.63427   +0.77053     Germany        Bonn
- 3 521   10.88794  +49.884549    287.665 0.645624  +0.761154    Germany        Remeis Observatory, Bamberg
- 3 522    7.7677   +48.583819    168.907 0.66279   +0.74633     France         Strasbourg
- 3 523    8.6512   +50.116646    156.228 0.64251   +0.76374     Germany        Frankfurt
- 3 524    8.4605   +49.484894    -87.821 0.6509    +0.7566      Germany        Mannheim
- 3 525    8.76917  +50.811848    277.885 0.633171  +0.771473    Germany        Marburg
- 3 526   10.1477   +54.340949     75.281 0.58426   +0.80886     Germany        Kiel
- 3 527    9.9431   +53.545029    196.124 0.5955    +0.8007      Germany        Altona
- 3 528    9.9426   +51.529931    142.433 0.62340   +0.77931     Germany        Gottingen
- 3 529   10.7229   +59.912146     20.624 0.50259   +0.86163     Norway         Christiania
- 3 530   10.6898   +53.856800     31.564 0.5911    +0.8039      Germany        Lubeck
- 3 531   12.4797   +41.898438     56.817 0.74545   +0.66434     Italy          Collegio Romano, Rome
- 3 532   11.6084   +48.146087    514.477 0.66853   +0.74130     Germany        Munich
- 3 533   11.8715   +45.400199     43.830 0.70335   +0.70847     Italy          Padua
- 3 534   12.3913   +51.334935    147.349 0.62606   +0.77719     Germany        Leipzig (since 1861)
- 3 535   13.3578   +38.112038     76.740 0.78782   +0.61386     Italy          Palermo
- 3 536   13.1062   +52.406679    116.170 0.61135   +0.78873     Germany        Berlin-Babelsberg
- 3 537   13.3642   +52.526023    128.158 0.6097    +0.7900      Germany        Urania Observatory, Berlin
- 3 538   13.8461   +44.863303     41.921 0.70998   +0.70187     Croatia        Pola
- 3 539   14.1316   +48.056389    380.558 0.66968   +0.74024     Austria        Kremsmunster
- 3 540   14.2753   +48.442489    785.467 0.66470   +0.74477     Austria        Linz
- 3 541   14.3953   +50.076637    302.652 0.64306   +0.76331     Czech Republi  Prague
- 3 542   13.0374   +52.567266   -173.718 0.6091    +0.7904      Germany        Falkensee
- 3 543   12.3688   +51.337979    -41.931 0.6260    +0.7772      Germany        Leipzig (before 1861)
- 3 544   13.35131  +52.457381     65.288 0.610644  +0.789263    Germany        Wilhelm Foerster Observatory, Berlin
- 3 545   16.3817   +48.209620    184.008 0.66767   +0.74200     Austria        Vienna (before 1879)
- 3 546   16.3549   +48.215289    219.391 0.66760   +0.74207     Austria        Oppolzer Observatory, Vienna
- 3 547   17.0363   +51.115578    116.616 0.62904   +0.77479     Poland         Breslau
- 3 548   13.3950   +52.504462     39.093 0.60999   +0.78976     Germany        Berlin (1835-1913)
- 3 549   17.6257   +59.858039     51.645 0.50341   +0.86116     Sweden         Uppsala
- 3 550   11.4196   +53.627586   -240.982 0.5943    +0.8015      Germany        Schwerin
- 3 551   18.1895   +47.874161     98.688 0.67201   +0.73808     Slovakia       Hurbanovo, formerly O'Gyalla
- 3 552   11.3418   +44.468021    298.251 0.71485   +0.69700     Italy          Osservatorio S. Vittore, Bologna
- 3 553   18.9938   +50.299749   -206.364 0.64002   +0.76574     Poland         Chorzow
- 3 554    8.3959   +50.539287    192.307 0.63684   +0.76845     Germany        Burgsolms Observatory, Wetzlar
- 3 555   19.8263   +50.054245    308.259 0.64336   +0.76306     Poland         Cracow-Fort Skala
- 3 556   11.26     +47.589673  -6331.444 0.675     +0.734       Germany        Reintal, near Munich
- 3 557   14.77961  +49.914803    580.679 0.645250  +0.761529    Czech Republi  Ondrejov
- 3 558   21.0303   +52.217857    148.194 0.61396   +0.78672     Poland         Warsaw
- 3 559   14.98     +37.618100   -696.944 0.793     +0.607       Italy          Serra La Nave
- 3 560   10.93100  +45.407461     63.049 0.703262  +0.708561    Italy          Madonna di Dossobuono
- 3 561   19.89367  +47.917455    983.456 0.671543  +0.738689    Hungary        Piszkesteto Stn. (Konkoly)
- 3 562   15.9236   +48.083754    905.092 0.66938   +0.74062     Austria        Figl Observatory, Vienna
- 3 563   13.60     +47.952529    135.713 0.671     +0.739       Austria        Seewalchen
- 3 564   11.19     +48.029249   9614.117 0.671     +0.741       Germany        Herrsching
- 3 565   10.1344   +45.317821     31.563 0.70437   +0.70746     Italy          Bassano Bresciano
- 3 566  203.7424   +20.708375   3040.446 0.93623   +0.35156     US/Hawaii      Haleakala-NEAT/GEODSS
- 3 567   12.7117   +45.843338     37.101 0.69783   +0.71387     Italy          Chions
- 3 568  204.5278   +19.826116   4212.397 0.94171   +0.33725     US/Hawaii      Maunakea
- 3 569   24.9587   +60.155276     10.883 0.49891   +0.86375     Finland        Helsinki
- 3 570   25.2990   +54.682117    -55.218 0.5794    +0.8123      Lithuania      Vilnius (since 1939)
- 3 571   10.63     +45.354705    822.341 0.704     +0.708       Italy          Cavriana
- 3 572    6.89     +50.927521  -5853.344 0.631     +0.772       Germany        Cologne
- 3 573    9.6612   +52.175130   -361.197 0.6145    +0.7862      Germany        Eldagsen
- 3 574   10.2667   +45.297123     64.319 0.70463   +0.70721     Italy          Gottolengo
- 3 575    6.808    +47.089416   1011.673 0.68219   +0.72894     Switzerland    La Chaux de Fonds
- 3 576    0.3760   +50.994968     53.847 0.63067   +0.77346     UK/England     Burwash
- 3 577    7.50     +47.462736   6589.131 0.678     +0.734       Switzerland    Metzerlen Observatory
- 3 578   27.99     -26.204483   1350.698 0.898     -0.439       South Africa   Linden Observatory
- 3 579    8.85     +44.786623    744.462 0.711     +0.701       Italy          Novi Ligure
- 3 580   15.4936   +47.067254    516.080 0.68242   +0.72862     Austria        Graz
- 3 581   22.80     -33.995489    380.530 0.830     -0.556       South Africa   Sedgefield
- 3 582    1.2408   +52.009272     24.170 0.61682   +0.78447     UK/England     Orwell Park
- 3 583   30.2717   +46.397290     23.284 0.69087   +0.72056     Ukraine        Odesa-Mayaky
- 3 584   30.2946   +59.942394    -14.482 0.50213   +0.86189     Russia         Leningrad
- 3 585   30.52462  +50.297969     24.383 0.640067  +0.765748    Ukraine        Kyiv comet station
- 3 586    0.1423   +42.936555   2890.675 0.73358   +0.67799     France         Pic du Midi
- 3 587    9.22918  +45.882949   1176.946 0.697459  +0.714479    Italy          Sormano
- 3 588   11.25     +44.461990    981.042 0.715     +0.697       Italy          Eremo di Tizzano
- 3 589   12.64369  +42.519425    392.032 0.738223  +0.672386    Italy          Santa Lucia Stroncone
- 3 590    7.46     +47.462736   6589.131 0.678     +0.734       Switzerland    Metzerlen
- 3 591    9.6258   +52.507327     35.619 0.60995   +0.78979     Germany        Resse Observatory
- 3 592    7.02114  +51.174341    149.126 0.628245  +0.775437    Germany        Solingen
- 3 593   11.17     +42.430591  -1922.141 0.739     +0.671       Italy          Monte Argentario
- 3 594   13.2033   +41.957433   1827.850 0.74497   +0.66529     Italy          Monte Autore
- 3 595   13.52578  +45.915733     43.360 0.696925  +0.714749    Italy          Farra d'Isonzo
- 3 596   12.6183   +41.983845     91.857 0.74446   +0.66545     Italy          Colleverde di Guidonia
- 3 597    9.6631   +52.170501    119.457 0.61461   +0.78621     Germany        Springe
- 3 598   11.33409  +44.259208    745.434 0.717444  +0.694448    Italy          Loiano
- 3 599   13.55764  +42.444136   2141.321 0.739311  +0.671604    Italy          Campo Imperatore-CINEOS
- 3 600   11.4708   +44.358840    287.157 0.71618   +0.69564     Italy          TLC Observatory, Bologna
- 3 601   13.7281   +51.038129    106.413 0.63009   +0.77394     Germany        Engelhardt Observatory, Dresden
- 3 602   16.3854   +48.212050    199.164 0.66764   +0.74203     Austria        Urania Observatory, Vienna
- 3 603   10.1300   +54.202600     74.595 0.58622   +0.80745     Germany        Bothkamp
- 3 604   13.47524  +52.486761     39.219 0.610235  +0.789572    Germany        Archenhold Sternwarte, Berlin-Treptow
- 3 605    7.1130   +51.674076     46.379 0.62142   +0.78086     Germany        Marl
- 3 606    9.9956   +53.684186     33.692 0.59353   +0.80212     Germany        Norderstedt
- 3 607    8.0000   +51.218913    769.224 0.6277    +0.7760      Germany        Hagen Observatory, Ronkhausen
- 3 608  203.7420   +20.708375   3040.446 0.93623   +0.35156     US/Hawaii      Haleakala-AMOS
- 3 609   12.8533   +42.570843   1280.188 0.73772   +0.67314     Italy          Osservatorio Polino
- 3 610   11.3431   +44.391708    202.228 0.71577   +0.69604     Italy          Pianoro
- 3 611    8.6531   +49.647790    228.075 0.64877   +0.75848     Germany        Starkenburg Sternwarte, Heppenheim
- 3 612    7.10     +51.411396    -37.014 0.625     +0.778       Germany        Lenkerbeck
- 3 613    7.0709   +51.409604    122.117 0.62504   +0.77800     Germany        Heisingen
- 3 614    2.467    +48.635126    -13.469 0.6621    +0.7469      France         Soisy-sur-Seine
- 3 615    6.9067   +44.697855   2908.587 0.71233   +0.70014     France         St. Veran
- 3 616   16.58348  +49.204434    351.149 0.654655  +0.753466    Czech Republi  Brno
- 3 617    2.5725   +48.416110    -22.857 0.66496   +0.74437     France         Arbonne la Foret
- 3 618    5.0077   +43.419372     55.859 0.72750   +0.68382     France         Martigues
- 3 619    2.09013  +41.550043    211.667 0.749506  +0.659828    Spain          Sabadell
- 3 620    2.9517   +39.643980    206.540 0.77110   +0.63463     Spain          Observatorio Astronomico de Mallorca
- 3 621    7.48503  +51.086390    368.243 0.629461  +0.774501    Germany        Bergisch Gladbach
- 3 622    7.5680   +46.645163    439.239 0.68778   +0.72358     Switzerland    Oberwichtrach
- 3 623    5.5667   +50.618355    145.152 0.63577   +0.76932     Belgium        Liege
- 3 624    9.6167   +49.762986    151.377 0.64723   +0.75977     Germany        Dertingen
- 3 625  203.5683   +20.746069    119.141 0.93557   +0.35201     US/Hawaii      Kihei-AMOS Remote Maui Experimental Site
- 3 626    4.9864   +51.157211     70.258 0.62847   +0.77524     Belgium        Geel
- 3 627    5.2146   +44.042227    236.842 0.72002   +0.69168     France         Blauvac
- 3 628    6.84366  +51.427430     41.156 0.624789  +0.778184    Germany        Mulheim-Ruhr
- 3 629   20.1511   +46.250362     96.979 0.69273   +0.71880     Hungary        Szeged Observatory
- 3 630    7.2367   +47.992991    459.688 0.67051   +0.73951     France         Osenbach
- 3 631   10.02293  +53.508969     45.858 0.595992  +0.800307    Germany        Hamburg-Georgswerder
- 3 632   11.1739   +43.728395    148.489 0.72380   +0.68773     Italy          San Polo A Mosciano
- 3 633    9.9339   +44.099841     42.823 0.71930   +0.69238     Italy          Romito
- 3 634    5.1456   +45.527180    473.763 0.70182   +0.71007     France         Crolles
- 3 635    2.9019   +42.700402     53.934 0.73605   +0.67467     France         Pergignan
- 3 636    6.9794   +51.394563     70.505 0.62524   +0.77783     Germany        Essen
- 3 637   10.0903   +53.703441     42.021 0.59326   +0.80232     Germany        Hamburg-Himmelsmoor
- 3 638    8.8933   +51.940146    128.258 0.61778   +0.78374     Germany        Detmold
- 3 639   13.7233   +51.094359    136.269 0.62933   +0.77456     Germany        Dresden
- 3 640   13.5996   +50.086985     88.064 0.6429    +0.7634      Czech Republi  Senftenberger Sternwarte
- 3 641   20.0272   -34.535490    133.007 0.82468   -0.56374     South Africa   Overberg
- 3 642  236.6850   +48.427924    -79.848 0.6648    +0.7445      Canada/BritCo  Oak Bay, Victoria
- 3 643  243.2794   +33.483600   1339.817 0.83507   +0.54868     US/California  OCA-Anza Observatory
- 3 644  243.14022  +33.357340   1686.997 0.836325  +0.546877    US/California  Palomar Mountain/NEAT
- 3 645  254.17942  +32.780502   2791.253 0.841945  +0.538563    US/New Mexico  Apache Point-Sloan Digital Sky Survey
- 3 646  242.4369   +33.997240    434.639 0.82999   +0.55603     US/California  Santana Observatory, Rancho Cucamonga
- 3 647  245.9683   +50.778455   1061.331 0.6337    +0.7712      Canada/Albert  Stone Finder Observatory, Calgary
- 3 648  249.39822  +31.665606   1516.776 0.852115  +0.522053    US/Arizona     Winer Observatory, Sonoita
- 3 649  265.3003   +38.646416    274.347 0.78207   +0.62117     US/Kansas      Powell Observatory, Louisburg
- 3 650  242.9028   +33.467301    373.646 0.83510   +0.54836     US/California  Temecula
- 3 651  249.41916  +31.670421   1501.461 0.852069  +0.522123    US/Arizona     Grasslands Observatory, Tucson
- 3 652  245.9333   +51.116859    902.982 0.6291    +0.7749      Canada/Albert  Rock Finder Observatory, Calgary
- 3 653  237.8678   +47.183041    226.543 0.68091   +0.72996     US/Washington  Torus Observatory, Buckley
- 3 654  242.31841  +34.381822   2287.309 0.826471  +0.561727    US/California  Table Mountain Observatory, Wrightwood-PHMC
- 3 655  236.383    +48.366952    -30.546 0.6656    +0.7438      Canada/BritCo  Sooke
- 3 656  236.3921   +48.353425    197.379 0.66580   +0.74367     Canada/BritCo  Victoria
- 3 657  236.6903   +48.461980     57.759 0.66437   +0.74491     Canada/BritCo  Climenhaga Observatory, Victoria
- 3 658  236.58300  +48.519987    234.389 0.663631  +0.745601    Canada/BritCo  Dominion Astrophysical Observatory
- 3 659  237.0514   +48.599732     54.040 0.66257   +0.74650     US/Washington  Heron Cove Observatory, Orcas
- 3 660  237.7379   +37.873406    106.220 0.79038   +0.61059     US/California  Leuschner Observatory, Berkeley
- 3 661  245.7117   +50.868272   1309.870 0.63251   +0.77222     Canada/Albert  Rothney Astrophysical Observatory, Priddis
- 3 662  238.3545   +37.340108   1283.998 0.79619   +0.60335     US/California  Lick Observatory, Mount Hamilton
- 3 663  248.3136   +33.496489    450.332 0.83483   +0.54879     US/Arizona     Red Mountain Observatory
- 3 664  239.2775   +46.949324   1229.622 0.6840    +0.7273      US/Washington  Manastash Ridge Observatory
- 3 665  240.9903   +34.810651   1629.920 0.82215   +0.56781     US/California  Wallis Observatory
- 3 666  241.1692   +34.301680    298.548 0.8270    +0.5604      US/California  Moorpark College Observatory
- 3 667  240.00921  +46.902678    193.321 0.684483  +0.726626    US/Washington  Wanapum Dam
- 3 668  240.82     +34.857391  -3698.399 0.821     +0.568       US/California  San Emigdio Peak
- 3 669  240.8238   +34.467031    485.455 0.82540   +0.56279     US/California  Ojai
- 3 670  240.9558   +34.221330     15.051 0.82775   +0.55922     US/California  Camarillo
- 3 671  242.00198  +34.301561   1710.130 0.827184  +0.560523    US/California  Stony Ridge
- 3 672  241.9436   +34.224694   1734.505 0.82794   +0.55942     US/California  Mount Wilson
- 3 673  242.31783  +34.381488   2285.092 0.826474  +0.561722    US/California  Table Mountain Observatory, Wrightwood
- 3 674  242.33605  +34.382192   2261.268 0.826464  +0.561730    US/California  Ford Observatory, Wrightwood
- 3 675  243.13746  +33.354120   1696.158 0.836357  +0.546831    US/California  Palomar Mountain
- 3 676  242.3907   +33.418166     61.063 0.83553   +0.54762     US/California  San Clemente
- 3 677  242.8281   +34.273483   1716.562 0.82746   +0.56012     US/California  Lake Arrowhead
- 3 678  248.2597   +33.635876    682.249 0.83352   +0.55083     US/Arizona     Fountain Hills
- 3 679  244.5367   +31.043406   2824.770 0.85792   +0.51292     Mexico         San Pedro Martir
- 3 680  244.78     +33.803964   9147.690 0.833     +0.554       US/California  Los Angeles
- 3 681  245.8858   +51.086072   1126.438 0.62954   +0.77459     Canada/Albert  Calgary
- 3 682  247.6381   +37.046938   1648.706 0.79932   +0.59932     US/Utah        Kanab
- 3 683  248.9182   +32.155481    747.379 0.84751   +0.52922     US/Arizona     Goodricke-Pigott Observatory, Tucson
- 3 684  247.5100   +34.512629   1794.482 0.82512   +0.56356     US/Arizona     Prescott
- 3 685  247.84     +35.352234  -4112.910 0.816     +0.575       US/Arizona     Williams
- 3 686  249.2092   +32.441312   2755.255 0.84512   +0.53359     US/Arizona     U. of Minn. Infrared Obs., Mt. Lemmon
- 3 687  248.3473   +35.184460   2098.971 0.81848   +0.57318     US/Arizona     Northern Arizona University, Flagstaff
- 3 688  248.4645   +35.095943   2204.195 0.81938   +0.57193     US/Arizona     Lowell Observatory, Anderson Mesa Station
- 3 689  248.2601   +35.183936   2292.109 0.81851   +0.57319     US/Arizona     U.S. Naval Observatory, Flagstaff
- 3 690  248.3367   +35.201970   2220.750 0.81832   +0.57344     US/Arizona     Lowell Observatory, Flagstaff
- 3 691  248.39966  +31.962189   2041.007 0.849466  +0.526479    US/Arizona     Steward Observatory, Kitt Peak-Spacewatch
- 3 692  249.0513   +32.233024    735.163 0.84679   +0.53036     US/Arizona     Steward Observatory, Tucson
- 3 693  249.26745  +32.416873   2491.132 0.845313  +0.533209    US/Arizona     Catalina Station, Tucson
- 3 694  248.9943   +32.213449    950.016 0.84700   +0.53009     US/Arizona     Tumamoc Hill, Tucson
- 3 695  248.40533  +31.958398   2064.325 0.849504  +0.526425    US/Arizona     Kitt Peak
- 3 696  249.1154   +31.688954   2627.639 0.85205   +0.52249     US/Arizona     Whipple Observatory, Mt. Hopkins
- 3 697  248.38381  +31.951411   1896.663 0.849546  +0.526308    US/Arizona     Kitt Peak, McGraw-Hill
- 3 698  249.26736  +32.416926   2517.543 0.845316  +0.533212    US/Arizona     Mt. Bigelow
- 3 699  248.46331  +35.095943   2204.195 0.819380  +0.571930    US/Arizona     Lowell Observatory-LONEOS
- 3 700  250.3817   +36.350510   1624.518 0.80656   +0.58960     US/Arizona     Chinle
- 3 701  249.79716  +31.475562   1351.518 0.853823  +0.519224    US/Arizona     Junk Bond Observatory, Sierra Vista
- 3 702  252.8117   +33.984187   3381.271 0.8305    +0.5561      US/New Mexico  Joint Obs. for cometary research, Socorro
- 3 703  249.26736  +32.417032   2487.202 0.845311  +0.533211    US/Arizona     Catalina Sky Survey
- 3 704  253.34093  +33.818259   1528.504 0.831869  +0.553542    US/New Mexico  Lincoln Laboratory ETS, New Mexico
- 3 705  254.17942  +32.780502   2791.253 0.841945  +0.538563    US/New Mexico  Apache Point
- 3 706  253.9366   +38.582008   1664.614 0.78294   +0.62043     US/Colorado    Salida
- 3 707  254.56     +39.465804   7847.118 0.774     +0.633       US/Colorado    Chamberlin field station
- 3 708  255.0475   +39.675783   1643.012 0.77092   +0.63520     US/Colorado    Chamberlin Observatory, Denver
- 3 709  254.22882  +32.955690   2478.778 0.840250  +0.541096    US/New Mexico  W & B Observatory, Cloudcroft
- 3 710  254.7336   +38.880789   2602.563 0.77980   +0.62458     US/Colorado    MPO Observatory, Florissant
- 3 711  255.9785   +30.671481   2102.800 0.86114   +0.50731     US/Texas       McDonald Observatory, Fort Davis
- 3 712  255.11867  +39.007187   2179.112 0.778365  +0.626250    US/Colorado    USAF Academy Observatory, Colorado Springs
- 3 713  254.9897   +39.879687   1656.510 0.76865   +0.63793     US/Colorado    Thornton
- 3 714  246.8173   +34.574092   1223.770 0.82444   +0.56439     US/Arizona     Bagdad
- 3 715  253.2759   +32.384721   1338.112 0.84546   +0.53264     US/New Mexico  Jornada Observatory, Las Cruces
- 3 716  255.2489   +39.084677   2301.855 0.77753   +0.62731     US/Colorado    Palmer Divide Observatory, Colorado Springs
- 3 717  256.0481   +30.610986   1538.941 0.86160   +0.50636     US/Texas       Prude Ranch
- 3 718  247.7042   +40.641408   1340.167 0.76004   +0.64802     US/Utah        Tooele
- 3 719  253.08608  +34.072674   1422.588 0.829384  +0.557204    US/New Mexico  Etscorn Observatory
- 3 720  259.6261   +25.643182    620.469 0.90216   +0.43018     Mexico         Universidad de Monterrey
- 3 721  259.7312   +40.399469    776.214 0.76271   +0.64476     US/Nebraska    Lime Creek
- 3 722  264.4192   +29.604204      1.559 0.87017   +0.49110     US/Texas       Missouri City
- 3 723  263.3300   +34.874996    305.031 0.82134   +0.56861     US/Oklahoma    Cottonwood Observatory, Ada
- 3 724  260.8053   +19.404990   2282.825 0.94388   +0.33026     Mexico         National Observatory, Tacubaya
- 3 725  261.3453   +29.766354    410.062 0.86883   +0.49358     US/Texas       Fair Oaks Ranch
- 3 726  265.6933   +46.448790    210.614 0.69024   +0.72120     US/Minnesota   Brainerd
- 3 727  262.53872  +35.612756    357.610 0.813941  +0.579096    US/Oklahoma    Zeno Observatory, Edmond
- 3 728  262.6084   +27.691909     -0.235 0.88610   +0.46194     US/Texas       Corpus Christi
- 3 729  262.87858  +49.645227    227.534 0.648804  +0.758451    Saskatchewan   Glenlea Astronomical Observatory, Winnipeg
- 3 730  262.84143  +47.911570    268.237 0.671544  +0.738537    US/North Dako  University of North Dakota, Grand Forks
- 3 731  272.6711   +39.481134    160.731 0.77290   +0.63244     US/Indiana     Rose-Hulman Observatory, Terre Haute
- 3 732  263.2300   +17.181651   1721.159 0.95591   +0.29359     Mexico         Oaxaca
- 3 733  263.3546   +33.159311    209.096 0.83802   +0.54387     US/Texas       Allen, Texas
- 3 734  263.99758  +38.890242    376.418 0.779425  +0.624489    US/Kansas      Farpoint Observatory, Eskridge
- 3 735  264.40640  +29.375000     17.448 0.872133  +0.487634    US/Texas       George Observatory, Needville
- 3 736  263.3357   +29.618337     84.929 0.87006   +0.49132     US/Texas       Houston
- 3 737  275.6633   +34.177302    166.237 0.8282    +0.5586      US/Georgia     New Bullpen Observatory, Alpharetta
- 3 738  267.6733   +38.944581    123.634 0.7788    +0.6252      US/Missouri    Observatory of the State University of Missouri
- 3 739  265.2440   +38.868756    296.548 0.77965   +0.62419     US/Kansas      Sunflower Observatory, Olathe
- 3 740  265.3383   +31.757304    190.178 0.8511    +0.5233      US/Texas       SFA Observatory, Nacogdoches
- 3 741  266.8503   +44.461527    304.991 0.71493   +0.69692     US/Minnesota   Goodsell Observatory, Northfield
- 3 742  266.31216  +41.595519    284.173 0.748989  +0.660428    US/Iowa        Drake University, Des Moines
- 3 743  267.76148  +44.982902    371.355 0.708545  +0.703382    US/Wisconsin   University of Minnesota, Minneapolis
- 3 744  273.8378   +39.847122    215.578 0.76884   +0.63735     US/Indiana     Doyan Rose Observatory, Indianapolis
- 3 745  267.1747   +39.229358    249.776 0.77569   +0.62906     US/Missouri    Morrison Obervatory, Glasgow
- 3 746  275.2254   +43.587536    289.579 0.72551   +0.68597     US/Michigan    Brooks Observatory, Mt. Pleasant
- 3 747  268.9292   +30.346067     15.608 0.86373   +0.50227     US/Louisiana   Highland Road Park Observatory
- 3 748  268.4680   +41.495468    245.634 0.75014   +0.65912     US/Iowa        Van Allen Observatory, Iowa City
- 3 749  276.1642   +34.205355    352.676 0.82795   +0.55902     US/Georgia     Oakwood
- 3 750  268.7282   +44.815827    282.197 0.71059   +0.70131     US/Wisconsin   Hobbs Observatory, Fall Creek
- 3 751  269.2439   +38.799941    123.860 0.78038   +0.62324     US/Missouri    Lake Saint Louis
- 3 752  275.4647   +34.732390    492.890 0.82278   +0.56659     US/Georgia     Puckett Observatory, Mountain Town
- 3 753  270.59069  +43.076214    288.139 0.731622  +0.679491    US/Wisconsin   Washburn Observatory, Madison
- 3 754  271.4432   +42.570076    335.846 0.73762   +0.67303     US/Wisconsin   Yerkes Observatory, Williams Bay
- 3 755  274.6478   +42.914973    224.614 0.73353   +0.67743     US/Michigan    Optec Observatory
- 3 756  272.32567  +42.057533    126.506 0.743605  +0.666407    US/Illinois    Dearborn Observatory, Evanston (bef. July 1939)
- 3 757  280.0050   +36.038626    323.042 0.8096    +0.5851      US/North Caro  High Point
- 3 758  279.2379   +28.385032      6.696 0.88044   +0.47257     US/Florida     BCC Observatory, Cocoa
- 3 759  273.1947   +36.052656    351.675 0.80946   +0.58530     US/Tennessee   Nashville
- 3 760  273.6048   +39.549397    293.825 0.77216   +0.63337     US/Indiana     Goethe Link Observatory, Brooklyn
- 3 761  277.6456   +28.271214     17.950 0.88138   +0.47083     US/Florida     Zephyrhills
- 3 762  274.2008   +44.956645    206.023 0.70885   +0.70304     US/Michigan    Four Winds Observatory, Lake Leelanau
- 3 763  280.4658   +43.914771    308.935 0.72157   +0.69009     Canada/Ontari  King City
- 3 764  275.1439   +33.722310    326.617 0.83264   +0.55205     US/Georgia     Puckett Observatory, Stone Mountain
- 3 765  275.5775   +39.138735    277.252 0.77669   +0.62784     US/Ohio        Cincinnati
- 3 766  275.5167   +42.706569    252.146 0.73600   +0.67477     US/Michigan    Michigan State University Obs., East Lansing
- 3 767  276.2697   +42.280295    293.633 0.74102   +0.66930     US/Michigan    Ann Arbor
- 3 768  272.32488  +42.059283    130.066 0.743585  +0.666430    US/Illinois    Dearborn Observatory, Evanston (aft. Oct. 1939)
- 3 769  276.9892   +39.997598    225.137 0.76716   +0.63936     US/Ohio        McMillin Observatory, Columbus
- 3 770  274.0786   +39.225235    205.395 0.77573   +0.62900     US/Indiana     Crescent Moon Observatory, Columbus
- 3 771  277.57     +23.013306   7724.352 0.922     +0.389       Cuba           Boyeros Observatory, Havana
- 3 772  284.0865   +45.254105    131.522 0.70517   +0.70669     Canada/Ontari  Boltwood Observatory, Stittsville
- 3 773  278.4318   +41.536957    236.198 0.74966   +0.65966     US/Ohio        Warner and Swasey Observatory, Cleveland
- 3 774  278.9250   +41.591562    414.251 0.74905   +0.66039     US/Ohio        Warner and Swasey Nassau Station, Chardon
- 3 775  284.6168   +40.606343    100.299 0.76029   +0.64743     US/Pennsylvan  Sayre Observatory, South Bethlehem
- 3 776  284.4669   +42.816318    407.428 0.73472   +0.67619     US/New York    Foggy Bottom, Hamilton
- 3 777  280.6017   +43.666676    123.956 0.72454   +0.68695     Canada/Ontari  Toronto
- 3 778  279.9778   +40.482685    356.041 0.76172   +0.64582     US/Pennsylvan  Allegheny Observatory, Pittsburgh
- 3 779  280.5779   +43.862795    240.522 0.72219   +0.68943     Canada/Ontari  David Dunlap Observatory, Richmond Hill
- 3 780  281.4778   +38.033616    225.691 0.78868   +0.61280     US/Virginia    Leander McCormick Observatory, Charlottesville
- 3 781  281.5075    -0.233505   2922.799 1.00045   -0.00405     Ecuador        Quito
- 3 782  281.65      +0.000000  -6378.137 0.999     +0.000       Ecuador        Quito, comet astrograph station
- 3 783  282.02     +38.650286   8213.159 0.783     +0.622       US/Virginia    Rixeyville
- 3 784  282.2146   +42.250749    585.848 0.74140   +0.66895     US/New York    Stull Observatory, Alfred University
- 3 785  285.3542   +40.345554     39.128 0.76323   +0.64397     US/New Jersey  Fitz-Randolph Observatory, Princeton
- 3 786  282.9345   +38.920446     90.959 0.77906   +0.62487     US/Dist. of C  U.S. Naval Obs., Washington (since 1893)
- 3 787  282.9494   +38.894247     38.550 0.77934   +0.62451     US/Dist. of C  U.S. Naval Obs., Washington (before 1893)
- 3 788  284.3667   +39.784239    124.516 0.76953   +0.63650     US/Delaware    Mount Cuba Observatory, Wilmington
- 3 789  284.5940   +43.054734    310.081 0.73188   +0.67922     US/New York    Litchfield Observatory, Clinton
- 3 790  284.2835   +45.394109     84.240 0.70343   +0.70840     Canada/Ontari  Dominion Observatory, Ottawa
- 3 791  284.5236   +39.999146    119.552 0.76713   +0.63937     US/Pennsylvan  Flower and Cook Observatory, Philadelphia
- 3 792  288.29905  +41.353320    -24.079 0.751746  +0.657236    US/Rhode Isla  University of Rhode Island, Quonochontaug
- 3 793  286.2515   +42.663049    131.645 0.7365    +0.6742      US/New York    Dudley Observatory, Albany (before 1893)
- 3 794  286.1100   +41.688179     55.257 0.74789   +0.66161     US/New York    Vassar College Observatory, Poughkeepsie
- 3 795  286.03861  +40.809795     10.268 0.757969  +0.650106    US/New York    Rutherford
- 3 796  286.45     +41.090425   1985.622 0.755     +0.654       US/Connecticu  Stamford
- 3 797  287.0751   +41.316332     49.247 0.75218   +0.65676     US/Connecticu  Yale Observatory, New Haven
- 3 798  287.0154   +41.426698    220.953 0.75093   +0.65822     US/Connecticu  Yale Observatory, Bethany
- 3 799  288.8650   +42.453331     41.707 0.73896   +0.67150     US/Massachuse  Winchester
- 3 800  288.4511   -16.374554   2429.040 0.96006   -0.28021     Peru           Harvard Observatory, Arequipa
- 3 801  288.44233  +42.505363    180.012 0.738364  +0.672183    US/Massachuse  Oak Ridge Observatory
- 3 802  288.87164  +42.381468     22.543 0.739802  +0.670574    US/Massachuse  Harvard Observatory, Cambridge
- 3 803  288.9167   +41.900060     47.059 0.74543   +0.66436     US/Massachuse  Taunton
- 3 804  289.3121   -33.562676    571.287 0.83421   -0.54976     Chile          Santiago-San Bernardo
- 3 805  288.9800   -32.981524   2209.162 0.83997   -0.54145     Chile          Santiago-Cerro El Roble
- 3 806  289.4513   -33.396831    868.783 0.83584   -0.54738     Chile          Santiago-Cerro Calan
- 3 807  289.1941   -30.169135   2379.620 0.86560   -0.49980     Chile          Cerro Tololo Observatory, La Serena
- 3 808  290.6708   -31.802005   2361.167 0.85098   -0.52414     Argentina      El Leoncito
- 3 809  289.26626  -29.258822   2345.440 0.873440  -0.486052    Chile          European Southern Observatory, La Silla
- 3 810  288.5154   +42.610216    103.047 0.73712   +0.67352     US/Massachuse  Wallace Observatory, Westford
- 3 811  289.89565  +41.280622     12.056 0.752586  +0.656289    US/Massachuse  Maria Mitchell Observatory, Nantucket
- 3 812  288.4543   -32.958004    136.714 0.83992   -0.54093     Chile          Vina del Mar
- 3 813  289.3083   -33.445138    507.509 0.83533   -0.54805     Chile          Santiago-Quinta Normal (1862-1920)
- 3 814  288.41917  +41.851177    122.110 0.746007  +0.663734    US/Rhode Isla  North Scituate
- 3 815  289.3479   -33.440358    615.937 0.83539   -0.54799     Chile          Santiago-Santa Lucia (1849-1861)
- 3 816  285.7583   +44.338978    537.756 0.71645   +0.69542     US/New York    Rand Observatory
- 3 817  288.6104   +42.349703     67.510 0.74018   +0.67017     US/Massachuse  Sudbury
- 3 818  286.4167   +45.350672    368.570 0.7040    +0.7079      Canada/Quebec  Gemeaux Observatory, Laval
- 3 819  284.3850   +45.894857    169.075 0.69720   +0.71451     Canada/Quebec  Val-des-Bois
- 3 820  295.37581  -21.596256   1842.178 0.930491  -0.365872    Bolivia        Tarija
- 3 821  295.45041  -31.598329   1213.158 0.852688  -0.521032    Argentina      Cordoba-Bosque Alegre
- 3 822  295.80137  -31.420047    427.684 0.854203  -0.518325    Argentina      Cordoba
- 3 823  288.1691   +42.609895    330.232 0.73715   +0.67354     US/Massachuse  Fitchburg
- 3 824  285.7528   +44.342225    533.603 0.71641   +0.69546     US/New York    Lake Clear
- 3 825  288.2595   +42.337960    173.173 0.74033   +0.67003     US/Massachuse  Granville
- 3 826  288.2282   +46.219516    113.286 0.69312   +0.71843     Canada/Quebec  Plessissville
- 3 827  287.5393   +48.651315    101.164 0.66190   +0.74710     Canada/Quebec  Saint-Felicien
- 3 828  288.9758   +41.802871     53.671 0.74656   +0.66310     US/Massachuse  Assonet
- 3 829  290.6979   -31.799327   2477.163 0.85102   -0.52411     Argentina      Complejo Astronomico El Leoncito
- 3 830  288.5697   +42.796690     39.613 0.73491   +0.67590     US/New Hampsh  Hudson
- 3 831  277.4134   +29.401652     48.904 0.87191   +0.48804     US/Florida     Rosemary Hill Observatory, University of Florida
- 3 832  283.1850   +40.164833    347.142 0.7653    +0.6416      US/Pennsylvan  Etters
- 3 833  301.4633   -34.629923     -4.536 0.82373   -0.56508     Argentina      Obs. Astronomico de Mercedes, Buenos Aires
- 3 834  301.5654   -34.605196     39.518 0.82398   -0.56473     Argentina      Buenos Aires-AAAA
- 3 835  288.6428   +42.612227     48.587 0.73709   +0.67354     US/Massachuse  Drum Hill Station, Chelmsford
- 3 836  288.5011   +41.758139     62.114 0.74708   +0.66252     US/Rhode Isla  Furnace Brook Observatory, Cranston
- 3 837  279.7553   +26.915986    -25.095 0.89228   +0.44996     US/Florida     Jupiter
- 3 838  275.8628   +39.743125    225.850 0.77000   +0.63596     US/Ohio        Dayton
- 3 839  302.0678   -34.908385     11.159 0.82097   -0.56906     Argentina      La Plata
- 3 840  276.2833   +43.014499    237.840 0.73235   +0.67870     US/Michigan    Flint
- 3 841  279.44233  +37.332810    978.894 0.796229  +0.603220    US/Virginia    Martin Observatory, Blacksburg
- 3 842  282.7678   +39.831163    149.209 0.76901   +0.63713     US/Pennsylvan  Gettysburg College Observatory
- 3 843  273.0648   +34.523202    201.494 0.82481   +0.56357     US/Alabama     Emerald Lane Observatory, Decatur
- 3 844  303.80982  -34.755486     88.859 0.822499  -0.566884    Uruguay        Observatorio Astronomico Los Molinos
- 3 845  283.5058   +42.417288    356.484 0.73942   +0.67107     US/New York    Ford Observatory, Ithaca
- 3 846  269.65501  +38.850025    193.679 0.779842  +0.623926    US/Missouri    Principia Astronomical Observatory, Elsah
- 3 847  275.9750   +45.042271    251.034 0.7078    +0.7041      US/Michigan    Lunar Cafe Observator, Flint
- 3 848  237.0219   +43.702424    213.198 0.72412   +0.68741     US/Oregon      Tenagra Observatory, Cottage Grove
- 3 849  265.1694   +38.903927    331.908 0.77927   +0.62467     US/Kansas      Everstar Observatory, Olathe
- 3 850  274.0802   +35.204093    669.731 0.81810   +0.57333     US/Tennessee   Cordell-Lorenz Observatory, Sewanee
- 3 851  296.41962  +44.630588      2.798 0.712830  +0.698986    Canada/Nova S  Burke-Gaffney Observatory, Halifax
- 3 852  269.4050   +38.789352    160.938 0.7805    +0.6231      US/Missouri    River Moss Observatory, St. Peters
- 3 853  249.1517   +32.576438   1189.949 0.84365   +0.53544     US/Arizona     Biosphere 2 Observatory
- 3 854  249.17995  +32.299852    835.864 0.846183  +0.531351    US/Arizona     Sabino Canyon Observatory, Tucson
- 3 855  266.5383   +44.920528    255.426 0.7093    +0.7026      US/Minnesota   Wayside Observatory, Minnetonka
- 3 856  242.5540   +33.995489    380.530 0.8300    +0.5560      US/California  Riverside
- 3 857  249.3992   +31.664517   1554.678 0.85213   +0.52204     US/Arizona     Iowa Robotic Observatory, Sonoita
- 3 858  253.7800   +35.093872   2198.557 0.8194    +0.5719      US/New Mexico  Tebbutt Observatory, Edgewood
- 3 859  316.3097   -19.823982   1482.985 0.94132   -0.33707     Brazil         Wykrota Observatory-CEAMIG
- 3 860  313.0347   -23.003277    877.334 0.92108   -0.38842     Brazil         Valinhos
- 3 861  312.9204   -22.782460    589.080 0.92253   -0.38487     Brazil         Barao Geraldo
- 3 862  138.5262   +36.140884    780.881 0.80861   +0.58658     Japan          Saku
- 3 863  137.18     +36.261419  -2156.277 0.807     +0.588       Japan          Furukawa
- 3 864  130.7533   +32.675794     65.274 0.84257   +0.53680     Japan          Kumamoto
- 3 865  285.8792   +41.709352    100.308 0.74765   +0.66189     US/New York    Emmy Observatory, New Paltz
- 3 866  283.5100   +38.981367    145.244 0.7784    +0.6257      US/Maryland    U.S. Naval Academy, Michelson
- 3 867  134.1222   +35.338934    392.622 0.81671   +0.57522     Japan          Saji Observatory
- 3 868  135.1359   +33.922783     24.236 0.83066   +0.55492     Japan          Hidaka Observatory
- 3 869  133.4298   +33.493125    -26.023 0.83480   +0.54870     Japan          Tosa
- 3 870  313.17411  -22.900508   1030.194 0.921798  -0.386786    Brazil         Campinas
- 3 871  134.3925   +34.748574     30.413 0.82256   +0.56678     Japan          Akou
- 3 872  134.2411   +34.090233     91.441 0.82904   +0.55734     Japan          Tokushima
- 3 873  133.7717   +34.592760     17.631 0.82410   +0.56455     Japan          Kurashiki Observatory
- 3 874  314.41735  -22.535487   1810.714 0.924359  -0.380986    Brazil         Observatorio do Pico dos Dias, Itajuba
- 3 875  139.2353   +36.098847    140.295 0.80896   +0.58593     Japan          Yorii
- 3 876  139.2467   +36.228291     52.516 0.80762   +0.58774     Japan          Honjo
- 3 877  139.0828   +35.813560    657.927 0.81194   +0.58196     Japan          Okutama
- 3 878  136.9142   +34.987323     61.886 0.82019   +0.57019     Japan          Kagiya
- 3 879  137.3535   +35.041153    429.964 0.81970   +0.57099     Japan          Tokai
- 3 880  316.7771   -22.895183     33.313 0.92169   -0.38664     Brazil         Rio de Janeiro
- 3 881  137.2571   +35.135162    118.278 0.81872   +0.57230     Japan          Toyota
- 3 882  137.3558   +35.169063    426.624 0.81842   +0.57281     Japan          JCPM Oi Station
- 3 883  138.4215   +35.019868     20.814 0.81986   +0.57065     Japan          Shizuoka
- 3 884  138.0792   +35.140525    381.052 0.8187    +0.5724      Japan          Kawane
- 3 885  138.4667   +34.956708     21.270 0.82049   +0.56975     Japan          JCPM Yakiimo Station
- 3 886  138.9367   +35.170580     77.058 0.81836   +0.57280     Japan          Mishima
- 3 887  139.3367   +36.245194     82.816 0.80745   +0.58798     Japan          Ojima
- 3 888  138.9952   +35.124749    319.279 0.81885   +0.57217     Japan          Gekko
- 3 889  140.1427   +36.655017    132.307 0.80322   +0.59372     Japan          Karasuyama
- 3 890  140.2500   +35.919028    146.715 0.8108    +0.5834      Japan          JCPM Tone Station
- 3 891  140.8633   +38.275274     48.855 0.78606   +0.61609     Japan          JCPM Kimachi Station
- 3 892  139.4753   +36.140222     16.379 0.80852   +0.58650     Japan          YGCO Hoshikawa and Nagano Stations
- 3 893  140.86222  +38.259193     46.144 0.786233  +0.615870    Japan          Sendai Municipal Observatory
- 3 894  138.4476   +35.899059   1140.735 0.81113   +0.58321     Japan          Kiyosato
- 3 895  140.7203   +38.309121    333.545 0.78573   +0.61658     Japan          Hatamae
- 3 896  138.3678   +35.879154   1038.212 0.81132   +0.58292     Japan          Yatsugatake South Base Observatory
- 3 897  139.4929   +36.193681      7.383 0.80797   +0.58725     Japan          YGCO Chiyoda Station
- 3 898  138.1883   +34.901794    278.753 0.82107   +0.56899     Japan          Fujieda
- 3 899  142.5500   +43.840783   -251.770 0.7224    +0.6891      Japan          Toma
- 3 900  135.98994  +35.049756    102.190 0.819572  +0.571083    Japan          Moriyama
- 3 901  137.0877   +35.342668    139.106 0.81664   +0.57525     Japan          Tajimi
- 3 902  132.2208   +34.221330     15.051 0.82775   +0.55922     Japan          Ootake
- 3 903  135.17423  +35.270953     84.418 0.817354  +0.574227    Japan          Fukuchiyama and Kannabe
- 3 904  135.12     +34.617319   1122.666 0.824     +0.565       Japan          Go-Chome and Kobe-Suma
- 3 905  135.9246   +33.610193     13.370 0.83368   +0.55040     Japan          Nachi-Katsuura Observatory
- 3 906  145.667    -35.916135   3851.883 0.8113    -0.5837      Australia/VIC  Cobram
- 3 907  144.9758   -37.831574     52.102 0.79082   -0.61001     Australia/VIC  Melbourne
- 3 908  137.2467   +36.625358     68.965 0.80352   +0.59330     Japan          Toyama
- 3 909  237.8717   +47.944427     89.316 0.6711    +0.7389      US/Washington  Snohomish Hilltop Observatory
- 3 910    6.9267   +43.748916   1271.172 0.72368   +0.68811     France         Caussols-ODAS
- 3 911  282.9233   +42.118459    179.656 0.7429    +0.6672      US/New York    Collins Observatory, Corning Community College
- 3 912  288.2342   +41.706538    163.463 0.74769   +0.66186     US/Rhode Isla  Carbuncle Hill Observatory, Greene
- 3 913  303.8161   -34.912529     20.955 0.82093   -0.56912     Uruguay        Observatorio Kappa Crucis, Montevideo
- 3 914  288.0108   +42.531103    430.764 0.73809   +0.67254     US/Massachuse  Underwood Observatory, Hubbardston
- 3 915  261.8789   +29.790119    300.840 0.86861   +0.49393     US/Texas       River Oaks Observatory, New Braunfels
- 3 916  272.6836   +39.484004    175.268 0.77287   +0.63248     US/Indiana     Oakley Observatory, Terre Haute
- 3 917  237.5522   +47.143704    106.470 0.68140   +0.72948     US/Washington  Pacific Lutheran University Keck Observatory
- 3 918  257.8694   +43.990766    831.186 0.72071   +0.69110     US/South Dako  Badlands Observatory, Quinn
- 3 919  248.3183   +32.749846    261.339 0.8419    +0.5379      US/Arizona     Desert Beaver Observatory
- 3 920  282.3353   +43.075804    140.755 0.73161   +0.67947     US/New York    RIT Observatory, Rochester
- 3 921  254.4725   +32.991092   2213.814 0.83988   +0.54159     US/New Mexico  SW Institute for Space Research, Cloudcroft
- 3 922  272.8333   +34.671195    213.765 0.82335   +0.56569     US/Alabama     Timberland Observatory, Decatur
- 3 923  284.6300   +40.050923    117.074 0.76655   +0.64006     US/Pennsylvan  The Bradstreet Observatory, St. Davids
- 3 924  287.6769   +46.475621     16.057 0.68988   +0.72150     Canada/Quebec  Observatoire du Cegep de Trois-Rivieres
- 3 925  249.8589   +31.400591   1329.723 0.85450   +0.51811     US/Arizona     Palominas Observatory
- 3 926  249.1209   +31.462043   1308.766 0.85394   +0.51902     US/Arizona     Tenagra II Observatory, Nogales
- 3 927  270.56194  +42.790800    276.949 0.735007  +0.675850    US/Wisconsin   Madison-YRS
- 3 928  286.6761   +40.905185    -10.854 0.75688   +0.65136     US/New York    Moonedge Observatory, Northport
- 3 929  268.7758   +30.407442     11.532 0.86319   +0.50319     US/Louisiana   Port Allen
- 3 930  210.41224  -17.551379     98.541 0.953752  -0.299638    Tahiti         S. S. Observatory, Pamatai
- 3 931  210.3842   -17.634072    -23.897 0.95330   -0.30100     Tahiti         Puna'auia
- 3 932  286.57401  +41.525747     45.086 0.749767  +0.659494    US/Connecticu  John J. McCarthy Obs., New Milford
- 3 933  249.7342   +31.476137   1442.880 0.85383   +0.51924     US/Arizona     Rockland Observatory, Sierra Vista
- 3 934  242.9572   +32.967432    282.660 0.83985   +0.54108     US/California  Poway Valley
- 3 935  282.3394   +38.855930    132.138 0.77977   +0.62400     US/Virginia    Wyrick Observatory, Haymarket
- 3 936  263.3792   +39.188979    296.443 0.77614   +0.62852     US/Kansas      Ibis Observatory, Manhattan
- 3 937  358.6900   +54.594859     33.548 0.58065   +0.81143     UK/England     Bradbury Observatory, Stockton-on-Tees
- 3 938  351.6162   +39.522688     79.114 0.77243   +0.63299     Portugal       Linhaceira
- 3 939  359.6033   +39.759895    281.258 0.76982   +0.63619     Spain          Observatorio Rodeno
- 3 940  358.9611   +50.897187      9.138 0.63199   +0.77238     UK/England     Waterlooville
- 3 941  359.6139   +39.752833    126.770 0.76988   +0.63608     Spain          Observatorio Pla D'Arguines
- 3 942  359.3636   +52.926889     81.770 0.60413   +0.79423     UK/England     Grantham
- 3 943  355.8664   +50.391587     24.761 0.63881   +0.76679     UK/England     Peverell
- 3 944  354.08315  +37.281246     49.918 0.796657  +0.602418    Spain          Observatorio Geminis, Dos Hermanas
- 3 945  354.3986   +43.488901    433.897 0.72671   +0.68474     Spain          Observatorio Monte Deva
- 3 946    0.7931   +40.929721    156.381 0.75662   +0.65170     Spain          Ametlla de Mar
- 3 947    2.1244   +49.351780     80.058 0.65268   +0.75511     France         Saint-Sulpice
- 3 948    0.2189   +52.468571    -30.858 0.61048   +0.78937     UK/England     Pymoor
- 3 949  359.8169   +47.677637     32.582 0.67454   +0.73577     France         Durtal
- 3 950  342.1176   +28.760222   2320.790 0.87764   +0.47847     Canary Island  La Palma
- 3 951  358.2983   +51.636471    103.059 0.62194   +0.78046     UK/England     Highworth
- 3 952  359.7583   +38.952660     28.545 0.7787    +0.6253      Spain          Marxuquera
- 3 953    2.1339   +41.859061   1018.006 0.74602   +0.66393     Spain          Montjoia
- 3 954  343.4906   +28.298383   2362.774 0.88148   +0.47142     Canary Island  Teide Observatory
- 3 955  350.6739   +38.700163     66.570 0.78146   +0.62188     Portugal       Sassoeiros
- 3 956  356.1908   +40.440581    727.178 0.76224   +0.64530     Spain          Observatorio Pozuelo
- 3 957  359.3506   +44.823124      9.039 0.71047   +0.70137     France         Merignac
- 3 958  358.96947  +43.693384     82.648 0.724214  +0.687282    France         Observatoire de Dax
- 3 959    1.4653   +43.549352    215.147 0.72596   +0.68548     France         Ramonville Saint Agne
- 3 960    0.6108   +51.032485     40.027 0.63016   +0.77387     UK/England     Rolvenden
- 3 961  356.8206   +55.956698    109.992 0.56112   +0.82498     UK/Scotland    City Observatory, Calton Hill, Edinburgh
- 3 962  359.8188   +38.975541     32.074 0.77845   +0.62561     Spain          Gandia
- 3 963  359.7333   +52.616547   -352.798 0.6084    +0.7909      UK/England     Werrington
- 3 964  358.8433   +51.433687    106.005 0.62471   +0.77826     UK/England     Southend Bradfield
- 3 965  351.4008   +37.191463    111.199 0.79761   +0.60118     Portugal       Observacao Astronomica no Algarve, Portimao
- 3 966  357.20423  +52.534468    211.444 0.609591  +0.790100    UK/England     Church Stretton
- 3 967  358.9778   +52.136567    145.547 0.61508   +0.78585     UK/England     Greens Norton
- 3 968    0.4250   +52.084635    197.347 0.6158    +0.7853      UK/England     Haverhill
- 3 969  359.8454   +51.521519    -10.013 0.6235    +0.7792      UK/England     London-Regents Park
- 3 970    0.4954   +51.744716     17.336 0.62045   +0.78162     UK/England     Chelmsford
- 3 971  350.81249  +38.711792     87.532 0.781336  +0.622040    Portugal       Lisbon
- 3 972  357.5833   +57.160100    125.068 0.54359   +0.83656     UK/Scotland    Dun Echt
- 3 973  359.6671   +51.579445      3.680 0.62271   +0.77983     UK/England     Harrow
- 3 974    8.84431  +44.434647    171.397 0.715243  +0.696571    Italy          Genoa Observatory
- 3 975  359.6333   +39.478187     56.428 0.77292   +0.63239     Spain          Observatorio Astronomico de Valencia
- 3 976  358.4669   +52.317598    108.710 0.61258   +0.78778     UK/England     Leamington Spa
- 3 977  351.5483   +54.175554     44.465 0.58660   +0.80717     Ireland        Markree
- 3 978  357.24541  +54.028476    107.377 0.588685  +0.805673    UK/England     Conder Brow
- 3 979  358.6697   +51.121308     94.227 0.62896   +0.77485     UK/England     South Wonston
- 3 980  357.2200   +54.031472     78.168 0.58864   +0.80570     UK/England     Lancaster
- 3 981  353.3522   +54.352872     65.193 0.58409   +0.80898     UK/NIreland    Armagh
- 3 982  353.6621   +53.386636     80.068 0.59771   +0.79904     Ireland        Dunsink Observatory, Dublin
- 3 983  353.79525  +36.465879     27.531 0.805167  +0.591067    Spain          San Fernando
- 3 984  357.26975  +50.921432    102.412 0.631671  +0.772658    UK/England     Eastfield
- 3 985  357.5317   +52.648228    165.118 0.60801   +0.79130     UK/England     Telford
- 3 986  359.36053  +51.408914    118.040 0.625049  +0.777992    UK/England     Ascot
- 3 987  355.3735   +54.177825    176.666 0.58658   +0.80721     UK/Isle of Ma  Isle of Man Observatory, Foxdale
- 3 988  355.7060   +55.878367     81.272 0.56225   +0.82421     UK/Scotland    Glasgow
- 3 989  357.40582  +53.801442    119.681 0.591888  +0.803341    UK/England     Wilfred Hall Observatory, Preston
- 3 990  356.3121   +40.408374    696.708 0.76260   +0.64487     Spain          Madrid
- 3 991  356.9278   +53.401423     49.380 0.59750   +0.79919     UK/England     Liverpool (since 1867)
- 3 992  356.9995   +53.414384   -147.729 0.5973    +0.7993      UK/England     Liverpool (before 1867)
- 3 993  357.49556  +51.046536     96.570 0.629975  +0.774031    UK/England     Woolston Observatory
- 3 994  359.3878   +51.171894     65.251 0.62827   +0.77540     UK/England     Godalming
- 3 995  358.4177   +54.768164    122.181 0.57819   +0.81319     UK/England     Durham
- 3 996  358.7483   +51.759752     79.174 0.62025   +0.78179     UK/England     Oxford
- 3 997  359.15     +51.858946   1215.495 0.619     +0.783       UK/England     Hartwell
- 3 998  359.75753  +51.613320     76.314 0.622254  +0.780206    UK/England     London-Mill Hill
- 3 999  359.4725   +44.835301     95.206 0.71033   +0.70153     France         Bordeaux-Floirac
- 3 A00    0.3770   +51.430107     15.718 0.62475   +0.77821     UK/England     Gravesend
- 3 A01    0.7441   +42.017901    751.734 0.74414   +0.66596     Spain          Masia Cal Maciarol Modul 2
- 3 A02    0.7441   +42.017901    751.734 0.74414   +0.66596     Spain          Masia Cal Maciarol Modul 8
- 3 A03    1.4000   +41.150366    177.991 0.7541    +0.6546      Spain          Torredembarra
- 3 A04    1.7181   +43.873347    217.357 0.72206   +0.68956     France         Saint-Caprais
- 3 A05    1.8175   +43.445408    247.397 0.72721   +0.68417     France         Belesta
- 3 A06    2.4417   +41.573486     82.343 0.74922   +0.66012     Spain          Mataro
- 3 A07    2.7444   +48.742768     80.390 0.66070   +0.74815     France         Gretz-Armainvilliers
- 3 A08    2.8847   +43.435297    413.335 0.72735   +0.68406     France         Malibert
- 3 A09    1.1803   +49.527000    190.749 0.65037   +0.75711     France         Quincampoix
- 3 A10    1.9281   +41.266410    273.045 0.75278   +0.65613     Spain          Observatorio Astronomico de Corbera
- 3 A11    2.4718   +50.880083     -5.750 0.63222   +0.77219     France         Wormhout
- 3 A12    8.74768  +45.396541    122.186 0.703404  +0.708434    Italy          Stazione Astronomica di Sozzago
- 3 A13    7.1394   +46.762386    691.525 0.68632   +0.72501     Switzerland    Observatoire Naef, Ependes
- 3 A14    5.1864   +44.021537    320.799 0.72028   +0.69143     France         Les Engarouines Observatory
- 3 A15    6.7972   +51.848743     79.681 0.61903   +0.78275     Germany        Josef Bresser Sternwarte, Borken
- 3 A16    7.1922   +46.770495    719.330 0.68622   +0.72511     Switzerland    Tentlingen
- 3 A17    8.68147  +49.545453    267.623 0.650133  +0.757328    Germany        Guidestar Observatory, Weinheim
- 3 A18    7.1761   +51.527963     71.984 0.62342   +0.77928     Germany        Herne
- 3 A19    7.0744   +50.923246     37.189 0.63164   +0.77267     Germany        Koln
- 3 A20    7.51887  +52.844412     44.392 0.605274  +0.793357    Germany        Sogel
- 3 A21    8.0581   +50.553007    340.507 0.63667   +0.76862     Germany        Irmtraut
- 3 A22    8.6531   +49.647790    228.075 0.64877   +0.75848     Germany        Starkenburg Sternwarte-SOHAS
- 3 A23    8.6677   +49.534340    164.957 0.65027   +0.75719     Germany        Weinheim
- 3 A24    8.9481   +45.675313    240.623 0.69995   +0.71185     Italy          New Millennium Observatory, Mozzate
- 3 A25    9.1925   +45.587262    177.892 0.70104   +0.71077     Italy          Nova Milanese
- 3 A26    8.65736  +49.810438    140.768 0.646597  +0.760303    Germany        Darmstadt
- 3 A27   10.3236   +51.908175    241.421 0.61823   +0.78341     Germany        Eridanus Observatory, Langelsheim
- 3 A28   10.3342   +47.726489    695.295 0.67398   +0.73642     Germany        Kempten
- 3 A29   10.6733   +43.736494     38.357 0.72369   +0.68782     Italy          Santa Maria a Monte
- 3 A30   11.22308  +45.645137    887.541 0.700397  +0.711555    Italy          Crespadoro
- 3 A31   11.4186   +45.651379    164.720 0.70024   +0.71155     Italy          Corcaroli Observatory
- 3 A32   10.5517   +54.342680     15.560 0.58423   +0.80887     Germany        Panker
- 3 A33   11.0157   +50.875357    257.488 0.63231   +0.77217     Germany        Volkssternwarte Kirchheim
- 3 A34   10.7911   +49.598090    324.049 0.64944   +0.75793     Germany        Grosshabersdorf
- 3 A35   12.8978   +50.670518    582.728 0.63511   +0.76995     Germany        Hormersdorf Observatory
- 3 A36    9.7911   +45.794504   1132.237 0.69856   +0.71340     Italy          Ganda di Aviatico
- 3 A37   13.6634   +52.411257     45.972 0.61128   +0.78877     Germany        Mueggelheim
- 3 A38   13.3747   +41.764900    561.688 0.74706   +0.66266     Italy          Campocatino Automated Telescope, Collepardo
- 3 A39   12.4186   +50.983787    240.765 0.63084   +0.77336     Germany        Altenburg
- 3 A40   14.4978   +35.895108    114.773 0.81104   +0.58306     Malta          Pieta
- 3 A41   14.5911   +46.239745    432.217 0.69290   +0.71871     Slovenia       Rezman Observatory, Kamnik
- 3 A42    9.5019   +52.301311     58.124 0.61280   +0.78760     Germany        Gehrden
- 3 A43   13.0897   +52.358521     58.514 0.61201   +0.78821     Germany        Inastars Observatory, Potsdam (before 2006)
- 3 A44   13.6972   +48.332991    426.062 0.66609   +0.74346     Austria        Altschwendt
- 3 A45    9.3620   +51.395188    259.830 0.62525   +0.77786     Germany        Karrenkneul
- 3 A46   16.5825   +49.292629    351.728 0.65349   +0.75447     Czech Republi  Lelekovice
- 3 A47   16.6031   +40.668886    429.851 0.75962   +0.64829     Italy          Matera
- 3 A48   10.8885   +45.347038     50.403 0.70401   +0.70782     Italy          Povegliano Veronese
- 3 A49   17.6372   +59.837517     52.077 0.50372   +0.86098     Sweden         Uppsala-Angstrom
- 3 A50   28.9973   +50.000576    235.831 0.64407   +0.76245     Ukraine        Andrushivka Astronomical Observatory
- 3 A51   18.6667   +54.381717    274.887 0.5837    +0.8093      Poland         Danzig
- 3 A52   18.7553   +47.444102    180.493 0.67756   +0.73304     Hungary        Etyek
- 3 A53   10.6883   +45.433875    116.175 0.70294   +0.70889     Italy          Peschiera del Garda
- 3 A54   16.6217   +52.628276     94.881 0.60828   +0.79108     Poland         Ostrorog
- 3 A55   13.1181   +42.485891   1191.038 0.73871   +0.67204     Italy          Osservatorio Astronomico Vallemare di Borbona
- 3 A56   10.3197   +44.534187    459.733 0.71406   +0.69784     Italy          Parma
- 3 A57   11.1031   +43.742211    204.823 0.72364   +0.68791     Italy          Osservatorio Astron. Margherita Hack, Firenze
- 3 A58    2.4694   +48.693184     83.639 0.66135   +0.74758     France         Observatoire de Chalandray-Canotiers
- 3 A59   12.9071   +50.215609    608.107 0.64123   +0.76490     Czech Republi  Karlovy Vary Observatory
- 3 A60   20.8106   -32.379699   1740.106 0.84556   -0.53260     South Africa   YSTAR-NEOPAT Station, Sutherland
- 3 A61    8.8581   +44.903887    122.959 0.70949   +0.70238     Italy          Tortona
- 3 A62    9.2301   +48.620677    381.757 0.66233   +0.74678     Germany        Aichtal
- 3 A63    4.7567   +45.768240    235.435 0.69879   +0.71298     France         Cosmosoz Obs., Tassin la Demi Lune
- 3 A64    6.1151   +46.449376   1204.783 0.69034   +0.72132     Switzerland    Couvaloup de St-Cergue
- 3 A65    2.4083   +44.096659    499.448 0.71939   +0.69239     France         Le Couvent de Lentin
- 3 A66   10.3161   +43.533474     34.491 0.72613   +0.68526     Italy          Stazione Osservativa Astronomica, Livorno
- 3 A67    7.6785   +44.322746    558.823 0.71665   +0.69522     Italy          Chiusa di Pesio
- 3 A68    9.6533   +54.812329      9.444 0.57755   +0.81362     Germany        Swedenborg Obs., Bockholmwik
- 3 A69   11.3300   +43.321153    276.102 0.7287    +0.6826      Italy          Osservatorio Palazzo Bindi Sergardi
- 3 A70   25.2033   +64.826072     22.266 0.42654   +0.90144     Finland        Lumijoki
- 3 A71   15.4533   +48.428775    603.536 0.66486   +0.74459     Austria        Stixendorf
- 3 A72   13.6222   +51.116298    215.914 0.62904   +0.77481     Germany        Radebeul Observatory
- 3 A73   16.2895   +48.194141    268.403 0.66788   +0.74183     Austria        Penzing Astrometric Obs., Vienna
- 3 A74    8.76240  +50.158743    201.406 0.641951  +0.764216    Germany        Bergen-Enkheim Observatory
- 3 A75    2.1861   +41.398125     58.406 0.75124   +0.65783     Spain          Fort Pius Observatory, Barcelona
- 3 A76   20.8356   +48.069906    144.837 0.66948   +0.74037     Hungary        Andromeda Observatory, Miskolc
- 3 A77    5.64693  +43.999793    673.761 0.720583  +0.691196    France         Observatoire Chante-Perdrix, Dauban
- 3 A78   11.71509  +43.135211    500.041 0.730944  +0.680264    Italy          Stia
- 3 A79   23.84340  +42.063583   1428.726 0.743686  +0.666622    Bulgaria       Zvezdno Obshtestvo Observatory, Plana
- 3 A80   14.1222   +52.208909    113.094 0.61408   +0.78662     Germany        Lindenberg Observatory
- 3 A81   12.4033   +41.869968     48.280 0.74578   +0.66397     Italy          Balzaretto Observatory, Rome
- 3 A82   13.8744   +45.643237    425.113 0.70037   +0.71148     Italy          Osservatorio Astronomico di Trieste
- 3 A83   29.9969   +62.727467    138.254 0.45945   +0.88525     Finland        Jakokoski Observatory
- 3 A84   30.3333   +36.825271   2538.725 0.80175   +0.59632     Turkey         TUBITAK National Observatory
- 3 A85   30.8065   +46.560440     40.342 0.68881   +0.72252     Ukraine        Odesa  Astronomical Observatory, Kryzhanovka
- 3 A86    4.3547   +45.537721    574.856 0.70170   +0.71021     France         Albigneux
- 3 A87    8.7662   +49.603879    194.878 0.64935   +0.75798     Germany        Rimbach
- 3 A88    8.90133  +44.456799     66.399 0.714961  +0.696835    Italy          Bolzaneto
- 3 A89   10.3308   +47.708625    691.308 0.67421   +0.73621     Germany        Sterni Observatory, Kempten
- 3 A90    2.1431   +41.401798     77.930 0.75120   +0.65788     Spain          Sant Gervasi Observatory, Barcelona
- 3 A91   26.5997   +62.254457    122.560 0.46678   +0.88143     Finland        Hankasalmi Observatory
- 3 A92   26.0927   +44.448518     48.129 0.71506   +0.69673     Romania        Urseanu Observatory, Bucharest
- 3 A93   10.4189   +43.858291     24.931 0.72222   +0.68935     Italy          Lucca
- 3 A94   13.4577   +45.957361    100.956 0.69641   +0.71526     Italy          Cormons
- 3 A95   28.3892   +62.315387    157.417 0.46584   +0.88193     Finland        Taurus Hill Observatory, Varkaus
- 3 A96   16.2867   +48.296458    371.466 0.66656   +0.74303     Austria        Klosterneuburg
- 3 A97   16.4219   +48.302648    185.276 0.66646   +0.74308     Austria        Stammersdorf
- 3 A98   30.2092   +54.491084    195.234 0.58214   +0.81040     Belarus        Observatory Mazzarot-1, Baran'
- 3 A99   10.8589   +45.697524   1217.377 0.69978   +0.71223     Italy          Osservatorio del Monte Baldo
- 3 B00    2.5767   +48.575344     64.763 0.66289   +0.74622     France         Savigny-le-Temple
- 3 B01    8.4464   +50.221554    804.379 0.64117   +0.76499     Germany        Taunus Observatory, Frankfurt
- 3 B02   20.6566   +50.881003    322.153 0.63224   +0.77224     Poland         Kielce
- 3 B03   16.2698   +48.217246    367.130 0.66759   +0.74211     Austria        Alter Satzberg, Vienna
- 3 B04    7.47851  +45.789693   1652.565 0.698677  +0.713400    Italy          OAVdA, Saint-Barthelemy
- 3 B05   37.8831   +55.247706    200.521 0.57134   +0.81800     Russia         Ka-Dar Observatory, Barybino
- 3 B06    2.53372  +41.721521    194.404 0.747520  +0.662058    Spain          Montseny Astronomical Observatory
- 3 B07    9.0033   +46.164298    256.242 0.69383   +0.71778     Switzerland    Camorino
- 3 B08   11.3807   +44.455830    130.564 0.71498   +0.69683     Italy          San Lazzaro di Savena
- 3 B09   10.6708   +43.586269     67.483 0.72550   +0.68593     Italy          Capannoli
- 3 B10    5.5150   +44.408000    814.701 0.71564   +0.69631     France         Observatoire des Baronnies Provencales, Moydans
- 3 B11   10.6286   +45.775422   1238.485 0.69881   +0.71318     Italy          Osservatorio Cima Rest, Magasa
- 3 B12    4.4906   +52.265418      2.333 0.61329   +0.78721     Netherlands    Koschny Observatory, Noordwijkerhout
- 3 B13    8.9311   +45.712229    335.414 0.69950   +0.71231     Italy          Osservatorio di Tradate
- 3 B14    9.0758   +44.817867    687.376 0.71061   +0.70138     Italy          Ca del Monte
- 3 B15   13.0129   +52.423524     41.749 0.61111   +0.78890     Germany        Inastars Observatory, Potsdam (since 2006)
- 3 B16   36.9547   +55.770495    218.429 0.56382   +0.82317     Russia         1st Moscow Gymnasium Observatory, Lipki
- 3 B17   33.16280  +45.219533     43.480 0.705588  +0.706256    Ukraine        AZT-8 Yevpatoriya
- 3 B18   42.5008   +43.274820   3136.309 0.72958   +0.68232     Russia         Terskol
- 3 B19    2.4414   +41.538100     92.972 0.74963   +0.65966     Spain          Observatorio Iluro, Mataro
- 3 B20    2.2636   +41.484450    185.139 0.75026   +0.65897     Spain          Observatorio Carmelita, Tiana
- 3 B21   13.4744   +48.543040    428.750 0.66335   +0.74589     Austria        Gaisberg Observatory, Schaerding
- 3 B22    0.7441   +42.019523    742.352 0.74412   +0.66598     Spain          Observatorio d'Ager
- 3 B23   10.9710   +45.575852    706.249 0.70124   +0.71069     Italy          Fiamene
- 3 B24    2.5983   +48.554195     98.997 0.66317   +0.74598     France         Cesson
- 3 B25   15.0557   +37.548790    304.378 0.79386   +0.60614     Italy          Catania
- 3 B26    5.6667   +43.878280    567.472 0.72204   +0.68966     France         Observatoire des Terres Blanches, Reillanne
- 3 B27   14.1544   +48.476639    743.968 0.66425   +0.74516     Austria        Picard Observatory, St. Veit
- 3 B28   13.1836   +46.097357    154.472 0.69466   +0.71696     Italy          Mandi Observatory, Pagnacco
- 3 B29    0.6701   +40.807126     99.824 0.75801   +0.65008     Spain          L'Ampolla Observatory, Tarragona
- 3 B30   16.5689   +52.596406     75.903 0.60872   +0.79074     Poland         Szamotuly-Galowo
- 3 B31   20.8108   -32.375553   1750.640 0.84560   -0.53254     South Africa   Southern African Large Telescope, Sutherland
- 3 B32   12.9486   +50.702747    531.865 0.63467   +0.77030     Germany        Gelenau
- 3 B33   10.7783   +43.555428    152.971 0.72588   +0.68555     Italy          Libbiano Observatory, Peccioli
- 3 B34   33.7258   +35.258463     88.795 0.81748   +0.57405     Cyprus         Green Island Observatory, Gecitkale
- 3 B35   35.0317   +31.888210    265.605 0.84991   +0.52524     Israel         Bareket Observatory, Macabim
- 3 B36   13.7125   +48.274928    369.544 0.66684   +0.74278     Austria        Redshed Observatory, Kallham
- 3 B37    2.25934  +41.651214    226.400 0.748338  +0.661147    Spain          Obs. de L' Ametlla del Valles, Barcelona
- 3 B38   11.85746  +43.630911    344.002 0.724995  +0.686523    Italy          Santa Mama
- 3 B39    8.9072   +45.712229    335.414 0.69950   +0.71231     Italy          Tradate
- 3 B40   15.0706   +37.602675    480.120 0.79331   +0.60690     Italy          Skylive Observatory, Catania
- 3 B41   17.6925   +49.217367    407.314 0.65449   +0.75362     Czech Republi  Zlin Observatory
- 3 B42   30.3275   +55.061283    194.475 0.57401   +0.81614     Belarus        Vitebsk
- 3 B43    7.3089   +50.746314    111.206 0.63404   +0.77073     Germany        Hennef
- 3 B44    5.5906   +44.237548    858.200 0.71772   +0.69419     France         Eygalayes
- 3 B45   19.9356   +50.179564    379.228 0.64169   +0.76447     Poland         Narama
- 3 B46   12.05439  +44.504404      4.913 0.714373  +0.697420    Italy          Sintini Observatory, Alfonsine
- 3 B47   24.7503   +60.198376     51.788 0.49826   +0.86413     Finland        Metsala Observatory, Espoo
- 3 B48    6.5981   +51.849644      0.881 0.61901   +0.78275     Germany        Bocholt
- 3 B49    2.11250  +41.551035    241.169 0.749498  +0.659844    Spain          Paus Observatory, Sabadell
- 3 B50    8.2767   +48.942718    127.517 0.65808   +0.75045     Germany        Corner Observatory, Durmersheim
- 3 B51    7.06669  +43.577678    145.248 0.725612  +0.685830    France         Vallauris
- 3 B52    2.99725  +42.250063     34.133 0.741344  +0.668883    Spain          Observatorio El Far
- 3 B53   12.3536   +41.875261     61.326 0.74572   +0.66404     Italy          Casal Lumbroso, Rome
- 3 B54    0.7439   +42.018712    747.042 0.74413   +0.66597     Spain          Ager
- 3 B55   12.87600  +46.507990    777.480 0.689553  +0.721975    Italy          Comeglians
- 3 B56    2.44935  +41.538838     29.275 0.749614  +0.659663    Spain          Observatorio Sant Pere, Mataro
- 3 B57    2.22439  +41.565488    112.997 0.749316  +0.660019    Spain          Laietania Observatory, Parets del Valles
- 3 B58   19.02529  +47.553014    140.081 0.676156  +0.734318    Hungary        Polaris Observatory, Budapest
- 3 B59    6.87881  +51.833875     49.273 0.619231  +0.782586    Germany        Borken
- 3 B60    7.17531  +52.299382     30.615 0.612824  +0.787576    Germany        Deep Sky Observatorium, Bad Bentheim
- 3 B61    2.04350  +41.456722    144.638 0.750575  +0.658604    Spain          Valldoreix Obs.,Sant Cugat del Valles
- 3 B62    9.68531  +52.556305     69.281 0.609275  +0.790314    Germany        Brelingen
- 3 B63   20.10799  +50.111626    273.790 0.642589  +0.763698    Poland         Solaris Observatory, Luczanowice
- 3 B64   24.88779  +60.637874    101.711 0.491587  +0.867927    Finland        Slope Rock Observatory, Hyvinkaa
- 3 B65   24.3878   +60.173240     39.353 0.49864   +0.86391     Finland        Komakallio Observatory, Kirkkonummi
- 3 B66    9.00693  +44.816520    403.721 0.710595  +0.701332    Italy          Osservatorio di Casasco
- 3 B67    9.22419  +46.804169   1332.507 0.685858  +0.725582    Switzerland    Sternwarte Mirasteilas, Falera
- 3 B68   13.53950  +46.203214   1338.054 0.693458  +0.718372    Italy          Mount Matajur Observatory
- 3 B69    9.01719  +48.635010    473.777 0.662152  +0.746956    Germany        Owls and Ravens Observatory, Holzgerlingen
- 3 B70    2.4937   +41.690658    129.680 0.74787   +0.66165     Spain          Sant Celoni
- 3 B71    1.5213   +41.189751     20.779 0.75363   +0.65510     Spain          Observatorio El Vendrell
- 3 B72    7.68105  +50.698830    311.596 0.634701  +0.770230    Germany        Soerth Observatory
- 3 B73    8.98503  +48.641134    494.486 0.662074  +0.747029    Germany        Mauren Valley Observatory, Holzgerlingen
- 3 B74    1.10536  +41.720161    315.999 0.747550  +0.662053    Spain          Santa Maria de Montmagastrell
- 3 B75    8.80519  +45.584704    197.535 0.701074  +0.710741    Italy          Stazione Astronomica Betelgeuse, Magnago
- 3 B76   13.8944   +51.032229    309.130 0.63019   +0.77390     Germany        Sternwarte Schonfeld, Dresden
- 3 B77    7.95083  +47.420270    821.790 0.677934  +0.732833    Switzerland    Schafmatt Observatory, Aarau
- 3 B78   14.12811  +47.963497    392.923 0.670885  +0.739158    Austria        Astrophoton Observatory, Audorf
- 3 B79   11.20990  +45.637801    810.756 0.700480  +0.711457    Italy          Marana Observatory
- 3 B80   12.74126  +42.173959    201.978 0.742254  +0.667919    Italy          Osservatorio Astronomico Campomaggiore
- 3 B81    2.8990   +39.772030    157.831 0.76967   +0.63634     Spain          Caimari
- 3 B82    9.9716   +49.846325    251.647 0.64613   +0.76072     Germany        Maidbronn
- 3 B83    5.79769  +45.184993    214.841 0.706034  +0.705851    France         Gieres
- 3 B84    3.53775  +51.571978      3.253 0.622812  +0.779749    Netherlands    Cyclops Observatory, Oostkapelle
- 3 B85    6.51011  +52.866626     12.135 0.604962  +0.793587    Netherlands    Beilen Observatory
- 3 B86    7.45561  +51.345508    300.749 0.625931  +0.777324    Germany        Sternwarte Hagen
- 3 B87    2.7701   +42.114404    202.344 0.74295   +0.66715     Spain          Banyoles
- 3 B88    8.29681  +44.816595    187.212 0.710570  +0.701309    Italy          Bigmuskie Observatory, Mombercelli
- 3 B89    2.2619   +41.491795    225.443 0.75018   +0.65907     Spain          Observatori Astronomic de Tiana
- 3 B90   13.29686  +46.150357    152.761 0.693994  +0.717600    Italy          Malina River Observatory, Povoletto
- 3 B91    7.25544  +47.864977    291.348 0.672149  +0.737995    France         Bollwiller
- 3 B92    0.27539  +47.169202     95.867 0.681073  +0.729781    France         Chinon
- 3 B93    6.47856  +52.712619     11.928 0.607102  +0.791962    Netherlands    Hoogeveen
- 3 B94   34.2817   +61.772379    143.303 0.47422   +0.87748     Russia         Petrozavodsk
- 3 B95    8.15450  +53.047909      8.682 0.602437  +0.795492    Germany        Achternholt
- 3 B96    4.31031  +51.163512      5.304 0.628378  +0.775301    Belgium        Brixiis Observatory, Kruibeke
- 3 B97    6.1118   +52.004797      8.413 0.61688   +0.78442     Netherlands    Sterrenwacht Andromeda, Meppel
- 3 B98   11.31300  +43.317796    327.652 0.728746  +0.682563    Italy          Siena
- 3 B99    0.7443   +42.019139    789.736 0.74413   +0.66598     Spain          Santa Coloma de Gramenet
- 3 C00   30.5150   +56.321628    112.714 0.55583   +0.82853     Russian        Velikie Luki
- 3 C01   13.92293  +51.027264    386.831 0.630265  +0.773855    Germany        Lohrmann-Observatorium, Triebenberg
- 3 C02    2.5305   +41.731336    141.085 0.74740   +0.66218     Spain          Observatorio Royal Park
- 3 C03   24.96114  +60.552084     93.268 0.492892  +0.867190    Finland        Clayhole Observatory, Jokela
- 3 C04   37.6331   +48.797639     75.718 0.65998   +0.74878     Ukraine        Kramatorsk
- 3 C05   12.1153   +47.247514   1587.071 0.68023   +0.73088     Austria        Konigsleiten
- 3 C06   92.9744   +56.012308    163.273 0.56032   +0.82553     Russia         Krasnoyarsk
- 3 C07    0.7442   +42.018712    747.042 0.74413   +0.66597     Spain          Anysllum Observatory, Ager
- 3 C08   17.3761   +59.883671     16.669 0.50302   +0.86138     Sweden         Fiby
- 3 C09    3.80397  +43.823490    202.409 0.722660  +0.688932    France         Rouet
- 3 C10    3.42622  +48.717713    183.468 0.661039  +0.747874    France         Maisoncelles
- 3 C11   14.0901   +50.236680    233.752 0.64091   +0.76509     Czech Republi  City Observatory, Slany
- 3 C12    2.1107   +41.535717    199.354 0.74967   +0.65964     Spain          Berta Observatory, Sabadell
- 3 C13    9.10031  +45.805083    255.581 0.698332  +0.713430    Italy          Como
- 3 C14   15.96700  +48.150634    438.398 0.668463  +0.741344    Austria        Sky Vistas Observatory, Eichgraben
- 3 C15  132.1656   +43.698384    313.604 0.72418   +0.68737     Russia         ISON-Ussuriysk Observatory
- 3 C16   11.57261  +47.749381    717.692 0.673687  +0.736691    Germany        Isarwinkel Observatory, Bad Tolz
- 3 C17    0.74381  +42.019284    752.767 0.744124  +0.665978    Spain          Observatorio Joan Roget, Ager
- 3 C18    3.60400  +50.683525    114.717 0.634888  +0.770037    Belgium        Frasnes-Lez-Anvaing
- 3 C19    5.4231   +44.384037    617.262 0.71591   +0.69599     France         ROSA Observatory, Vaucluse
- 3 C20   42.66191  +43.741564   2069.489 0.723859  +0.688104    Russia         Kislovodsk Mtn. Astronomical Stn., Pulkovo Obs.
- 3 C21    0.74383  +42.019284    752.767 0.744124  +0.665978    Spain          Observatorio Via Lactea, Ager
- 3 C22   12.9599   +50.415635    957.333 0.63858   +0.76717     Germany        Oberwiesenthal
- 3 C23    5.15439  +51.140448     32.658 0.628694  +0.775052    Belgium        Olmen
- 3 C24    9.1331   +45.642443    243.712 0.70036   +0.71145     Italy          Seveso
- 3 C25   13.55806  +42.444217   2140.918 0.739310  +0.671605    Italy          Pulkovo Observatory Station, Campo Imperatore
- 3 C26    4.49928  +52.155052     17.072 0.614813  +0.786032    Netherlands    Levendaal Observatory, Leiden
- 3 C27    1.35302  +41.618091    582.800 0.748763  +0.660753    Spain          Pallerols
- 3 C28    7.48300  +51.469481    129.685 0.624224  +0.778652    Germany        Wellinghofen
- 3 C29    1.07889  +42.617886   1597.762 0.737202  +0.673777    Spain          Observatori Astronomic de Les Planes de Son
- 3 C30   35.3425   +61.403580     41.680 0.47988   +0.87440     Russia         Petrozavodsk University Obs., Sheltozero Stn.
- 3 C31    6.9825   +51.208962    104.276 0.62777   +0.77581     Germany        Sternwarte Neanderhoehe Hochdahl e.V., Erkrath
- 3 C32   41.4258   +43.649619   2017.973 0.72496   +0.68694     Russia         Ka-Dar Observatory, TAU Station, Nizhny Arkhyz
- 3 C33    2.8989   +39.772030    157.831 0.76967   +0.63634     Spain          Observatorio CEAM, Caimari
- 3 C34   19.0108   +46.180557    112.791 0.69361   +0.71796     Hungary        Baja Astronomical Observatory
- 3 C35    2.0349   +41.571580    320.922 0.74927   +0.66012     Spain          Terrassa
- 3 C36   30.3086   +54.479628    165.064 0.58230   +0.81028     Belarus        Starry Wanderer Observatory, Baran'
- 3 C37    1.01830  +52.196794     60.917 0.614242  +0.786484    UK/England     Stowupland
- 3 C38    7.64911  +45.405815    422.562 0.703322  +0.708581    Italy          Varuna Observatory, Cuorgne
- 3 C39    5.7992   +51.829232      1.013 0.61929   +0.78253     Netherlands    Nijmegen
- 3 C40   39.0308   +45.019547     69.270 0.70806   +0.70380     Russia         Kuban State University Astrophysical Observatory
- 3 C41   42.66126  +43.741685   2064.683 0.723857  +0.688105    Russia         MASTER-II Observatory, Kislovodsk
- 3 C42   87.1778   +43.471021   2065.686 0.72711   +0.68469     China          Xingming Observatory, Mt. Nanshan
- 3 C43   14.2792   +51.448370    108.880 0.62451   +0.77842     Germany        Hoyerswerda
- 3 C44    9.02239  +45.975463    879.158 0.696268  +0.715567    Italy          A. Volta Observatory, Lanzo d'Intelvi
- 3 C45   12.40639  +41.988382    142.100 0.744413  +0.665514    Italy          La Giustiniana
- 3 C46   69.12219  +54.878195    119.250 0.576620  +0.814296    Kazakhstan     Horizon Observatory, Petropavlovsk
- 3 C47   15.2356   +48.786797    538.182 0.66017   +0.74871     Austria        Nonndorf
- 3 C48  100.9214   +51.619826   1976.399 0.62235   +0.78051     Russia         Sayan Solar Observatory, Irkutsk
--2 C49    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  STEREO-A
--2 C50    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  STEREO-B
--2 C51    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  WISE
--2 C52    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Swift
--2 C53    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  NEOSSat
--2 C54    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  New Horizons
--2 C55    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Kepler
--2 C56    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  LISA-Pathfinder
--2 C57    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  TESS
--2 C58    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  NEO Surveyor
--2 C59    0.000000  +0.000000      0.000 0.0000000 +0.0000000                  Yangwang-1
- 3 C60    7.06926  +50.729791     89.682 0.634261  +0.770545    Germany        Argelander Institute for Astronomy Obs., Bonn
- 3 C61    2.58202  +48.880216     36.501 0.658892  +0.749723    France         Chelles
- 3 C62   11.3467   +46.494235    250.158 0.68967   +0.72175     Italy          Eurac Observatory, Bolzano
- 3 C63    9.9797   +46.188865   1259.638 0.69363   +0.71819     Italy          Giuseppe Piazzi Observatory, Ponte in Valtellina
- 3 C64   15.28439  +47.929391    902.213 0.671380  +0.738819    Austria        Puchenstuben
- 3 C65    0.72965  +42.051680   1618.630 0.743847  +0.666488    Spain          Observatori Astronomic del Montsec
- 3 C66    2.8050   +39.666780    150.906 0.77084   +0.63493     Spain          Observatorio El Cielo de Consell
- 3 C67   12.2199   +53.403828     88.922 0.59747   +0.79922     Germany        Gnevsdorf
- 3 C68   23.89339  +37.997695    168.912 0.789058  +0.612302    Greece         Ellinogermaniki Agogi Observatory, Pallini
- 3 C69   13.3611   +48.927653    825.982 0.65835   +0.75036     Germany        Bayerwald Sternwarte, Neuhuette
- 3 C70    4.49775  +52.157400     -0.127 0.614779  +0.786055    Netherlands    Uiterstegracht Station, Leiden
- 3 C71    1.4892   +41.702336    687.265 0.74780   +0.66186     Spain          Sant Marti Sesgueioles
- 3 C72   12.8717   +41.836813    431.408 0.74621   +0.66358     Italy          Palestrina
- 3 C73   28.0325   +45.418865     58.658 0.70312   +0.70870     Romania        Galati Observatory
- 3 C74    0.7449   +42.019523    742.352 0.74412   +0.66598     Spain          Observatorio El Teatrillo de Lyra, Ager
- 3 C75   13.2225   +46.163089    208.403 0.69384   +0.71776     Italy          Whitestar Observatory, Borgobello
- 3 C76    0.74431  +42.018998    749.904 0.744127  +0.665974    Spain          Observatorio Estels, Ager
- 3 C77    7.4535   +44.385250    570.711 0.71589   +0.69600     Italy          Bernezzo Observatory
- 3 C78   34.81242  +31.908277     57.943 0.849698  +0.525519    Israel         Martin S. Kraar Observatory, Rehovot
- 3 C79    2.7855   +41.677592     33.057 0.74801   +0.66147     Spain          Roser Observatory, Blanes
- 3 C80   39.7651   +47.284989     81.957 0.67959   +0.73115     Russia         Don Astronomical Observatory, Rostov-on-Don
- 3 C81   10.84098  +46.241077   1721.080 0.693023  +0.718872    Italy          Dolomites Astronomical Observatory
- 3 C82   14.35759  +40.618777    292.893 0.760172  +0.647614    Italy          Osservatorio Astronomico Nastro Verde, Sorrento
- 3 C83   91.8425   +56.084127    392.094 0.55930   +0.82626     Russia         Badalozhnyj Observatory
- 3 C84    2.24372  +41.445592     31.514 0.750690  +0.658447    Spain          Badalona
- 3 C85    1.2408   +38.891102    166.624 0.77939   +0.62448     Spain          Observatorio Cala d'Hort, Ibiza
- 3 C86    2.7813   +41.677592     33.057 0.74801   +0.66147     Spain          Blanes
- 3 C87    8.7689   +49.620548    208.705 0.64913   +0.75817     Germany        Rimbach
- 3 C88   11.18331  +43.232801    345.783 0.729763  +0.681487    Italy          Montarrenti Observatory, Siena
- 3 C89   21.55558  +43.140233   1145.223 0.730958  +0.680397    Serbia         Astronomical Station Vidojevica
- 3 C90    1.05181  +41.110418     80.291 0.754546  +0.654066    Spain          Vinyols
- 3 C91   11.22621  +44.243180    434.943 0.717604  +0.694214    Italy          Montevenere Observatory, Monzuno
- 3 C92   13.60995  +43.426292    124.923 0.727425  +0.683915    Italy          Valdicerro Observatory, Loreto
- 3 C93   13.4064   +42.334904    640.455 0.74042   +0.67004     Italy          Bellavista Observatory, L'Aquila
- 3 C94  103.0670   +51.810111    700.423 0.61962   +0.78241     Russia         MASTER-II Observatory, Tunka
- 3 C95    5.71239  +43.932050    705.892 0.721406  +0.690350    France         SATINO Remote Observatory, Haute Provence
- 3 C96   13.8786   +42.753689    225.199 0.73544   +0.67537     Italy          OACL Observatory, Mosciano Sant Angelo
- 3 C97   57.97633  +23.629468     43.382 0.916656  +0.398354    Oman           Al-Fulaij Observatory, Oman
- 3 C98   11.1764   +43.764918     59.705 0.72335   +0.68818     Italy          Osservatorio Casellina, Scandicci
- 3 C99    2.89631  +41.826669    150.489 0.746295  +0.663419    Spain          Observatori Can Roig, Llagostera
- 3 D00   42.6536   +43.740151   2104.520 0.72388   +0.68809     Russia         ASC-Kislovodsk Observatory
- 3 D01   23.93061  +60.352767     79.288 0.495920  +0.865471    Finland        Andean Northern Observatory, Nummi-Pusula
- 3 D02    2.05189  +41.383634    119.250 0.751414  +0.657647    Spain          Observatori Petit Sant Feliu
- 3 D03   10.58892  +44.441106    696.564 0.715223  +0.696709    Italy          Rantiga Osservatorio, Tincana
- 3 D04   38.8569   +44.894146     34.666 0.70960   +0.70225     Russia         Krasnodar
- 3 D05   42.50005  +43.274569   3110.076 0.729580  +0.682314    Russia         ISON-Terskol Observatory
- 3 D06   12.77017  +41.750270    581.475 0.747232  +0.662472    Italy          Associazione Tuscolana di Astronomia, Domatore
- 3 D07    6.2094   +51.142527     75.685 0.62867   +0.77508     Germany        Wegberg
- 3 D08    8.9191   +46.455115    950.271 0.69024   +0.72136     Switzerland    Ghezz Observatory, Leontica
- 3 D09    5.6794   +50.941601     22.656 0.63139   +0.77287     Belgium        Observatory Gromme, Maasmechelen
- 3 D10    8.90181  +48.648915    531.533 0.661976  +0.747123    Germany        Gaertringen
- 3 D11    5.62797  +43.790819    476.480 0.723085  +0.688551    France         Bastidan Observatory
- 3 D12   11.33806  +46.422793    318.634 0.690580  +0.720900    Italy          Filzi School Observatory, Laives
- 3 D13   11.56369  +42.479972    199.693 0.738665  +0.671859    Italy          Cat's Eye Observatory
- 3 D14  113.3231   +23.143683     14.260 0.92000   +0.39061     China          Nanchuan Observatory, Guangzhou
- 3 D15   11.31781  +50.983394    267.931 0.630848  +0.773359    Germany        Sternwarte F.Schiller-Gymnasium, Weimar
- 3 D16  113.96422  +22.376619     31.957 0.925155  +0.378330    China          Po Leung Kuk Observatory, Tuen Mun
- 3 D17  114.2200   +22.474601     -9.736 0.9245    +0.3799      China          Hong Kong
- 3 D18  114.3580   +30.521411     43.624 0.86219   +0.50490     China          Mt. Guizi Observatory
- 3 D19  114.32300  +22.408327     98.975 0.924955  +0.378843    China          Hong Kong Space Museum Sai Kung iObservatory
- 3 D20  115.71311  -31.355948     51.272 0.854733  -0.517343    Australia/WA   Zadko Observatory, Wallingup Plain
- 3 D21  115.8150   -31.961553     -2.733 0.8492    -0.5263      Australia/WA   Shenton Park
- 3 D22  115.81667  -31.978893     24.482 0.849044  -0.526558    Australia/WA   UWA Observatory, Crawley
- 3 D23    0.51853  +41.561741    178.656 0.749367  +0.659977    Spain          OAIA, Alcarras
- 3 D24  117.08969  -32.514144    147.864 0.844095  -0.534439    Australia/WA   LightBuckets Observatory, Pingelly
- 3 D25  117.08978  -32.513139    144.846 0.844104  -0.534424    Australia/WA   Tzec Maun Observatory, Pingelly (before 2010)
- 3 D26    1.92131  +43.807685    356.002 0.722868  +0.688750    France         Peyrole Observatory, Peyrole
- 3 D27    3.80361  +43.626682    125.173 0.725021  +0.686446    France         Observatoire de Fontcaude, Juvignac
- 3 D28    2.18286  +41.619802    282.425 0.748708  +0.660744    Spain          Escaldarium Observatory,Caldes de Montbui
- 3 D29  118.4639   +32.734366    218.979 0.84204   +0.53767     China          Purple Mountain Observatory, XuYi Station
- 3 D30   11.08350  +50.942811    340.480 0.631405  +0.772922    Germany        Sternwarte Silbergraben, Erfurt
- 3 D31   10.09797  +44.504353    920.531 0.714476  +0.697520    Italy          Osservatorio Aldebaran, Rivalba
- 3 D32  119.59975  +30.469432    942.861 0.862770  +0.504193    China          JiangNanTianChi Observatory, Mt. Getianling
- 3 D33  120.6982   +22.049959     38.416 0.92730   +0.37308     Taiwan         Kenting Observatory, Checheng
- 3 D34  120.7839   +21.950269    118.573 0.92796   +0.37148     Taiwan         Kenting Observatory, Hengchun
- 3 D35  120.8736   +23.468580   2879.047 0.91818   +0.39597     Taiwan         Lulin Observatory
- 3 D36  120.8897   +23.487263   2596.013 0.91801   +0.39625     Taiwan         Tataka, Mt. Yu-Shan National Park
- 3 D37  120.87325  +23.468778   2860.725 0.918176  +0.395972    Taiwan         Lulin Widefield Telescope, Mt. Lulin
- 3 D38    8.43764  +44.912897    157.438 0.709383  +0.702495    Italy          Tecnosky Astropark, Felizzano
- 3 D39  122.04961  +37.535927    100.091 0.793971  +0.605943    China          Shandong University Observatory, Weihai
- 3 D40   13.33772  +41.653222    254.016 0.748318  +0.661176    Italy          Frosinone
- 3 D41   10.71704  +43.429224    485.944 0.727431  +0.683991    Italy          Osservatorio Astronomico Orciatico
- 3 D42   11.19084  +43.747676    123.853 0.723565  +0.687970    Italy          Piero Angela Observatory, Scandicci
- 3 D43    7.77039  +45.044600    555.431 0.707805  +0.704162    Italy          45th Parallel Observatory, Pino Torinese
- 3 D44  124.13928  +24.372862    196.762 0.911427  +0.410157    Japan          Ishigakijima Astronomical Observatory
- 3 D45   21.49325  +50.334547    203.712 0.639594  +0.766177    Poland         Kamyk, Trzesn
- 3 D46    9.90265  +47.906000    724.482 0.671664  +0.738525    Germany        Observatory Bad Wurzach
- 3 D47   11.56366  +42.479972    199.693 0.738665  +0.671859    Italy          BigBang Observatory, Manciano
- 3 D48    7.26381  +49.330851    296.849 0.652979  +0.754898    Germany        Niederbexbach Observatory
- 3 D49    0.79444  +40.876687     58.241 0.757213  +0.650992    Spain          L'Ametlla de Mar
- 3 D50    5.21519  +44.039478    314.126 0.720062  +0.691654    France         Vaucluse Observatoire Celeste, Blauvac
- 3 D51    1.94844  +44.082999    352.160 0.719539  +0.692203    France         Plateau Astronomique La Couronne
- 3 D52    9.79750  +45.098032     87.240 0.707094  +0.704768    Italy          ULU Observatory, Caselle Landi
- 3 D53  127.4820   +50.318536    214.305 0.63981   +0.76600     Russia         ISON-Blagoveschensk Observatory
- 3 D54  127.4830   +50.318902    263.392 0.63981   +0.76601     Russia         MASTER-II Observatory, Blagoveshchensk
- 3 D55  127.9747   +37.372831    205.007 0.79571   +0.60370     South Korea    Kangwon Science High School Observatory, Ksho
- 3 D56   11.67408  +45.607803     93.456 0.700775  +0.711011    Italy          Osservatorio Sideris Oculus, San Pietro in Gu
- 3 D57  128.88744  +35.252875    369.150 0.817572  +0.573996    South Korea    Gimhae Astronomical Observatory, Uhbang-dong
- 3 D58  129.02500  +35.165619    149.564 0.818419  +0.572736    South Korea    KSA SEM Observatory, Danggam-dong
- 3 D59    7.15617  +43.747770    398.800 0.723595  +0.688001    France         MARIAMIR, Saint-Jeannet
- 3 D60   13.55146  +46.183670    832.667 0.693649  +0.718079    Italy          Sparky's Stars, Masseris
- 3 D61  134.9131   +34.327701     29.273 0.82671   +0.56075     Japan          Suntopia Marina, Sumoto
- 3 D62  130.4494   +33.289452     56.396 0.83676   +0.54575     Japan          Miyaki-Argenteus
- 3 D63   10.46138  +44.081326    296.499 0.719553  +0.692176    Italy          G. Pascoli Observatory, Barga (since June 2023)
- 3 D64   14.10967  +42.305528    179.161 0.740711  +0.669613    Italy          Fucama, Casalincontrada
- 3 D65   11.53480  +45.497415    227.692 0.702163  +0.709679    Italy          G. Beltrame, Arcugnano Vicenza
- 3 D66    9.14839  +45.376776    165.993 0.703654  +0.708197    Italy          Civico Osservatorio Astronomico di Rozzano
- 3 D67   37.62472  +54.209185    175.117 0.586136  +0.807530    Russia         Tula Rooftop Observatory, Tula
- 3 D68   11.73622  +45.465410     67.007 0.702543  +0.709270    Italy          Osservatorio Galileo, Padova
- 3 D69    9.97013  +49.782617    342.740 0.646988  +0.760014    Germany        JMU Space-Observatory
- 3 D70  133.4686   +33.467927     37.268 0.83505   +0.54834     Japan          Tosa
- 3 D71   15.89225  +46.822401    304.705 0.685516  +0.725682    Austria        ObservaSTYRium, Stainz bei Straden
- 3 D72   16.36131  -23.236603   1856.060 0.919630  -0.392207    Namibia        WAA Remote Observatory, Hakos
- 3 D73   16.36139  -23.236611   1870.298 0.919632  -0.392208    Namibia        SNX-NET, Hakos
- 3 D74  134.6819   +33.948936     54.371 0.83041   +0.55530     Japan          Nakagawa
- 3 D75   16.95608  +39.488772     74.321 0.772805  +0.632534    Italy          Cariati
- 3 D76    2.00702  +41.564599    349.351 0.749354  +0.660032    Spain          AAT-Terrassa, Terrassa
- 3 D77   10.71736  +43.429020    482.054 0.727433  +0.683988    Italy          TD-TRO (Tuscany Remote Observatory)
- 3 D78  136.13281  +34.768568    156.708 0.822378  +0.567077    Japan          Iga-Ueno
- 3 D79  138.63092  -34.884487     43.798 0.821212  -0.568722    Australia/SA   YSVP Observatory, Vale Park
- 3 D80  138.9728   +36.596424    861.621 0.80392   +0.59297     Japan          Gumma Astronomical Observatory
- 3 D81  138.2239   +36.669278    356.183 0.80310   +0.59394     Japan          Nagano
- 3 D82  137.6317   -33.931075     28.039 0.83058   -0.55504     Australia/SA   Wallaroo
- 3 D83  138.4681   +36.496336   1281.527 0.80501   +0.59161     Japan          Miwa
- 3 D84  138.5086   -35.086370     54.807 0.8192    -0.5716      Australia/SA   Hallet Cove
- 3 D85  138.6597   -34.820641    147.776 0.82186   -0.56782     Australia/SA   Ingle Farm
- 3 D86  138.6407   -33.918940    429.387 0.83075   -0.55490     Australia/SA   Penwortham
- 3 D87  138.5500   -34.926094    -17.531 0.82079   -0.56931     Australia/SA   Brooklyn Park
- 3 D88  139.3142   +35.369663     -3.842 0.81635   +0.57562     Japan          Hiratsuka
- 3 D89  140.3383   +38.184585    562.682 0.7871    +0.6149      Japan          Yamagata
- 3 D90  140.3420   -34.269333     13.586 0.82728   -0.55991     Australia/SA   RAS Observatory, Moorook
- 3 D91  140.8250   +37.665917    254.841 0.79261   +0.60775     Japan          Adati
- 3 D92  140.94638  +38.565522     41.729 0.782920  +0.620047    Japan          Osaki
- 3 D93  140.75516  +38.255144    162.860 0.786291  +0.615826    Japan          Sendai Astronomical Observatory
- 3 D94  139.9962   +36.628007    208.037 0.80351   +0.59335     Japan          Takanezawa, Tochigi
- 3 D95  141.0680   +38.801469     14.706 0.78035   +0.62325     Japan          Kurihara
- 3 D96  140.34216  -34.268869     32.525 0.827287  -0.559905    Australia/SA   Tzec Maun Observatory, Moorook
- 3 D97  140.5700   -34.244932     22.177 0.82752   -0.55956     Australia/SA   Berri
- 3 D98   11.33409  +44.259208    745.434 0.717444  +0.694448    Italy          Loiano TANDEM
- 3 D99    0.39122  +44.261624    232.292 0.717357  +0.694422    France         AstroKoT, Port-Ste-Marie
- 3 E00  144.2089   -37.059619    313.796 0.79902   -0.59937     Australia/VIC  Castlemaine
- 3 E01  144.54142  -37.098948    398.631 0.798618  -0.599924    Australia/VIC  Barfold
- 3 E03  145.3822   -38.136178     71.609 0.78756   -0.61419     Australia/VIC  RAS Observatory, Officer
- 3 E04  145.7403   +15.156538     92.290 0.96545   +0.25977     US/Saipan      Pacific Sky Observatory, Saipan
- 3 E05  145.69721  -16.794672     73.158 0.957625  -0.287092    Australia/QLD  Earl Hill Observatory, Trinity Beach
- 3 E07  148.99889  -34.958699    595.907 0.820544  -0.569830    Australia/NSW  Murrumbateman
- 3 E08  149.33431  -31.226991    600.644 0.855971  -0.515472    Australia/NSW  Wobblesock Observatory, Coonabarabran
- 3 E09  149.0814   -31.281463    827.066 0.85551   -0.51630     Australia/NSW  Oakley Southern Sky Observatory, Coonabarabran
- 3 E10  149.07085  -31.272806   1154.348 0.855632  -0.516198    Australia/NSW  Siding Spring-Faulkes Telescope South
- 3 E11  149.6627   -32.456034    543.515 0.84469   -0.53362     Australia/NSW  Frog Rock Observatory, Mudgee
- 3 E12  149.0642   -31.273455   1183.177 0.85563   -0.51621     Australia/NSW  Siding Spring Survey
- 3 E13  149.0969   -35.390394    612.644 0.81622   -0.57597     Australia/NSW  Wanniassa
- 3 E14  149.1100   -35.162463    690.888 0.81852   -0.57274     Australia/NSW  Hunters Hill Observatory, Ngunnawal
- 3 E15  149.6061   -34.998673    709.829 0.82016   -0.57041     Australia/NSW  Magellan Observatory, near Goulburn
- 3 E16  149.36624  -33.829624    952.993 0.831684  -0.553656    Australia/NSW  Grove Creek Observatory, Trunkey
- 3 E17  150.3417   -33.706839   1174.992 0.8329    -0.5519      Australia/NSW  Leura
- 3 E18  151.02714  -34.010413    104.761 0.829819  -0.556191    Australia/NSW  BDI Observatory, Regents Park
- 3 E19  151.0958   -33.947661     36.044 0.83042   -0.55528     Australia/NSW  Kingsgrove
- 3 E20  151.10320  -33.770507    108.983 0.832146  -0.552728    Australia/NSW  Marsfield
- 3 E21  151.5667   -27.985792    609.832 0.8838    -0.4665      Australia/QLD  Norma Rose Observatory, Leyburn
- 3 E22  151.85500  -27.797722    669.202 0.885337  -0.463616    Australia/QLD  Univ. of Southern Queensland Obs., Mt. Kent
- 3 E23  151.07119  -33.621199    181.607 0.833596  -0.550574    Australia/NSW  Arcadia
- 3 E24  150.7769   -33.809709     56.430 0.83176   -0.55329     Australia/NSW  Tangra Observatory, St. Clair
- 3 E25  153.1170   -27.563958     -6.532 0.88713   -0.45997     Australia/QLD  Rochedale (APTA)
- 3 E26  153.3971   -27.933917     13.334 0.88414   -0.46566     Australia/QLD  RAS Observatory, Biggera Waters
- 3 E27  153.2667   -27.566288    -87.610 0.8871    -0.4600      Australia/QLD  Thornlands
- 3 E28  150.64105  -33.664388    305.021 0.833196  -0.551210    Australia/NSW  Kuriwa Observatory, Hawkesbury Heights
- 3 E29  115.95533  -32.309798    -13.625 0.845978  -0.531426    Australia/WA   Mardella Observatory
- 3 E62  149.08135  -31.281739    838.174 0.855509  -0.516305    Australia/NSW  Slooh.com Australia, Coonabarabran
- 3 E81  173.2617   -41.274462    124.363 0.75267   -0.65622     New Zealand    Nelson
- 3 E83  173.95703  -41.535738     13.963 0.749648  -0.659621    New Zealand    Wither Observatory, Witherlea
- 3 E85  174.89400  -36.895808      6.601 0.800696  -0.597064    New Zealand    Farm Cove
- 3 E87  175.6540   -40.411595     79.802 0.76249   -0.64485     New Zealand    Turitea
- 3 E89  176.2040   -38.136018    300.884 0.78759   -0.61421     New Zealand    Geyserland Observatory, Pukehangi
- 3 E94  177.88331  -38.629922     11.072 0.782217  -0.620920    New Zealand    Possum Observatory, Gisborne
- 3 F51  203.74409  +20.707235   3067.733 0.936241  +0.351543    US/Hawaii      Pan-STARRS 1, Haleakala
- 3 F52  203.74409  +20.707384   3060.311 0.936239  +0.351545    US/Hawaii      Pan-STARRS 2, Haleakala
- 3 F59  201.94100  +21.311100     27.429 0.932037  +0.361160    US/Hawaii      Ironwood Remote Observatory, Hawaii
- 3 F60  201.95283  +21.644636    199.079 0.929942  +0.366558    US/Hawaii      Ironwood Observatory, Hawaii
- 3 F65  203.74250  +20.707007   3044.524 0.936239  +0.351538    US/Hawaii      Haleakala-Faulkes Telescope North
- 3 F84  210.3842   -17.634072    -23.897 0.95330   -0.30100     Tahiti         Hibiscus Observatory, Punaauia
- 3 F85  210.3842   -17.634072    -23.897 0.95330   -0.30100     Tahiti         Tiki Observatory, Punaauia
- 3 F86  210.38381  -17.634221      8.145 0.953304  -0.301004    Tahiti         Moana Observatory, Punaauia
- 3 G00   15.12600  +48.381564    914.616 0.665508  +0.744080    Austria        AZM Martinsberg, Oed
- 3 G01    8.16528  +53.152847     53.648 0.600977  +0.796597    Germany        Universitaetssternwarte Oldenburg
- 3 G02   18.76539  +49.307316    460.986 0.653307  +0.754650    Slovakia       KYSUCE Observatory, Kysucke Nove Mesto
- 3 G03   18.26061  +47.362997    361.722 0.678620  +0.732104    Hungary        Capricornus Observatory, Csokako
- 3 G04    7.14133  +51.230706    386.071 0.627502  +0.776082    Germany        Schuelerlabor Astronomie St. 7, Wuppertal
- 3 G05  354.53363  +38.177283    582.408 0.787181  +0.614802    Spain          Piconcillo, Sierra Morena
- 3 G06    4.67150  +51.779218     45.596 0.619980  +0.781996    Netherlands    Dordrecht, Sterrenburg
- 3 G07    3.06386  +44.096004    464.510 0.719394  +0.692378    France         Millau Observatory
- 3 G08    1.99694  +41.620271    704.035 0.748752  +0.660794    Spain          Observatorio Les Pedritxes, Matadepera
- 3 G09    0.61056  +51.647539     55.756 0.621784  +0.780574    UK/England     SWF Observatory, South Woodham Ferrers
- 3 G10  354.45055  +37.667863    131.547 0.792574  +0.607765    Spain          Clavier Observatory, Lora Del Rio
- 3 G11    7.18379  +50.993278    247.233 0.630712  +0.773465    Germany        Breitenweg Observatory, Herkenrath
- 3 G12    8.3306   +51.676397    167.423 0.62140   +0.78090     Germany        Sternwarte EG, Lippstadt
- 3 G13    9.77164  +63.214082     69.656 0.451870  +0.889105    Norway         Astronomihagen, Fannrem
- 3 G14    7.00520  +43.609130    257.941 0.725247  +0.686239    France         Novaloop Observatory, Mougins
- 3 G15    9.1183   +44.772008    570.316 0.71116   +0.70080     Italy          Magroforte Observatory, Alessandria
- 3 G16   13.34869  +38.100310     93.304 0.787948  +0.613701    Italy          OmegaLab Observatory, Palermo
- 3 G17   11.20261  +43.752136     94.994 0.723508  +0.688023    Italy          BAS Observatory, Scandicci
- 3 G18   11.28056  +44.626939     59.547 0.712881  +0.698947    Italy          ALMO Observatory, Padulle
- 3 G19   12.7460   +50.860591    360.680 0.63252   +0.77202     Germany        Immanuel Kant Observatory,Limbach
- 3 G20    6.05989  +43.401236    283.226 0.727743  +0.683615    France         Brignoles Observatory
- 3 G21   13.73789  +37.347128    546.724 0.796024  +0.603377    Italy          Osservatorio Castrofilippo
- 3 G22    9.21439  +49.144491    244.414 0.655435  +0.752770    Germany        Experimenta Observatory, Heilbronn
- 3 G23   19.09234  +47.588701    151.197 0.675698  +0.734739    Hungary        Vulpecula Observatory, Budapest
- 3 G24    9.09350  +48.612819    480.168 0.662443  +0.746701    Germany        Dettenhausen
- 3 G25  288.1050   +45.415613    146.229 0.70317   +0.70867     Canada/Quebec  Sherbrooke
- 3 G26  109.8236   +34.508337    460.794 0.82499   +0.56338     China          Fushan Observatory, Mt Shaohua
- 3 G27    0.72935  +42.051659   1573.590 0.743842  +0.666483    Spain          Fabra Observatory, Montsec
- 3 G28    1.00850  +52.510997     43.951 0.609900  +0.789830    UK/England     Wyncroft Observatory, Attleborough
- 3 G29  358.9124   +39.491384    685.211 0.77285   +0.63263     Spain          Requena
- 3 G30  284.90719  +45.306132     60.570 0.704518  +0.707320    Canada/Ontari  Casselman
- 3 G31   13.7253   +45.714674    248.590 0.69946   +0.71233     Italy          CCAT Trieste
- 3 G32  291.82040  -22.953233   2399.446 0.921639  -0.387713    Chile          Elena Remote Observatory, San Pedro de Atacama
- 3 G33    7.60879  +51.528831    101.188 0.623411  +0.779293    Germany        Wickede
- 3 G34   13.70150  +50.860005    553.479 0.632547  +0.772037    Germany        Oberfrauendorf
- 3 G35  249.15789  +31.945051    930.571 0.849476  +0.526134    US/Arizona     Elephant Head Obsevatory, Sahuarita
- 3 G36  357.45250  +37.222887   2182.977 0.797538  +0.601812    Spain          Calar Alto-CASADO
- 3 G37  248.57779  +34.744378   2346.659 0.822900  +0.566927    US/Arizona     Lowell Discovery Telescope
- 3 G38  356.76842  +40.641132    700.225 0.759967  +0.647951    Spain          Observatorio La Senda, Cabanillas del Campo
- 3 G39  291.82039  -22.953105   2400.344 0.921640  -0.387711    Chile          ROAD, San Pedro de Atacama
- 3 G40  343.49174  +28.299720   2370.113 0.881470  +0.471441    Canary Island  Slooh.com Canary Islands Observatory
- 3 G41  264.73816  +29.967077     22.264 0.867040  +0.496575    US/Texas       Insperity Observatory, Humble
- 3 G42  259.0230   +25.427831   1591.314 0.90391   +0.42687     Mexico         Observatorio Astronomico UAdeC, Saltillo
- 3 G43  293.6879   -33.152186    835.635 0.83817   -0.54382     Argentina      Observatorio Buenaventura Suarez, San Luis
- 3 G44  313.3061   -22.987244    816.636 0.92118   -0.38816     Brazil         Observatorio Longa Vista, Sao Paulo
- 3 G45  253.63564  +33.739422   2422.438 0.832748  +0.552480    US/New Mexico  Space Surveillance Telescope, Atom Site
- 3 G46  244.66153  +35.224571   1664.545 0.818022  +0.573711    US/California  Pinto Valley Observatory
- 3 G47  253.80654  +35.049714   2085.663 0.819827  +0.571261    US/New Mexico  HillTopTop Observatory, Edgewood
- 3 G48  251.10148  +31.946920   1345.470 0.849514  +0.526196    US/New Mexico  Harlingten Research Observatory, Rancho Hildalgo
- 3 G49  266.5943   +44.954211    296.434 0.70889   +0.70302     US/Minnesota   Minnetonka
- 3 G50  253.3300   +32.296029   1375.248 0.84629   +0.53134     US/New Mexico  Organ Mesa Observatory, Las Cruces
- 3 G51  239.95778  +34.691463    326.978 0.823164  +0.565990    US/California  Byrne Observatory, Sedgwick Reserve
- 3 G52  237.49604  +38.288709     63.924 0.785917  +0.616275    US/California  Stone Edge Observatory, El Verano
- 3 G53  240.58727  +37.070515   1411.134 0.799043  +0.599625    US/California  Alder Springs Observatory, Auberry
- 3 G54  243.0630   +33.693764    590.970 0.83295   +0.55166     US/California  Hemet
- 3 G55  241.09533  +35.370750    167.821 0.816361  +0.575651    US/California  Bakersfield
- 3 G56  237.9294   +37.924106     41.427 0.78983   +0.61128     US/California  Walnut Creek
- 3 G57  236.8564   +45.532488     73.300 0.70171   +0.71009     US/Oregon      Dilbert Observatory, Forest Grove
- 3 G58  237.8180   +37.819331    450.451 0.79100   +0.60988     US/California  Chabot Space and Science Center, Oakland
- 3 G59  237.4530   +47.661778     85.808 0.67475   +0.73559     US/Washington  Maiden Lane Obs., Bainbridge Island
- 3 G60  240.33888  +34.448409    181.790 0.825544  +0.562496    US/California  Carroll Observatory, Montecito
- 3 G61  238.1524   +37.655933    124.724 0.79270   +0.60760     US/California  Pleasanton
- 3 G62  238.5469   +43.876370   1248.264 0.72214   +0.68971     US/Oregon      Sunriver Nature Center Observatory, Sunriver
- 3 G63  238.6858   +45.549113    226.047 0.70152   +0.71031     US/Oregon      Mill Creek Observatory, The Dalles
- 3 G64  239.2911   +39.274187   1516.509 0.77535   +0.62979     US/California  Blue Canyon Observatory
- 3 G65  238.3612   +37.342524   1247.934 0.79616   +0.60338     US/California  Vulcan North, Lick Observatory, Mount Hamilton
- 3 G66  238.9169   +38.712186    236.987 0.78135   +0.62206     US/California  Lake Forest Observatory, Forest Hills
- 3 G67  239.3650   +38.721062    945.194 0.78134   +0.62225     US/California  Rancho Del Sol, Camino
- 3 G68  240.2250   +38.811659   1661.171 0.78044   +0.62355     US/California  Sierra Stars Observatory, Markleeville
- 3 G69  241.0158   +34.169638    282.897 0.82829   +0.55850     US/California  Via Capote Sky Observatory, Thousand Oaks
- 3 G70  241.4547   +34.463211    426.647 0.82543   +0.56273     US/California  Francisquito Observatory, Los Angeles
- 3 G71  241.6047   +33.771589    296.664 0.83216   +0.55276     US/California  Rancho Palos Verdes
- 3 G72  241.82408  +34.064203    147.998 0.829301  +0.556970    US/California  University Hills
- 3 G73  241.9400   +34.213381   1652.153 0.82804   +0.55925     US/California  Mount Wilson-TIE
- 3 G74  242.88538  +33.225028    473.027 0.837429  +0.544849    US/California  Boulder Knolls Observatory, Escondido
- 3 G75  243.2783   +33.483607   1569.783 0.8351    +0.5487      US/California  Starry Knight Observatory, Coto de Caza
- 3 G76  242.4178   +33.591854    193.429 0.83388   +0.55015     US/California  Altimira Observatory, Coto de Caza
- 3 G77  243.7183   +34.283975   2046.956 0.8274    +0.5603      US/California  Baldwin Lake
- 3 G78  244.3127   +32.780118     -5.175 0.84158   +0.53832     US/California  Desert Wanderer Observatory, El Centro
- 3 G79  243.6165   +34.291099    887.611 0.82718   +0.56030     US/California  Goat Mountain Astronomical Research Station
- 3 G80  240.5873   +37.070390   1376.643 0.79904   +0.59962     US/California  Sierra Remote Observatories, Auberry
- 3 G81  242.91300  +33.486900    312.496 0.834904  +0.548639    US/California  Temecula
- 3 G82  248.40057  +31.960531   2046.557 0.849482  +0.526455    US/Arizona     SARA Observatory, Kitt Peak
- 3 G83  250.11039  +32.701485   3182.410 0.842740  +0.537440    US/Arizona     Mt. Graham-LBT
- 3 G84  249.21084  +32.442529   2780.623 0.845112  +0.533610    US/Arizona     Mount Lemmon SkyCenter
- 3 G85  247.56518  +37.029036   1603.332 0.799502  +0.599067    US/Utah        Vermillion Cliffs Observatory, Kanab
- 3 G86  249.0697   +32.269723    739.115 0.84645   +0.53090     US/Arizona     Tucson-Winterhaven
- 3 G87  248.1894   +41.808031   1421.960 0.74666   +0.66331     US/Utah        Calvin M. Hooper Memorial Observatory, Hyde Park
- 3 G88  247.8881   +33.933920    701.591 0.83064   +0.55514     US/Arizona     LAMP Observatory, New River
- 3 G89  248.3069   +35.099476   2089.964 0.81933   +0.57197     US/Arizona     Kachina Observatory, Flagstaff
- 3 G90  248.9658   +32.642288   1016.782 0.84301   +0.53639     US/Arizona     Three Buttes Observatory, Tucson
- 3 G91  249.1219   +31.680709   2287.949 0.85208   +0.52234     US/Arizona     Whipple Observatory, Mt. Hopkins--2MASS
- 3 G92  249.2814   +31.976191   1010.354 0.84920   +0.52660     US/Arizona     Jarnac Observatory, Vail
- 3 G93  249.3726   +31.662445   1562.811 0.85215   +0.52201     US/Arizona     Sonoita Research Observatory, Sonoita
- 3 G94  249.9267   +31.928464   1542.600 0.84971   +0.52594     US/Arizona     Sonoran Skies Observatory, St. David
- 3 G95  249.7622   +31.452173   1386.852 0.85404   +0.51888     US/Arizona     Hereford Arizona Observatory, Hereford
- 3 G96  249.21128  +32.442732   2757.131 0.845107  +0.533611    US/Arizona     Mt. Lemmon Survey
- 3 G97  250.8694   +31.933218   1420.219 0.84965   +0.52600     US/Arizona     Astronomical League Alpha Observatory, Portal
- 3 G98  251.34354  +35.525435   2022.028 0.815037  +0.578012    US/New Mexico  Calvin-Rehoboth Observatory, Rehoboth
- 3 G99  251.8104   +32.770984   1921.735 0.84192   +0.53835     US/New Mexico  NF Observatory, Silver City
- 3 H00  251.6987   +32.710840   1802.273 0.84247   +0.53746     US/New Mexico  Tyrone
- 3 H01  252.81067  +33.984831   3229.504 0.830474  +0.556096    US/New Mexico  Magdalena Ridge Observatory, Socorro
- 3 H02  253.3706   +35.882355   2397.204 0.81146   +0.58309     US/New Mexico  Sulphur Flats Observatory, La Cueva
- 3 H03  253.3553   +35.273229   1638.070 0.81753   +0.57440     US/New Mexico  Sandia View Observatory, Rio Rancho
- 3 H04  254.0260   +35.640212   2062.465 0.81388   +0.57964     US/New Mexico  Santa Fe
- 3 H05  256.0707   +39.644309   1562.060 0.77126   +0.63477     US/Colorado    Edmund Kline Observatory, Deer Trail
- 3 H06  254.47130  +32.903325   2226.842 0.840712  +0.540310    US/New Mexico  iTelescope Observatory, Mayhill
- 3 H07  254.47134  +32.903391   2224.016 0.840711  +0.540310    US/New Mexico  7300 Observatory, Cloudcroft
- 3 H08  254.47081  +32.903978   2220.540 0.840705  +0.540319    US/New Mexico  BlackBird Observatory, Cloudcroft
- 3 H09  255.5886   +39.696668   1744.344 0.77070   +0.63549     US/Colorado    Antelope Hills Observatory, Bennett
- 3 H10  254.47141  +32.903308   2218.022 0.840711  +0.540309    US/New Mexico  Tzec Maun Observatory, Mayhill
- 3 H11  250.9840   +31.861040   1246.041 0.85029   +0.52492     US/New Mexico  LightBuckets Observatory, Rodeo
- 3 H12  254.47078  +32.903180   2216.448 0.840712  +0.540307    US/New Mexico  TechDome, Mayhill
- 3 H13  248.25212  +32.901794    422.881 0.840489  +0.540134    US/Arizona     Lenomiya Observatory, Casa Grande
- 3 H14  249.21233  +32.275816    803.793 0.846402  +0.530995    US/Arizona     Morning Star Observatory, Tucson
- 3 H15  254.47156  +32.903260   2214.558 0.840711  +0.540308    US/New Mexico  ISON-NM Observatory, Mayhill
- 3 H16  253.2890   +39.632573   2635.661 0.77152   +0.63472     US/Colorado    HUT Observatory, Eagle
- 3 H17  254.38333  +38.516886   2777.241 0.783783  +0.619652    US/Colorado    Angel Peaks Observatory
- 3 H18  249.28798  +31.973881   1083.507 0.849231  +0.526572    US/Arizona     Vail View Observatory, Vail
- 3 H19  263.86259  +34.183154    175.329 0.828144  +0.558685    US/Oklahoma    Lone Star Observatory, Caney
- 3 H20  271.81682  +39.477224    216.287 0.772950  +0.632393    US/Illinois    Eastern Illinois University Obs., Charleston
- 3 H21  272.03173  +39.483057    212.609 0.772885  +0.632471    US/Illinois    Astronomical Research Observatory, Westfield
- 3 H22  272.7371   +39.346375     83.384 0.77438   +0.63062     US/Indiana     Terre Haute
- 3 H23  273.49858  +30.506292     10.842 0.862319  +0.504671    US/Florida     Pear Tree Observatory, Valparaiso
- 3 H24  274.59881  +42.905314    254.743 0.733648  +0.677310    US/Michigan    J. C. Veen Observatory, Lowell
- 3 H25  266.87082  +44.499312    289.465 0.714467  +0.697388    US/Minnesota   Harvest Moon Observatory, Northfield
- 3 H26  270.78922  +42.785578    330.950 0.735075  +0.675789    US/Wisconsin   Doc Greiner Research Observatory, Janesvillle
- 3 H27  266.23134  +38.829091    222.247 0.780074  +0.623645    US/Missouri    Moonglow Observatory, Warrensburg
- 3 H28  263.23150  +33.275954    233.328 0.836912  +0.545569    US/Texas       Preston Hills Observatory, Celina
- 3 H29  262.5494   +35.634360    341.184 0.81372   +0.57940     US/Oklahoma    Ivywood Observatory, Edmond
- 3 H30  262.5558   +35.202408    381.655 0.81808   +0.57328     US/Oklahoma    University of Oklahoma Observatory, Norman
- 3 H31  263.3300   +29.612413     78.502 0.87011   +0.49123     US/Texas       Star Ridge Observatory, Weimar
- 3 H32  263.6334   +30.572720     67.886 0.86174   +0.50567     US/Texas       Texas A&M Physics Observatory, College Station
- 3 H33  264.1217   +36.008030    220.118 0.80990   +0.58466     US/Oklahoma    Bixhoma Observatory, Bixby
- 3 H34  264.8258   +32.309316    118.605 0.84600   +0.53143     US/Texas       Chapel Hill
- 3 H35  264.9517   +39.362057    273.834 0.77423   +0.63085     US/Kansas      Leavenworth
- 3 H36  264.29345  +38.797720    318.498 0.780428  +0.623229    US/Kansas      Sandlot Observatory, Scranton
- 3 H37  265.2003   +43.258250    439.660 0.72947   +0.68182     US/Iowa        Grems Timmons Observatories, Graettinger
- 3 H38  265.9864   +41.439768    311.220 0.75079   +0.65840     US/Iowa        Timberline Observatory, Urbandale
- 3 H39  266.6828   +44.909571    302.332 0.70944   +0.70247     US/Minnesota   S.O.S. Observatory, Minneapolis
- 3 H40  266.7306   +34.484766    211.687 0.82519   +0.56302     US/Arkansas    Nubbin Ridge Observatory
- 3 H41  267.0742   +35.139585    307.630 0.81870   +0.57238     US/Arkansas    Petit Jean Mountain
- 3 H42  267.5078   +42.733796    267.136 0.73568   +0.67512     US/Iowa        Wartburg College Observatory, Waverly
- 3 H43  267.4998   +35.088442     60.415 0.81918   +0.57163     US/Arkansas    Conway
- 3 H44  267.7982   +35.127814    168.545 0.81880   +0.57220     US/Arkansas    Cascade Mountain
- 3 H45  267.0831   +35.119804    323.257 0.81890   +0.57210     US/Arkansas    Arkansas Sky Obs., Petit Jean Mountain South
- 3 H46  265.7297   +39.003609    338.882 0.77818   +0.62602     US/Missouri    Ricky Observatory, Blue Springs
- 3 H47  269.1439   +32.266216     40.962 0.84639   +0.53079     US/Mississipp  Vicksburg
- 3 H48  265.0139   +37.513158    322.530 0.79424   +0.60565     US/Kansas      PSU Greenbush Observatory, Pittsburg
- 3 H49  266.8636   +35.294819    129.734 0.81712   +0.57457     US/Arkansas    ATU Astronomical Observatory, Russellville
- 3 H50  267.54139  +35.081608     96.806 0.819253  +0.571536    US/Arkansas    University of Central Arkansas Obs., Conway
- 3 H51  270.4003   +43.119890    880.587 0.73117   +0.68011     US/Wisconsin   Greiner Research Observatory, Verona
- 3 H52  270.67354  +42.438939    230.393 0.739151  +0.671335    US/Illinois    Hawkeye Observatory, Durand
- 3 H53  271.22842  +37.945237    155.191 0.789618  +0.611581    US/Illinois    Thompsonville
- 3 H54  271.6514   +44.615346    302.592 0.71305   +0.69883     US/Wisconsin   Cedar Drive Observatory, Pulaski
- 3 H55  271.8558   +39.488125    221.716 0.77283   +0.63254     US/Illinois    Astronomical Research Observatory, Charleston
- 3 H56  272.16764  +42.136354    197.320 0.742693  +0.667433    US/Illinois    Northbrook Meadow Observatory
- 3 H57  275.97246  +40.735169    283.677 0.758850  +0.649150    US/Ohio        Ohio State University Observatory, Lima
- 3 H58  273.3353   +34.656687    186.404 0.82349   +0.56548     US/Alabama     NASA/MSFC ALaMO, Redstone Arsenal
- 3 H59  273.3651   +40.313104    243.022 0.76362   +0.64356     US/Indiana     Prairie Grass Observatory, Camp Cullom
- 3 H60  273.86542  +39.973100    232.934 0.767435  +0.639034    US/Indiana     Heartland Observatory, Carmel
- 3 H61  281.41689  +43.915830     94.697 0.721533  +0.690080    Canada/Ontari  Newcastle
- 3 H62  274.4117   +42.930419    252.634 0.73335   +0.67763     US/Michigan    Calvin College Observatory
- 3 H63  274.9276   +41.311195    311.976 0.75227   +0.65672     US/Indiana     DeKalb Observatory, Auburn
- 3 H64  275.4364   +39.020939     91.728 0.77796   +0.62623     US/Kentucky    Thomas More College Observatory, Crestview Hills
- 3 H65  275.4364   +38.840942    266.115 0.77995   +0.62381     US/Kentucky    Waltonfields Observatory, Walton
- 3 H66  276.1460   +39.783577    312.370 0.76956   +0.63651     US/Ohio        Yellow Springs
- 3 H67  276.16241  +42.297722    269.695 0.740813  +0.669522    US/Michigan    Stonegate Observatory, Ann Arbor
- 3 H68  276.34824  +31.410266     86.601 0.854246  +0.518152    US/Georgia     Red Barn Observatory, Ty Ty
- 3 H69  276.94463  +40.251222    271.611 0.764320  +0.642741    US/Ohio        Perkins Observatory, Delaware
- 3 H70  277.4458   +35.600877    817.939 0.81412   +0.57897     US/North Caro  Asheville
- 3 H71  276.48282  +31.560349     99.163 0.852885  +0.520378    US/Georgia     Chula
- 3 H72  278.2258   +26.460316      9.051 0.89584   +0.44289     US/Florida     Evelyn L. Egan Observatory, Fort Myers
- 3 H73  278.6351   +41.637437    248.358 0.74850   +0.66097     US/Ohio        Lakeland Astronomical Observatory, Kirtland
- 3 H74  278.8747   +28.915559      6.858 0.87602   +0.48066     US/Florida     Bar J Observatory, New Smyrna Beach
- 3 H75  278.91856  +41.547813    375.703 0.749551  +0.659816    US/Ohio        Indian Hill North Observatory, Huntsburg
- 3 H76  279.4133   +25.657258     25.016 0.90197   +0.43036     US/Florida     Oakridge Observatory, Miami
- 3 H77  279.7653   +26.079020     -1.355 0.89877   +0.43695     US/Florida     Buehler Observatory
- 3 H78  282.70896   +1.212645   2586.683 1.000183  +0.021030    Colombia       University of Narino Observatory, Pasto
- 3 H79  280.49270  +43.773878    200.719 0.723258  +0.688308    Canada/Ontari  York University Observatory, Toronto
- 3 H80  285.33567  +40.348863     49.951 0.763194  +0.644015    US/New Jersey  Halsted Observatory, Princeton
- 3 H81  283.61539  +42.458241    532.119 0.738959  +0.671615    US/New York    Hartung-Boothroyd Observatory, Ithaca
- 3 H82  281.7839   +38.985492    187.675 0.77836   +0.62576     US/Virginia    CBA-NOVAC Observatory, Front Royal
- 3 H83  282.6641   +38.902499    122.053 0.77926   +0.62463     US/Virginia    Timberlake Observatory, Oakton
- 3 H84  282.4961   +42.993766    182.728 0.73259   +0.67843     US/New York    Northview Observatory, Mendon
- 3 H85  283.0029   +39.031975     99.568 0.77784   +0.62638     US/Maryland    Silver Spring
- 3 H86  283.1576   +39.114436     56.048 0.77693   +0.62749     US/Maryland    CBA-East Observatory, Laurel
- 3 H87  282.4361   +37.618584     69.201 0.79309   +0.60708     US/Virginia    Fenwick Observatory, Richmond
- 3 H88  283.7577   +39.475317     41.924 0.77295   +0.63235     US/Maryland    Hope Observatory, Belcamp
- 3 H89  284.2975   +45.480550     22.266 0.70235   +0.70945     Canada/Quebec  Galaxy Blues Observatory, Gatineau
- 3 H90  284.4731   +45.454982     44.168 0.70267   +0.70914     Canada/Ontari  Ottawa
- 3 H91  285.04839  +44.678121    137.806 0.712263  +0.699590    US/New York    Reynolds Observatory, Potsdam
- 3 H92  285.6211   +39.933838     33.854 0.76785   +0.63849     US/New Jersey  Arcturus Observatory
- 3 H93  285.5758   +40.689822     73.279 0.75934   +0.64853     US/NJersey     Berkeley Heights
- 3 H94  285.5439   +40.825066    134.965 0.75781   +0.65032     US/NJersey     Cedar Knolls
- 3 H95  285.82120  +40.741760     30.152 0.758745  +0.649211    US/NJersey     NJIT Observatory, Newark
- 3 H96  286.6142   +46.353842    132.875 0.69143   +0.72005     Canada/Quebec  Observatoire des Pleiades, Mandeville
- 3 H97  287.20132  +41.811358    272.106 0.746487  +0.663233    US/Connecticu  Talcott Mountain Science Center, Avon
- 3 H98  287.2655   +41.516924     54.950 0.74987   +0.65938     US/Connecticu  Dark Rosanne Obs., Middlefield
- 3 H99  288.8036   +42.330584     30.724 0.74040   +0.66992     US/Massachuse  Sunhill Observatory, Newton
- 3 I00  288.2294   +41.684554    123.744 0.74794   +0.66157     US/Rhode Isla  Carbuncle Hill Observatory, Coventry
- 3 I01  288.86253  +42.307564     91.767 0.740677  +0.669630    US/Massachuse  Clay Center Observatory, Brookline
- 3 I02  289.1949   -30.167725   2141.124 0.86558   -0.49976     Chile          Cerro Tololo Observatory, La Serena--2MASS
- 3 I03  289.26626  -29.258822   2345.440 0.873440  -0.486052    Chile          European Southern Obs., La Silla--ASTROVIRTEL
- 3 I04  289.3152   -29.989924    673.397 0.86693   -0.49697     Chile          Mamalluca Observatory
- 3 I05  289.2980   -29.003554   2270.438 0.87559   -0.48217     Chile          Las Campanas Observatory-TIE
- 3 I06  289.8061   +41.677592     33.057 0.74801   +0.66147     US/Massachuse  Werner Schmidt Obs., Dennis-Yarmouth Regional HS
- 3 I07  288.0971   +42.129084    300.990 0.74279   +0.66735     US/Massachuse  Conlin Hill Observatory, Oxford
- 3 I08  290.6932   -31.786778   2664.865 0.85116   -0.52394     Argentina      Alianza S4, Cerro Burek
- 3 I09  289.80377  -24.597743   2705.711 0.910166  -0.413875    Chile          Cerro Armazones
- 3 I10  291.8200   -22.952297   2431.716 0.92165   -0.38770     Chile          CAO, San Pedro de Atacama (until 2012)
- 3 I11  289.26345  -30.240641   2715.440 0.865020  -0.500901    Chile          Gemini South Observatory, Cerro Pachon
- 3 I12  288.87053  +42.647556     98.300 0.736679  +0.673998    US/Massachuse  Phillips Academy Observatory, Andover
- 3 I13  282.93006  +38.914982     60.338 0.779116  +0.624793    US/Dist. of C  Burleith Observatory, Washington D.C.
- 3 I14  288.58931  +42.339622     65.265 0.740298  +0.670040    US/Massachuse  Tigh Speuran Observatory, Framingham
- 3 I15  288.70076  +41.761526      4.679 0.747034  +0.662558    US/Rhode Isla  Wishing Star Observatory, Barrington
- 3 I16  291.82033  -22.953362   2398.547 0.921638  -0.387715    Chile          IAA-AI Atacama, San Pedro de Atacama
- 3 I17  284.32206  +41.596355    400.641 0.748993  +0.660451    US/Pennsylvan  Thomas G. Cupillari Observatory, Fleetville
- 3 I18  281.3067   +37.878395    536.966 0.79038   +0.61070     US/Virginia    Fan Mountain Observatory, Covesville
- 3 I19  295.40711  -31.356805    863.573 0.854834  -0.517422    Argentina      Observatorio El Gato Gris, Tanti
- 3 I20  295.68161  -33.106600    437.543 0.838551  -0.543122    Argentina      Observatorio Astronomico Salvador, Rio Cuarto
- 3 I21  295.8281   -31.371056    452.376 0.85465   -0.51760     Argentina      El Condor Observatory, Cordoba
- 3 I22  296.17399  +44.689361     90.320 0.712120  +0.699724    Canada/Nova S  Abbey Ridge Observatory, Stillwater Lake
- 3 I23  292.26649  +44.520760      2.981 0.714173  +0.697623    US/Maine       Frosty Cold Observatory, Mash Harbor
- 3 I24  282.2306   +38.342850    122.468 0.78534   +0.61702     US/Virginia    Lake of the Woods Observatory, Locust Grove
- 3 I25  295.44381  -31.795292   1201.662 0.850887  -0.523945    Argentina      ECCCO Observatory, Bosque Alegre
- 3 I26  295.8214   -31.424228    464.209 0.85417   -0.51839     Argentina      Observatorio Kappa Crucis, Cordoba
- 3 I27  284.0006   +45.347441     95.776 0.70401   +0.70783     Canada/Ontari  Barred Owl Observatory, Carp
- 3 I28  289.0889   +41.813840     30.905 0.74643   +0.66324     US/Massachuse  Starhoo Observatory, Lakeville
- 3 I29  288.63304  +42.498408     60.234 0.738432  +0.672081    US/Massachuse  Middlesex School Observatory, Concord
- 3 I30  299.3417   -32.984475     64.497 0.83966   -0.54131     Argentina      Observatorio Geminis Austral
- 3 I31  299.3649   -32.953687     54.393 0.83995   -0.54086     Argentina      Observatorio Astronomico del Colegio Cristo Rey
- 3 I32  299.3464   -32.980641     16.675 0.83969   -0.54125     Argentina      Observatorio Beta Orionis, Rosario
- 3 I33  289.26631  -30.237926   2776.132 0.865052  -0.500865    Chile          SOAR, Cerro Pachon
- 3 I34  284.1297   +40.146752    155.206 0.76548   +0.64134     US/Pennsylvan  Morgantown
- 3 I35  301.5572   -34.807262     47.885 0.82198   -0.56762     Argentina      Sidoli
- 3 I36  301.28271  -35.008112     26.061 0.819978  -0.570483    Argentina      Observatorio Los Campitos, Canuelas
- 3 I37  301.35275  -34.440042      1.504 0.825603  -0.562360    Argentina      Astrodomi Observatory, Santa Rita
- 3 I38  302.02141  -31.392540     37.679 0.854400  -0.517885    Uruguay        Observatorio Los Algarrobos, Salto
- 3 I39  301.42661  -34.669660     33.927 0.823342  -0.565652    Argentina      Observatorio Cruz del Sur, San Justo
- 3 I40  289.26061  -29.254610   2317.774 0.873472  -0.485986    Chile          La Silla--TRAPPIST
- 3 I41  243.14022  +33.357339   1664.000 0.836322  +0.546875    US/California  Palomar Mountain--ZTF
- 3 I42  288.9081   +41.596233     21.932 0.74895   +0.66041     US/Massachuse  Westport Observatory
- 3 I43  261.90237  +32.216192    395.386 0.846901  +0.530084    US/Texas       Tarleton State University Obs., Stephenville
- 3 I44  273.5176   +30.542034     59.200 0.86201   +0.50521     US/Florida     Northwest Florida State College, Niceville
- 3 I45  301.4281   -34.677922     31.971 0.82326   -0.56577     Argentina      W Crusis Astronomical Observatory, San Justo
- 3 I46  281.6108   +40.464743    332.805 0.76192   +0.64558     US/Pennsylvan  The Cottage Observatory, Altoona
- 3 I47  290.5503   -35.495442   1394.125 0.81526   -0.57753     Argentina      Pierre Auger Observatory, Malargue
- 3 I48  295.6757   -36.637775    139.771 0.80340   -0.59348     Argentina      Observatorio El Catalejo, Santa Rosa
- 3 I49  253.98617  +35.709179   2085.219 0.813183  +0.580617    US/New Mexico  Sunflower Observatory, Santa Fe
- 3 I50  254.47142  +32.903277   2223.377 0.840712  +0.540309    US/New Mexico  P2 Observatory, Mayhill
- 3 I51  283.0547   +38.711560     17.782 0.78133   +0.62203     US/Maryland    Clinton
- 3 I52  249.21108  +32.442573   2761.053 0.845109  +0.533609    US/Arizona     Steward Observatory, Mt. Lemmon Station
- 3 I53  356.3783   +37.140060    668.536 0.79822   +0.60052     Spain          Armilla
- 3 I54  353.03081  +38.849002    192.307 0.779853  +0.623912    Spain          Observatorio Las Vaguadas, Badajoz
- 3 I55  359.64214  +39.491506     26.918 0.772769  +0.632566    Spain          Valencia
- 3 I56  357.71066  +36.849853     56.089 0.801182  +0.596429    Spain          Observatorio Astronomico John Beckman, Almeria
- 3 I57  359.3256   +38.301573    159.427 0.78579   +0.61646     Spain          Elche
- 3 I58  359.5374   +39.556598    126.971 0.77206   +0.63345     Spain          Betera
- 3 I59  356.1558   +43.415709     21.985 0.72754   +0.68377     Spain          Observatorio Fuente de los matos, Muriedas
- 3 I60  357.1781   +47.722283     86.074 0.67397   +0.73630     France         Guernanderf
- 3 I61  352.1494   +42.326604    231.949 0.74047   +0.66989     Spain          Ourense
- 3 I62  356.42639  +40.009691    619.317 0.767072  +0.639561    Spain          Observatorio Helios Ontigola
- 3 I63  358.8330   +51.085851     80.634 0.62944   +0.77446     UK/England     Cygnus Observatory, New Airesford
- 3 I64  359.29386  +51.519441     27.111 0.623532  +0.779182    UK/England     Maidenhead
- 3 I65  355.0796   +36.736299    729.935 0.80245   +0.59491     Spain          Yunquera
- 3 I66  312.0000   -15.857427   1093.369 0.96235   -0.27153     Brazil         Taurus Australis Observatory, Brasilia
- 3 I67  359.08753  +51.306464     68.739 0.626440  +0.776870    UK/England     Hartley Wintney
- 3 I68  312.4981   -14.317305   1122.439 0.96931   -0.24573     Brazil         Pousada dos Anoes Observatory
- 3 I69  352.0069   +31.627448    444.626 0.85232   +0.52140     Morocco        AGM Observatory, Marrakech
- 3 I70  359.94158  +52.926531      7.925 0.604128  +0.794217    UK/England     Gedney House Observatory, Kirton
- 3 I71  353.6698   +39.449234    549.267 0.77330   +0.63205     Spain          Observatorio Los Milanos, Caceres
- 3 I72  355.9849   +40.711357   1205.070 0.75923   +0.64893     Spain          Observatorio Carpe-Noctem, Madrid
- 3 I73  359.58711  +47.982660    146.819 0.670611  +0.739353    France         Salvia Observatory, Saulges
- 3 I74  358.18739  +51.074819     63.290 0.629588  +0.774337    UK/England     Baxter Garden Observatory, Salisbury
- 3 I75  359.9650   +39.979142     87.936 0.76735   +0.63910     Spain          Observatorio Los Caracoles, Castello
- 3 I76  355.93681  +40.500702    831.635 0.761573  +0.646107    Spain          Observatorio Tesla, Valdemorillo
- 3 I77  316.0025   -19.830315    854.414 0.94119   -0.33714     Brazil         CEAMIG-REA Observatory, Belo Horizonte
- 3 I78  355.5721   +36.733411     92.875 0.80240   +0.59481     Spain          Observatorio Principia, Malaga
- 3 I79  357.6733   +38.165641   1586.569 0.78743   +0.61474     Spain          AstroCamp, Nerpio
- 3 I80  358.13328  +53.882005    218.302 0.590762  +0.804183    UK/England     Rose Cottage Observatory, Keighley
- 3 I81  356.20111  +57.844125     48.979 0.533510  +0.842967    UK/Scotland    Tarbatness Observatory, Portmahomack
- 3 I82  343.5797   +28.317208    371.593 0.88105   +0.47156     Canary Island  Guimar
- 3 I83  353.1900   +53.487043     50.599 0.59630   +0.80008     Ireland        Cherryvalley Observatory, Rathmolyon
- 3 I84  353.0212   +38.866246    235.772 0.77967   +0.62415     Spain          Cerro del Viento, Badajoz
- 3 I85  357.9848   +36.880773     62.193 0.80086   +0.59686     Spain          Las Negras
- 3 I86  356.2739   +40.451107    634.072 0.76211   +0.64543     Spain          Observatorio UCM, Madrid
- 3 I87  352.9593   +53.136421     92.729 0.60121   +0.79643     Ireland        Astroshot Observatory, Monasterevin
- 3 I88  356.0823   +37.646781    710.468 0.79287   +0.60753     Spain          Fuensanta de Martos
- 3 I89  357.6739   +38.165286   1636.716 0.78744   +0.61474     Spain          iTelescope Observatory, Nerpio
- 3 I90  351.59760  +51.900379     13.729 0.618315  +0.783298    Ireland        Blackrock Castle Observatory
- 3 I91  357.69250  +36.848496     22.977 0.801192  +0.596407    Spain          Retamar
- 3 I92  353.95289  +37.345585    119.226 0.795987  +0.603315    Spain          Astreo Observatory, Mairena del Aljarafe
- 3 I93  359.79704  +44.558673     68.359 0.713717  +0.698101    France         St Pardon de Conques
- 3 I94  356.1367   +40.495586    740.648 0.76162   +0.64603     Spain          Observatorio Rho Ophiocus, Las Rozas de Madrid
- 3 I95  356.81394  +39.568615    674.998 0.771993  +0.633666    Spain          Observatorio de la Hita
- 3 I96  356.50384  +40.793540    676.395 0.758233  +0.649960    Spain          Hyperion Observatory, Urbanizacion Caraquiz
- 3 I97  359.50178  +51.639937     66.217 0.621889  +0.780493    UK/England     Penn Heights Observatory, Rickmansworth
- 3 I98  356.41339  +40.883277   1054.554 0.757256  +0.651181    Spain          El Berrueco
- 3 I99  356.46043  +40.352499    618.930 0.763221  +0.644121    Spain          Observatorio Blanquita, Vaciamadrid
- 3 J00  359.5056   +39.852563    387.539 0.76880   +0.63744     Spain          Segorbe
- 3 J01  354.28450  +42.377689    813.776 0.739938  +0.670609    Spain          Observatorio Cielo Profundo, Leon
- 3 J02  359.5550   +38.475838    187.428 0.78391   +0.61884     Spain          Busot
- 3 J03  355.13250  +50.394175    142.538 0.638787  +0.766833    UK/England     Gothers Observatory, St. Dennis
- 3 J04  343.48817  +28.300959   2451.325 0.881471  +0.471466    Canary Island  ESA Optical Ground Station, Tenerife
- 3 J05  355.29639  +41.545557    716.135 0.749617  +0.659822    Spain          Bootes Observatory, Boecillo
- 3 J06  358.81247  +52.909132     48.265 0.604374  +0.794039    UK/England     Trent Astronomical Observatory, Clifton
- 3 J07  353.89543  +39.935161    414.738 0.767881  +0.638546    Spain          Observatorio SPAG Monfrague, Palazuelo-Empalme
- 3 J08  359.6549   +39.627133     65.096 0.77127   +0.63439     Spain          Observatorio Zonalunar, Puzol
- 3 J09  353.7917   +53.615299     53.452 0.59450   +0.80141     Ireland        Balbriggan
- 3 J10  359.59839  +38.426006     87.067 0.784437  +0.618151    Spain          Alicante
- 3 J11  351.31769  +41.765965     17.453 0.746984  +0.662617    Portugal       Matosinhos
- 3 J12  356.51061  +40.792499    702.988 0.758248  +0.649949    Spain          Caraquiz
- 3 J13  342.1208   +28.762516   2387.634 0.87763   +0.47851     Canary Island  La Palma-Liverpool Telescope
- 3 J14  345.99281  +28.405033    211.647 0.880303  +0.472891    Canary Island  La Corte
- 3 J15  352.83061  +41.036699    339.349 0.755420  +0.653125    Portugal       Muxagata
- 3 J16  354.20356  +54.338324     18.074 0.584292  +0.808826    UK/NIreland    An Carraig Observatory, Loughinisland
- 3 J17  357.20313  +52.525604    308.523 0.609723  +0.790018    UK/England     Ragdon
- 3 J18  356.90600  +52.510610    197.500 0.609920  +0.789845    UK/Wales       Dingle Observatory, Montgomery
- 3 J19  359.83036  +40.221450    406.820 0.764671  +0.642359    Spain          El Maestrat
- 3 J20  356.21926  +40.459348    651.801 0.762019  +0.645541    Spain          Aravaca
- 3 J21  356.08003  +40.723283    956.626 0.759065  +0.649062    Spain          El Boalo
- 3 J22  342.13235  +28.641561    754.099 0.878415  +0.476543    Canary Island  Tacande Observatory, La Palma
- 3 J23  358.49361  +47.893049     91.582 0.671765  +0.738300    France         Centre Astronomique de La Couyere
- 3 J24  343.55719  +28.246779    597.052 0.881661  +0.470499    Canary Island  Observatorio Altamira
- 3 J25  354.48883  +43.359111    230.593 0.728241  +0.683076    Spain          Penamayor Observatory, Nava
- 3 J26  356.98119  +52.325044    419.779 0.612507  +0.787898    UK/Wales       The Spaceguard Centre, Knighton
- 3 J27  355.96899  +40.607513    909.034 0.760373  +0.647528    Spain          El Guijo Observatory
- 3 J28  356.21381  +37.781625    497.289 0.791408  +0.609366    Spain          Jaen
- 3 J29  346.34213  +28.957746    223.350 0.875695  +0.481318    Canary Island  Observatorio Nira, Tias
- 3 J30  356.29300  +40.468314    713.058 0.761925  +0.645666    Spain          Observatorio Ventilla, Madrid
- 3 J31  355.77411  +36.729515    128.362 0.802445  +0.594759    Spain          La Axarquia
- 3 J32  352.97769  +37.270489     38.906 0.796769  +0.602268    Spain          Aljaraque
- 3 J33  359.90600  +51.774991     66.912 0.620040  +0.781953    UK/England     University of Hertfordshire Obs., Bayfordbury
- 3 J34  355.22711  +41.625192    703.402 0.748695  +0.660858    Spain          La Fecha
- 3 J35  356.02911  +37.712491    678.328 0.792167  +0.608432    Spain          Tucci Observatory, Martos
- 3 J36  356.94519  +40.171906      0.137 0.765179  +0.641659    Spain          Observatorio DiezALaOnce, Illana
- 3 J37  353.06469  +37.258673     34.976 0.796893  +0.602104    Spain          Huelva
- 3 J38  353.60924  +43.472663    278.726 0.726887  +0.684518    Spain          Observatorio La Vara, Valdes
- 3 J39  344.5636   +27.920212    291.074 0.88429   +0.46547     Canary Island  Ingenio
- 3 J40  355.55847  +36.718766     42.102 0.802546  +0.594601    Spain          Malaga
- 3 J41  353.8189   +53.380563     26.052 0.59779   +0.79897     Ireland        Raheny
- 3 J42  359.6989   +39.616909     36.067 0.77138   +0.63425     Spain          Puzol
- 3 J43  352.13354  +31.206440   2724.687 0.856441  +0.515339    Morocco        Oukaimeden Observatory, Marrakech
- 3 J44  357.6552   +42.793367   1001.634 0.73506   +0.67596     Spain          Observatorio Iturrieta, Alava
- 3 J45  344.46735  +28.011631    875.528 0.883626  +0.466916    Canary Island  Observatorio Montana Cabreja, Vega de San Mateo
- 3 J46  346.3594   +28.957482    170.742 0.87569   +0.48131     Canary Island  Observatorio Montana Blanca, Tias
- 3 J47  346.4440   +29.041376    366.222 0.87501   +0.48260     Canary Island  Observatorio Nazaret
- 3 J48  343.6960   +28.472217    378.167 0.87977   +0.47393     Canary Island  Observatory Mackay, La Laguna
- 3 J49  359.4482   +38.192624     47.317 0.78695   +0.61496     Spain          Santa Pola
- 3 J50  342.1176   +28.760222   2320.790 0.87764   +0.47847     Canary Island  La Palma-NEON
- 3 J51  343.72898  +28.465574    116.816 0.879789  +0.473809    Canary Island  Observatorio Atlante, Tenerife
- 3 J52  358.6608   +42.199032    367.640 0.74198   +0.66826     Spain          Observatorio Pinsoro
- 3 J53  354.89278  +37.801935     98.520 0.791142  +0.609607    Spain          Posadas
- 3 J54  343.4906   +28.298111   2418.933 0.88149   +0.47142     Canary Island  Bradford Robotic Telescope
- 3 J55  344.3144   +27.768871     87.664 0.88549   +0.46313     Canary Island  Los Altos de Arguineguin Observatory
- 3 J56  344.4536   +27.962862   1859.801 0.88416   +0.46624     Canary Island  Observatorio La Avejerilla
- 3 J57  358.89089  +39.950159   1277.011 0.767817  +0.638833    Spain          Centro Astronomico Alto Turia, Valencia
- 3 J58  356.6644   +51.556074    112.885 0.62304   +0.77959     UK/Wales       Brynllefrith Observatory, Llantwit Fardre
- 3 J59  356.20256  +43.464438     18.924 0.726956  +0.684386    Spain          Observatorio Linceo, Santander
- 3 J60  354.3406   +41.711440    990.475 0.74773   +0.66201     Spain          Tocororo Observatory, Arquillinos
- 3 J61  353.4264   +53.423544     48.757 0.59719   +0.79942     Ireland        Brownstown Observatory, Kilcloon
- 3 J62  351.6345   +53.923156     91.250 0.59017   +0.80459     Ireland        Kingsland Observatory, Boyle
- 3 J63  359.4831   +38.329297     71.202 0.78548   +0.61683     Spain          San Gabriel
- 3 J64  359.3459   +38.028481     22.753 0.78871   +0.61271     Spain          La Mata
- 3 J65  353.4497   +53.344457     73.534 0.59830   +0.79860     Ireland        Celbridge
- 3 J66  357.7833   +52.452879    104.357 0.61071   +0.78922     UK/England     Kinver
- 3 J67  359.4667   +39.639860    158.849 0.77114   +0.63457     Spain          Observatorio La Puebla de Vallbona
- 3 J68  357.7055   +51.914101     48.763 0.61813   +0.78345     UK/England     Tweenhills Observatory, Hartpury
- 3 J69  358.98034  +50.938988    200.998 0.631443  +0.772863    UK/England     North Observatory, Clanfield
- 3 J70  358.8404   +37.938923    110.177 0.78968   +0.61149     Spain          Obs. Astronomico Vega del Thader, El Palmar
- 3 J71  357.8947   +53.687268    177.344 0.59350   +0.80217     UK/England     Willow Bank Observatory
- 3 J72  358.9664   +37.849820    252.274 0.79065   +0.61028     Spain          Valle del Sol
- 3 J73  359.0833   +51.872472     33.932 0.6187    +0.7830      UK/England     Quainton
- 3 J74  357.0961   +43.251635     10.842 0.72950   +0.68169     Spain          Bilbao
- 3 J75  357.43471  +37.982402   1513.658 0.789388  +0.612222    Spain          OAM Observatory, La Sagra
- 3 J76  358.79718  +37.840245    403.868 0.790771  +0.610163    Spain          La Murta
- 3 J77  357.5947   +50.930949     80.816 0.63154   +0.77276     UK/England     Golden Hill Observatory, Stourton Caundle
- 3 J78  358.8244   +38.014670    119.524 0.78887   +0.61253     Spain          Murcia
- 3 J79  358.38066  +37.389097     27.208 0.795516  +0.603908    Spain          Observatorio Calarreona, Aguilas
- 3 J80  359.1083   +44.973688     24.471 0.70862   +0.70323     France         Sainte Helene
- 3 J81  358.13489  +42.711748    644.382 0.735984  +0.674878    Spain          Guirguillano
- 3 J82  357.3067   +53.684892   -182.414 0.5935    +0.8021      UK/England     Leyland
- 3 J83  357.3883   +53.740348     33.423 0.59274   +0.80270     UK/England     Olive Farm Observatory, Hoghton
- 3 J84  358.9803   +50.938652    124.559 0.63144   +0.77285     UK/England     South Observatory, Clanfield
- 3 J85  357.4833   +55.578572    366.961 0.5666    +0.8213      UK/Scotland    Makerstoun
- 3 J86  356.6153   +37.064136   2930.527 0.79930   +0.59968     Spain          Sierra Nevada Observatory
- 3 J87  355.5067   +40.603975   1387.041 0.76047   +0.64753     Spain          La Canada
- 3 J88  358.5592   +50.922439     27.881 0.63165   +0.77266     UK/England     Strawberry Field Obs., Southampton
- 3 J89  356.2861   +40.598618    709.071 0.76045   +0.64739     Spain          Tres Cantos Observatory
- 3 J90  358.5317   +51.594484     60.692 0.62251   +0.78000     UK/England     West Challow
- 3 J91  357.0483   +42.272956    242.106 0.7411    +0.6692      Spain          Alt emporda Observatory, Figueres
- 3 J92  359.3487   +51.622145    144.821 0.62214   +0.78031     UK/England     Beaconsfield
- 3 J93  357.7426   +51.830842     22.467 0.61927   +0.78255     UK/England     Mount Tuffley Observatory, Gloucester
- 3 J94  357.7886   +51.844268     65.319 0.61909   +0.78270     UK/England     Abbeydale
- 3 J95  358.55301  +51.474960    157.984 0.624152  +0.778715    UK/England     Great Shefford
- 3 J96  356.05669  +42.771620   1077.143 0.735326  +0.675690    Spain          Observatorio de Cantabria
- 3 J97  359.5333   +39.250576   -214.484 0.7754    +0.6293      Spain          Alginet
- 3 J98  359.5344   +39.493264     30.750 0.77275   +0.63259     Spain          Observatorio Manises
- 3 J99  359.57808  +39.508013     49.802 0.772589  +0.632790    Spain          Burjassot
- 3 K00    8.94836  +50.107653    152.765 0.642630  +0.763639    Germany        Hanau
- 3 K01    0.62091  +51.877481     82.965 0.618636  +0.783060    UK/England     Astrognosis Observatory, Bradwell
- 3 K02    0.66761  +51.568808     30.723 0.622858  +0.779718    UK/England     Eastwood Observatory, Leigh on Sea
- 3 K03    0.74411  +42.018981    799.682 0.744133  +0.665979    Spain          Observatori AAS Montsec
- 3 K04    0.74416  +42.019267    802.544 0.744130  +0.665983    Spain          Lo Fossil Observatory, Ager
- 3 K05    1.02311  +52.454288     88.474 0.610689  +0.789233    UK/England     Eden Observatory, Banham
- 3 K06    1.99950  +41.538882    408.515 0.749658  +0.659703    Spain          Observatorio Montagut, Can Sola
- 3 K07    2.4614   +48.817494    177.468 0.65973   +0.74902     France         Observatoire de Gravelle, St. Maurice
- 3 K08    1.8800   +41.386982    497.949 0.75142   +0.65773     Spain          Observatorio Lledoner, Vallirana
- 3 K09    2.2400   +41.602815    159.213 0.74889   +0.66051     Spain          Llica d'Amunt
- 3 K10    5.4214   +44.170140    601.460 0.71851   +0.69332     France         Micro Palomar, Reilhanette
- 3 K11    2.88079  +45.879436    764.988 0.697458  +0.714390    France         Observatoire de Pommier
- 3 K12    2.7267   +39.632871     95.809 0.77121   +0.63447     Spain          Obsevatorio Astronomico de Marratxi
- 3 K13    2.9124   +39.728341    105.355 0.77015   +0.63575     Spain          Albireo Observatory, Inca
- 3 K14    2.9131   +39.661042    119.816 0.77090   +0.63485     Spain          Observatorio de Sencelles
- 3 K15    3.75522  +43.615884    136.003 0.725152  +0.686311    France         Murviel-les-Montpellier
- 3 K16    5.42106  +44.167417    574.277 0.718540  +0.693283    France         Reilhanette
- 3 K17    7.02679  +46.247616    442.189 0.692802  +0.718806    Switzerland    Observatoire des Valentines, Bex
- 3 K18    7.5242   +47.575615    279.709 0.67588   +0.73460     France         Hesingue
- 3 K19    5.64731  +43.999461    629.298 0.720582  +0.691187    France         PASTIS Observatory, Banon
- 3 K20    4.68015  +50.135470    185.578 0.642261  +0.763954    Belgium        Danastro Observatory, Romeree
- 3 K21    4.9292   +43.958569     38.175 0.72101   +0.69061     France         Saint-Saturnin-les-Avignon
- 3 K22    5.07611  +43.693108    123.948 0.724222  +0.687283    France         Les Barres Observatory, Lamanon
- 3 K23    9.4023   +45.535727    166.859 0.70168   +0.71014     Italy          Gorgonzola
- 3 K24    6.86069  +49.443210    251.411 0.651487  +0.756168    Germany        Schmelz
- 3 K25    5.7136   +43.916838    530.129 0.72157   +0.69014     France         Haute Provence Sud, Saint-Michel-l'Observatoire
- 3 K26    6.2201   +49.582230    318.154 0.64965   +0.75775     Luxembourg     Contern
- 3 K27    6.2094   +47.026599    715.563 0.68296   +0.72816     France         St-Martin Observatory, Amathay Vesigneux
- 3 K28    6.8947   +50.804161    127.442 0.63326   +0.77137     Germany        Sternwarte Eckdorf
- 3 K29    7.78347  +45.983391   3140.549 0.696415  +0.715918    Switzerland    Stellarium Gornergrat
- 3 K30    7.14839  +47.046621    429.178 0.682674  +0.728365    Switzerland    Luscherz
- 3 K31    7.00361  +44.579323   1782.993 0.713656  +0.698546    Italy          Osservatorio Astronomico di Bellino
- 3 K32    7.52964  +44.363780    574.207 0.716152  +0.695733    Italy          Maritime Alps Observatory, Cuneo
- 3 K33    7.49761  +44.394665    568.590 0.715775  +0.696117    Italy          San Defendente
- 3 K34    7.7005   +45.109230    215.772 0.70697   +0.70492     Italy          Turin
- 3 K35    8.16369  +50.313008    202.387 0.639883  +0.765937    Germany        Huenfelden
- 3 K36    8.24887  +49.918185    205.646 0.645167  +0.761522    Germany        Ebersheim
- 3 K37    8.3148   +45.075143    119.476 0.70738   +0.70449     Italy          Cereseto
- 3 K38    8.91824  +45.873785    547.891 0.697505  +0.714297    Italy          M57 Observatory, Saltrio
- 3 K39    8.95556  +44.533546    568.557 0.714080  +0.697844    Italy          Serra Observatory
- 3 K40    9.0135   +48.625483    505.977 0.66228   +0.74685     Germany        Altdorf
- 3 K41    8.7930   +44.771183    209.877 0.71113   +0.70075     Italy          Vegaquattro Astronomical Obs., Novi Ligure
- 3 K42    8.3332   +49.035841     81.185 0.65685   +0.75151     Germany        Knielingen
- 3 K43    9.8389   +46.310097   1688.958 0.69215   +0.71970     Italy          OVM Observatory, Chiesa in Valmalencom
- 3 K44    9.97331  +52.130403    105.169 0.615161  +0.785779    Germany        Marienburg Sternwarte, Hildesheim
- 3 K45   10.49814  +42.932791     53.569 0.733299  +0.677639    Italy          Oss. Astronomico di Punta Falcone, Piombino
- 3 K46   10.9114   +49.885015    210.620 0.64561   +0.76115     Germany        Bamberg
- 3 K47   10.68822  +43.689188     16.607 0.724257  +0.687222    Italy          BSCR Observatory, Santa Maria a Monte
- 3 K48   10.83881  +45.209185     25.648 0.705714  +0.706127    Italy          Keyhole Observatory, San Giorgio di Mantova
- 3 K49   11.18581  +43.681117    253.729 0.724381  +0.687146    Italy          Carpione Observatory, Spedaletto
- 3 K50   11.13300  +49.790115    489.515 0.646903  +0.760116    Germany        Sternwarte Feuerstein, Ebermannstadt
- 3 K51   11.65789  +46.029483   1295.483 0.695636  +0.716268    Italy          Osservatorio del Celado, Castello Tesino
- 3 K52    7.6478   +45.230562    300.858 0.70548   +0.70642     Italy          Gwen Observatory, San Francesco al Campo
- 3 K53   12.04564  +41.981365      7.018 0.744479  +0.665409    Italy          Marina di Cerveteri
- 3 K54   11.33678  +43.312669    290.262 0.728803  +0.682494    Italy          Astronomical Observatory University of Siena
- 3 K55    7.76500  +49.886880    219.303 0.645586  +0.761172    Germany        Wallhausen
- 3 K56   12.70497  +42.960268    228.436 0.732993  +0.678008    Italy          Osservatorio di Foligno
- 3 K57   13.0444   +45.786125     -8.225 0.69854   +0.71317     Italy          Fiore Observatory
- 3 K58    7.4497   +51.300825    407.813 0.62655   +0.77685     Germany        Gevelsberg
- 3 K59   13.27744  +51.747997     78.696 0.620411  +0.781663    Germany        Elsterland Observatory, Jessnigk
- 3 K60   13.51069  +55.435949     40.994 0.568623  +0.819848    Sweden         Lindby
- 3 K61   13.6026   +49.751403    406.207 0.64741   +0.75967     Czech Republi  Rokycany Observatory
- 3 K62   13.84675  +50.638321    277.939 0.635514  +0.769557    Czech Republi  Teplice Observatory
- 3 K63   10.46252  +44.082789    302.917 0.719536  +0.692195    Italy          G. Pascoli Observatory, Barga (before June 2023)
- 3 K64   11.74397  +49.935479    471.055 0.644963  +0.761748    Germany        Waizenreuth
- 3 K65   12.2339   +44.141649     16.634 0.71879   +0.69290     Italy          Cesena
- 3 K66   12.62861  +41.463359     80.963 0.750491  +0.658684    Italy          Osservatorio Astronomico di Anzio
- 3 K67   13.3610   +48.927653    825.982 0.65835   +0.75036     Germany        Bayerwald Sternwarte, Spiegelau
- 3 K68   14.90512  +40.657713    112.353 0.759709  +0.648110    Italy          Osservatorio Elianto, Pontecagnano
- 3 K69   10.9941   +51.090688    138.035 0.62938   +0.77452     Germany        Riethnordhausen
- 3 K70   15.9736   +38.489205     63.305 0.78375   +0.61901     Italy          Rosarno
- 3 K71   12.2159   +48.989760    309.413 0.65748   +0.75101     Germany        Neutraubling
- 3 K72   16.3396   +39.311045    744.864 0.77485   +0.63021     Italy          Celico
- 3 K73   16.4158   +40.820758    396.003 0.75789   +0.65029     Italy          Gravina in Puglia
- 3 K74   10.2364   +49.805279    183.022 0.64667   +0.76025     Germany        Muensterschwarzach Observatory, Schwarzach
- 3 K75   11.7289   +46.560481   1529.327 0.68897   +0.72269     Italy          Astro Dolomites, Santa Cristina Valgardena
- 3 K76    7.62898  +44.580531    410.924 0.713488  +0.698410    Italy          BSA Osservatorio, Savigliano
- 3 K77   11.2903   +49.797364    425.892 0.64680   +0.76019     Germany        EHB01 Observatory, Engelhardsberg
- 3 K78    9.85356  +44.126277    110.112 0.718987  +0.692718    Italy          iota Scorpii Observatory, La Spezia
- 3 K79   11.05789  +50.959372    283.142 0.631175  +0.773097    Germany        Erfurt
- 3 K80   16.63733  +52.442301    132.413 0.610859  +0.789111    Poland         Platanus Observatory, Lusowko
- 3 K81   13.78511  +41.624624    399.907 0.748666  +0.660819    Italy          P.M.P.H.R. Deep Sky Observatory, Atina
- 3 K82   17.5894   +40.689134    259.949 0.75937   +0.64854     Italy          Alphard Observatory, Ostuni
- 3 K83   11.04317  +43.755333    249.665 0.723487  +0.688080    Italy          Beppe Forti Astronomical Observatory, Montelupo
- 3 K84   10.75861  +44.187683    983.975 0.718340  +0.693581    Italy          Felliscopio Observatory, Fellicarolo
- 3 K85    6.03161  +50.723994    238.039 0.634354  +0.770499    Belgium        Kelmis
- 3 K86   10.18189  +45.549196    199.075 0.701516  +0.710308    Italy          Brescia
- 3 K87   10.17011  +49.807693    273.486 0.646647  +0.760288    Germany        Dettelbach Vineyard Observatory
- 3 K88   19.89367  +47.917455    983.456 0.671543  +0.738689    Hungary        GINOP-KHK, Piszkesteto
- 3 K89   11.56339  +42.480015    204.001 0.738665  +0.671860    Italy          Digital Stargate Observatory, Manciano
- 3 K90   20.54577  +44.530241    323.499 0.714093  +0.697776    Serbia         Sopot Astronomical Observatory
- 3 K91   20.81019  -32.380542   1806.975 0.845561  -0.532618    South Africa   Sutherland-LCO A
- 3 K92   20.81004  -32.380542   1806.975 0.845561  -0.532618    South Africa   Sutherland-LCO B
- 3 K93   20.81011  -32.380670   1808.420 0.845560  -0.532620    South Africa   Sutherland-LCO C
- 3 K94   20.81097  -32.379959   1765.986 0.845561  -0.532606    South Africa   Sutherland
- 3 K95   20.81106  -32.380484   1757.578 0.845555  -0.532613    South Africa   MASTER-SAAO Observatory, Sutherland
- 3 K96   16.75119  +39.314406   1215.321 0.774870  +0.630302    Italy          Savelli Observatory
- 3 K97    7.18026  +48.467691    688.105 0.664361  +0.745050    France         Freconrupt
- 3 K98   17.07217  +52.633870    121.861 0.608205  +0.791142    Poland         6ROADS Observatory 1, Wojnowko
- 3 K99   22.45350  +48.563384    234.847 0.663064  +0.746102    Ukraine        Derenivka Observatory
- 3 L00   12.5375   +41.907402     93.279 0.74535   +0.66446     Italy          East Rome Observatory, Rome
- 3 L01   13.74930  +45.290899    380.986 0.704742  +0.707169    Croatia        Visnjan Observatory, Tican
- 3 L02   20.81658  +39.652455    580.427 0.771051  +0.634781    Greece         NOAK Observatory, Stavraki
- 3 L03   14.73081  +47.896626    531.662 0.671765  +0.738393    Austria        SGT Observatory, Gaflenz
- 3 L04   23.59640  +46.820954    394.350 0.685544  +0.725675    Romania        ROASTERR-1 Observatory, Cluj-Napoca
- 3 L05   10.0699   +45.596590    233.706 0.70093   +0.71089     Italy          Dridri Observatory, Franciacorta
- 3 L06    9.25403  +45.970103    372.867 0.696280  +0.715445    Italy          Sormano 2 Observatory, Bellagio Via Lattea
- 3 L07   14.56406  +40.623927    733.082 0.760166  +0.647727    Italy          Osservatorio Salvatore di Giacomo, Agerola
- 3 L08   24.39447  +60.220516     72.764 0.497926  +0.864325    Finland        Metsahovi Optical Telescope, Metsahovi
- 3 L09   20.80987  -32.380652   1799.618 0.845559  -0.532619    South Africa   Sutherland-LCO Aqawan A #1
- 3 L10   22.6186   +37.972222    971.259 0.78943   +0.61203     Greece         Kryoneri Observatory
- 3 L11   17.2092   +59.805209     79.327 0.50421   +0.86070     Sweden         Sandvreten Observatory
- 3 L12    2.67789  +51.113033     49.998 0.629068  +0.774754    Belgium        Koksijde
- 3 L13   25.62193  +45.641596    594.461 0.700409  +0.711479    Romania        Stardust Observatory, Brasov
- 3 L14    4.92247  +45.777818    222.737 0.698669  +0.713095    France         Planetarium de Vaulx-en-Velin Observatory
- 3 L15   25.97839  +45.007006    244.838 0.708234  +0.703665    Romania        St. George Observatory, Ploiesti
- 3 L16   26.04561  +45.203696    370.724 0.705820  +0.706098    Romania        Stardreams Observatory, Valenii de Munte
- 3 L17    2.7114   +42.306713    290.357 0.74071   +0.66964     Spain          Observatori Astronomic Albanya
- 3 L18   26.71828  +48.848295    393.395 0.659348  +0.749399    Ukraine        QOS Observatory, Zalistsi
- 3 L19   11.15258  +44.356284    696.270 0.716257  +0.695653    Italy          Osservatorio Felsina AAB, Montepastore
- 3 L20   18.32069  +43.844908    550.943 0.722441  +0.689239    Bosnia/Herzeg  AG_Sarajevo Observatory, Sarajevo
- 3 L21   27.42128  +44.027588     74.795 0.720179  +0.691479    Romania        Ostrov Observatory, Constanta
- 3 L22   27.66953  +46.231697     79.100 0.692963  +0.718573    Romania        Barlad Observatory
- 3 L23   27.8319   +45.499624     -4.702 0.70211   +0.70968     Romania        Schela Observatory
- 3 L24   27.9289   -26.102569   1631.489 0.89882   -0.43743     South Africa   Gauteng
- 3 L25   14.43739  +53.353671    105.517 0.598174  +0.798700    Poland         Smolecin
- 3 L26   11.81019  +42.077138     55.594 0.743368  +0.666653    Italy          Sanderphil Urban Observatory, Civitavecchia
- 3 L27    5.64704  +43.999846    679.476 0.720583  +0.691197    France         29PREMOTE Observatory, Dauban
- 3 L28   15.46339  +40.817569   1303.696 0.758034  +0.650341    Italy          ISON-Castelgrande Observatory
- 3 L29   18.0169   -23.460102   1358.816 0.91802   -0.39574     Namibia        Drebach-South Observatory, Windhoek
- 3 L30    7.51469  +51.476911    164.475 0.624126  +0.778737    Germany        Lohbach Observatory, Benninghofen
- 3 L31   12.85615  +50.860377    371.837 0.632524  +0.772019    Germany        RaSo Observatory, Chemnitz
- 3 L32   20.81044  -32.378866   1802.380 0.845576  -0.532593    South Africa   Korea Microlensing Telescope Network-SAAO
- 3 L33   29.9546   +47.736097     68.989 0.67379   +0.73646     Ukraine        Ananiv
- 3 L34   14.02061  +37.939361    649.493 0.789742  +0.611548    Italy          Galhassin Robotic Telescope, Isnello
- 3 L35   30.5086   +50.262816    138.562 0.64055   +0.76537     Ukraine        DreamSky Observatory, Lisnyky
- 3 L36   14.78008  +49.909487    561.543 0.645319  +0.761467    Czech Republi  Ondrejov--BlueEye600 Telescope
- 3 L37  353.73883  +36.585182     70.422 0.803937  +0.592739    Spain          Observatorio Alnitak, El Puerto de Santa Maria
- 3 L38    9.69997  +52.095277    140.123 0.615648  +0.785407    Germany        Gartensternwarte Schafsweide, Sehlde
- 3 L39   11.04031  +43.789205    101.342 0.723062  +0.688490    Italy          Osservatorio Spica, Signa
- 3 L40    6.95681  +49.252813    301.278 0.654011  +0.754011    Germany        Sternwarte Saarbruecken Rastpfuhl
- 3 L41   12.30181  +43.988621    361.762 0.720683  +0.691022    Italy          Ponte Uso
- 3 L42   11.5633   +42.646824    205.461 0.73670   +0.67400     Italy          Observatory-Astrocamp Manciano
- 3 L43    0.74439  +42.019186    803.013 0.744131  +0.665982    Spain          Ager, Leida
- 3 L44    6.22111  +46.619606   1192.958 0.688185  +0.723360    Switzerland    AstroVal, Le Chenit
- 3 L45   15.06243  +37.537428    260.217 0.793975  +0.605979    Italy          ObsCT, Catania
- 3 L46  356.11939  +40.460865    778.678 0.762017  +0.645574    Spain          Observatorio Majadahonda
- 3 L47   12.50711  +43.585895    397.839 0.725542  +0.685961    Italy          Osservatorio Astronomico, Piobbico
- 3 L48   23.56873  +47.658052    256.188 0.674816  +0.735566    Romania        CNVL Observatory, Baia Mare
- 3 L49   13.00730  +47.923899    834.864 0.671444  +0.738747    Austria        VEGA-Sternwarte, Dorfleiten
- 3 L50   34.0114   +44.738732    586.106 0.71157   +0.70039     Ukraine        GenShtab Observatory, Nauchnyi
- 3 L51   34.0164   +44.729400    636.020 0.71169   +0.70028     Ukraine        MARGO, Nauchnyi
- 3 L52   34.01694  +44.730130    617.598 0.711679  +0.700287    Ukraine        MASTER-Tavrida
- 3 L53    9.03381  +45.705208    348.311 0.699589  +0.712226    Italy          Lomazzo Observatory, Como
- 3 L54   22.88878  +45.616535    437.587 0.700704  +0.711156    Romania        Berthelot Observatory, Hunedoara
- 3 L55   35.08750  +48.320586    142.581 0.666222  +0.743283    Ukraine        Sura Gardens, Dnipro
- 3 L56    8.05858  +50.381562    177.816 0.638960  +0.766697    Germany        Sternwarte Limburg, Limburg
- 3 L57   26.90419  +46.565635    204.987 0.688762  +0.722601    Romania        Bacau Observatory, Bacau
- 3 L58   30.57108  +46.331167     78.317 0.691710  +0.719771    Ukraine        Heavenly Owl observatory
- 3 L59    1.22606  +49.438402    205.358 0.651546  +0.756108    France         Compustar Observatory, Rouen
- 3 L60   30.69722  +49.933611    204.138 0.644961  +0.761695    Ukraine        Popovich Observatory, Ivanivka
- 3 L61   20.81028  -32.378897   1796.993 0.845575  -0.532593    South Africa   MONET South, Sutherland
- 3 L62   12.52889  +44.086121     48.916 0.719467  +0.692209    Italy          Hypatia Observatory, Rimini
- 3 L63   11.00914  +43.738450     78.676 0.723671  +0.687849    Italy          HOB Observatory, Capraia Fiorentina
- 3 L64    9.36314  +45.524485    186.870 0.701822  +0.710005    Italy          Martesana Observatory, Cassina de Pecchi
- 3 L65    8.82831  +53.075281     48.411 0.602059  +0.795784    Germany        Bredenkamp Observatory, Bremen
- 3 L66   20.81122  -32.379904   1882.910 0.845577  -0.532615    South Africa   MeerLICHT-1, Sutherland
- 3 L67   37.79889  +55.961388    165.171 0.561057  +0.825033    Russia         Cherkizovo Observatory, Moscow Oblast
- 3 L68   25.53683  -33.987939    185.069 0.830048  -0.555874    South Africa   PESCOPE, Port Elizabeth
- 3 L69   28.2142   -25.834328   1484.610 0.90084   -0.43323     South Africa   LaCaille Observatory, Pretoria
- 3 L70   15.92333  +45.819577    201.745 0.698145  +0.713600    Croatia        Zvjezdarnica Graberje, Zagreb
- 3 L71   38.5839   +44.791477    291.470 0.71089   +0.70101     Russia         Vedrus Observatory, Azovskaya
- 3 L72   38.6928   +56.049008    178.735 0.55979   +0.82589     Russia         Melezhy Astrophoto Observatory
- 3 L73   11.26183  +43.675409    336.030 0.724459  +0.687083    Italy          Beato Ermanno Observatory, Impruneta
- 3 L74   14.21109  +40.879156    287.171 0.757212  +0.651048    Italy          AstroColauri, Naples
- 3 L75   26.46394  +58.264015     96.158 0.527292  +0.846853    Estonia        Tartu Observatory of Tartu University
- 3 L76   39.65161  +46.976196     36.873 0.683530  +0.727483    Russia         Nomad Observatory, Kochevanchik
- 3 L77   39.82025  +47.336868     98.063 0.678927  +0.731765    Russia         RDSS, Kovalevka
- 3 L78   14.7800   +40.682532    134.342 0.75943   +0.64844     Italy          San Marco Observatory, Salerno
- 3 L79   18.22039  +45.953082    223.834 0.696477  +0.715222    Hungary        BOSZA Observatory, Szalanta
- 3 L80   18.0175   -23.460102   1358.816 0.91802   -0.39574     Namibia        SpringBok Observatory, Tivoli
- 3 L81   16.36169  -23.236422   1854.372 0.919631  -0.392204    Namibia        Skygems Namibia Remote Observatory
- 3 L82  352.67950  +39.275814    650.798 0.775227  +0.629726    Portugal       Crow Observatory, Portalegre
- 3 L83  356.22231  +37.787351    562.295 0.791355  +0.609451    Spain          UJA Observatory, Jaen
- 3 L84   41.27989  +46.034028     46.080 0.695443  +0.716182    Russia         Kairos Observatory, Letnik
- 3 L85   15.86325  +40.028874    750.576 0.766873  +0.639830    Italy          BiAnto Observatory, Lauria
- 3 L86    9.2631   +44.754974    848.734 0.71140   +0.70062     Italy          Giordano Bruno Observatory, Brallo
- 3 L87   16.36189  -23.236422   1854.372 0.919631  -0.392204    Namibia        Moonbase South Observatory, Hakos
- 3 L88   16.5422   +39.102953   1321.103 0.77721   +0.62746     Italy          Stazione Astronomica Le Pleiadi, Pantane
- 3 L89   11.14439  +43.865166    104.481 0.722146  +0.689445    Italy          PAO, Prato
- 3 L90   15.97949  +38.455736    125.258 0.784120  +0.618560    Italy          ABObservatory, Rosarno
- 3 L91   13.8078   +41.705150    624.087 0.74776   +0.66189     Italy          Antares MTM Observatory, S. Donato
- 3 L92   16.00211  +38.705394    229.370 0.781423  +0.621967    Italy          San Costantino
- 3 L93    1.77221  +41.258806     75.113 0.752844  +0.656010    Spain          Garraf Observatory, Sant Pere de Ribes
- 3 L94  354.14561  +43.364161    286.735 0.728187  +0.683146    Spain          Observatorio MOMA, Oviedo
- 3 L95  358.95159  +37.612347    131.633 0.793164  +0.607000    Spain          Observatorio Astronomico de Cartagena
- 3 L96   44.2745   +40.347550   1650.066 0.76340   +0.64416     Armenia        ISON-Byurakan Observatory
- 3 L97  357.99161  +51.437018    120.565 0.624666  +0.778298    UK/England     Castle Fields Observatory, Calne
- 3 L98  357.43425  +37.982643   1583.074 0.789394  +0.612232    Spain          La Sagra Observatory, Puebla de Don Fadrique
- 3 L99   30.60281  +50.607688    137.300 0.635913  +0.769201    Ukraine        Novosilky
- 3 M00   26.21154  +60.734470    107.531 0.490116  +0.868754    Finland        Viestikallio, Artjarvi
- 3 M02    0.86386  +41.123329    425.965 0.754439  +0.654271    Spain          Astropriorat Observatory
- 3 M03    2.25822  +41.456428     56.282 0.750568  +0.658591    Spain          Badalona Boreal
- 3 M04    1.4256   +41.717450    816.625 0.74764   +0.66207     Spain          Pujalt Observatory, Barcelona
- 3 M05    1.33161  +43.215106    388.695 0.729979  +0.681267    France         Observatoire de la Nine, Canens
- 3 M06    0.74381  +42.019267    802.544 0.744130  +0.665983    Spain          PeLe's Observatory, Ager
- 3 M07   10.29447  +53.636900    112.535 0.594202  +0.801641    Germany        Siek
- 3 M08    4.0381   +51.202067     66.235 0.62786   +0.77573     Belgium        CHON, Stekene
- 3 M09    5.60094  +51.032739    115.579 0.630164  +0.773882    Belgium        Observatory Gromme - Oudsbergen
- 3 M10    6.85411  +43.692307    771.080 0.724305  +0.687343    France         CPF Observatory, St Vallier de Thiey
- 3 M11    5.64718  +43.999389    683.567 0.720589  +0.691192    France         Novaastro Observatory, Banon
- 3 M12   47.8639   +56.109697    169.230 0.55891   +0.82648     Russia         Puschino
- 3 M13    7.74250  +48.578160    188.268 0.662866  +0.746267    France         Lucie Berger Observatory, Strasbourg
- 3 M14    8.78939  +45.673318    296.649 0.699981  +0.711832    Italy          Schiaparelli Gallarate Station
- 3 M15    9.1506   +45.640009    240.683 0.70039   +0.71142     Italy          Virgo Oservatory, Seveso
- 3 M16    9.77319  +44.094900    407.809 0.719401  +0.692358    Italy          Osservatorio Il Coreggiolo
- 3 M17    9.80922  +44.111291     59.045 0.719163  +0.692525    Italy          SN1572 Tycho Observatory, La Spezia
- 3 M18   11.83939  +50.335757    605.830 0.639618  +0.766239    Germany        Koeditz
- 3 M19   13.88327  +44.863912     73.330 0.709976  +0.701881    Croatia        Osservatorio Explorer, Pula
- 3 M20   13.01169  +46.469391    805.816 0.690044  +0.721515    Italy          Polse di Cougnes Observatory, Zuglio
- 3 M21   16.36144  -23.236551   1853.543 0.919630  -0.392206    Namibia        Schiaparelli Southern Observatory, Hakos
- 3 M22   20.81059  -32.380158   1802.640 0.845564  -0.532612    South Africa   ATLAS South Africa, Sutherland
- 3 M23   16.60350  +47.258007    265.378 0.679955  +0.730852    Hungary        ELTE Gothard Observatory, Szombathely
- 3 M24   16.20050  +38.169874     49.482 0.787195  +0.614649    Italy          La Macchina del Tempo, Ardore Marina
- 3 M25   23.8283   +61.494525    118.381 0.47849   +0.87517     Finland        Einarin Observatory, Tampere
- 3 M26   11.13494  +43.774586     81.749 0.723236  +0.688304    Italy          Zen Observatory, Scandicci
- 3 M27   10.7175   +43.429222    476.927 0.72743   +0.68399     Italy          Elijah Observatory, Lajatico
- 3 M28   20.81064  -32.379792   1807.107 0.845568  -0.532607    South Africa   Lesedi Telescope-SAAO Observatory, Sutherland
- 3 M29   12.24864  +44.147748     87.707 0.718724  +0.692984    Italy          O.M.Ni.A. Observatory, Cesena
- 3 M30   25.62000  +45.644270    633.879 0.700380  +0.711516    Romania        Zeta Aquarii Observatory, Brasov
- 3 M31   26.21281  +60.733519    101.107 0.490130  +0.868745    Finland        Ursa Havaintokeskus,  Artjarvi
- 3 M32   22.70919  +48.379032    175.121 0.665464  +0.743964    Ukraine        Sunny Transcarpathian, Mukachevo
- 3 M33   34.76334  +30.597722    906.069 0.861632  +0.506111    Israel         OWL-Net, Mitzpe Ramon
- 3 M34   17.27363  +48.372520    579.676 0.665591  +0.743936    Slovakia       AGO70, Astronomical Observatory, Modra
- 3 M35   26.61669  +46.575381    347.485 0.688654  +0.722734    Romania        PS Observatory, Parjol
- 3 M36   13.79647  +45.693884    364.517 0.699732  +0.712090    Italy          Opicina, Trieste
- 3 M37   13.91243  +45.920164    836.096 0.696956  +0.714892    Slovenia       Astronomsko drustvo Nanos, Ajdovscina
- 3 M38   21.76719  +47.945818    155.979 0.671089  +0.738924    Hungary        Harsona Observatory, Nyiregyhaza
- 3 M39   22.95888  +40.630651     87.966 0.760013  +0.647750    Greece         AUTH Observatory, Thessaloniki
- 3 M40   31.82708  +29.936004    481.345 0.867372  +0.496143    Egypt          OSTS-NRIAG, Kottamia
- 3 M41   39.25827  +21.521802     59.001 0.930706  +0.364567    Saudi Arabia   Jeddah
- 3 M42   54.6708   +24.580820    -18.052 0.90990   +0.41343     United Arab E  Emirates Observatory, Al Rahba
- 3 M43   54.68478  +24.176308     19.886 0.912805  +0.407034    United Arab E  Al Sadeem Observatory, Abu Dhabi
- 3 M44   54.92031  +24.219597     55.781 0.912502  +0.407722    United Arab E  Al-Khatim Observatory, Abu Dhabi
- 3 M45   25.76889  +45.865496    624.117 0.697617  +0.714205    Romania        Starhopper Observatory, Sfantu Gheorghe
- 3 M46   55.45033  +25.213476     21.599 0.905280  +0.423399    United Arab E  Althuraya Astronomy Center, Dubai
- 3 M47   55.46205  +25.282675     -9.122 0.904763  +0.424484    United Arab E  Sharjah Observatory, Sharjah
- 3 M48   15.09222  +37.506621     63.111 0.794277  +0.605535    Italy          GAC - Via L. Sturzo Observatory, Catania
- 3 M49   16.36172  -23.236551   1853.543 0.919630  -0.392206    Namibia        IAS Remote Observatory, Hakos
- 3 M50   11.56375  +42.480177    203.208 0.738663  +0.671862    Italy          Virtual Telescope Project, Manciano
- 3 M51    9.22697  +49.139383    221.363 0.655500  +0.752709    Germany        Robert Mayer Sternwarte, Heilbronn
- 3 M52    8.57850  +40.727494    315.641 0.758941  +0.649052    Italy/Sardini  Sassari
- 3 M53   10.28219  +54.219692     63.289 0.585977  +0.807623    Germany        CAS Observatory, Preetz
- 3 M54    7.07781  +43.617357    186.188 0.725140  +0.686335    France         Observatoire Albireo de Biot
- 3 M55   19.98700  +49.054414    855.727 0.656685  +0.751814    Slovakia       Luckystar Observatory, Vazec
- 3 M56    9.17483  +45.604381    233.762 0.700833  +0.710985    Italy          Varedo
- 3 M57   14.02020  +37.868881   1905.282 0.790651  +0.610701    Italy          Wide-field Mufara Telescope, Isnello
- 3 M58   16.36133  -23.236603   1856.060 0.919630  -0.392207    Namibia        VdS Remote Observatory, Hakos
- 3 M59    7.22883  +47.232853    801.143 0.680334  +0.730616    Switzerland    Rondchamp Observatory, Reconvilier
- 3 M60   11.32554  +44.262338    790.559 0.717411  +0.694492    Italy          Virgil Observatory, Loiano
- 3 M61    6.58581  +51.420052     75.819 0.624893  +0.778108    Germany        Observatory Moers Kapellen
- 3 M62    7.13417  +47.281115   1035.212 0.679741  +0.731214    Switzerland    Lajoux Observatory
- 3 M63   18.36969  +39.842607    179.302 0.768886  +0.637286    Italy          RPF Observatory, Gagliano del Capo
- 3 M64    0.23964  +50.966907    202.917 0.631065  +0.773170    UK/England     Holbrook, Heathfield
- 3 M65   28.32494  +61.064799     88.046 0.485072  +0.871558    Finland        Mustola Observatory, Lappeenranta
- 3 M66   32.84019  +34.932094   1435.382 0.820917  +0.569526    Cyprus         SNX-NET, Prodromos
- 3 M68   37.83052  +55.760259    176.189 0.563964  +0.823064    Russia         School 1502 Rooftop Obs., Moscow
- 3 M70   26.40409  -29.039088   1414.479 0.875173  -0.482645    South Africa   BOOTES-6, Bloemfontein
- 3 M75   39.51155  +45.742940     44.995 0.699085  +0.712651    Russia         Online observatory, Peschany
- 3 M77   39.96553  +44.204621    768.124 0.718110  +0.693769    Russia         Mezmay Comet Search Center
- 3 M90   65.4286   +56.946120     63.640 0.54672   +0.83452     Russia         Chervishevo
- 3 N27   73.7253   +54.748119     58.759 0.57847   +0.81298     Russia         Omsk-Yogik Observatory
- 3 N30   74.3694   +31.472983    181.794 0.85369   +0.51909     Pakistan       Zeds Astronomical Observatory, Lahore
- 3 N31   74.44422  +31.513501    174.088 0.853321  +0.519690    Pakistan       Eden Astronomical Observatory, Lahore
- 3 N42   76.97181  +43.057299   2723.685 0.732126  +0.679511    Kazakhstan     Tien-Shan Astronomical Observatory
- 3 N43   77.1167   -80.417417   4082.524 0.16712   -0.98328     Antarctica     Plateau Observatory for Dome A, Kunlun Station
- 3 N44   77.13931  +38.384471   1201.281 0.785023  +0.617693    China          Shache Station, Langan Village
- 3 N50   78.96383  +32.779547   4475.445 0.842176  +0.538692    India          Himalayan Chandra Telescope, IAO, Hanle
- 3 N51   78.96461  +32.779243   4468.905 0.842178  +0.538687    India          GROWTH India Telescope, IAO, Hanle
- 3 N54   80.02674  +32.324939   5026.316 0.846505  +0.532071    China          Purple Mountain Observatory, Jiama'erdeng
- 3 N55   80.02623  +32.326059   5044.589 0.846497  +0.532089    China          Corona Borealis Observatory, Ngari, Tibet
- 3 N56   80.02675  +32.325098   5022.358 0.846503  +0.532073    China          Jiama'erdeng Tianwentai, Ali, Tibet
- 3 N57   80.04600  +32.306021   5350.969 0.846724  +0.531820    China          YLT, NAOC
- 3 N82   85.95494  +50.172048    910.314 0.641844  +0.764450    Russia         Multa Observatory
- 3 N83   86.23504  +41.552659    835.738 0.749549  +0.659927    China          LW-1, NAOC-Korla
- 3 N86   87.17852  +43.473808   2007.798 0.727070  +0.684719    China          Xingming Observatory-KATS, Nanshan
- 3 N87   87.17503  +43.473613   2039.957 0.727076  +0.684720    China          Nanshan Station, Xinjiang Observatory
- 3 N88   87.17322  +43.471787   2040.858 0.727098  +0.684697    China          Xingming Observatory #3, Nanshan
- 3 N89   87.17906  +43.470806   2016.695 0.727107  +0.684682    China          Xingming Observatory #2, Nanshan
- 3 N94   88.72792  +47.588448    971.591 0.675788  +0.734831    China          Altay Astronomical Observatory
- 3 O02   90.52614  +30.103182   4283.753 0.866434  +0.498958    China          Galaxy Tibet YBJ Observatory,Yangbajing
- 3 O17   93.88669  +38.588778   3790.308 0.783127  +0.620730    China          Purple Mountain Observatory, Lenghu-1
- 3 O18   93.89522  +38.607604   4145.658 0.782966  +0.621021    China          WFST, Lenghu
- 3 O37   98.48553  +18.589868   2514.131 0.948521  +0.316891    Thailand       TRT-NEO, Chiangmai
- 3 O39  100.03105  +26.695553   3195.334 0.894458  +0.446769    China          BOOTES-4, Lijiang
- 3 O40  100.22861  +29.013063   3854.266 0.875727  +0.482435    China          Xingyuan, Daocheng
- 3 O41   99.46556  +18.336971    212.998 0.949569  +0.312613    Thailand       Choakanan Observatory, Lampang
- 3 O42  100.02900  +26.722495   3134.381 0.894239  +0.447183    China          Gaomeigu Gemini Observatory, LiJiang
- 3 O43   99.78111   +6.307021    111.299 0.994005  +0.109127    Malaysia       Observatori Negara, Langkawi
- 3 O44  100.02973  +26.695089   3240.856 0.894468  +0.446765    China          Lijiang Station, Yunnan Observatories
- 3 O45  100.03261  +26.697920   3227.314 0.894444  +0.446808    China          Yunnan-HK Observatory, Gaomeigu
- 3 O46  100.22664  +29.011750   3853.753 0.875738  +0.482415    China          Daocheng Glacier Observatory
- 3 O47  101.13415  +25.624399   2274.672 0.902535  +0.429998    China          Yunling Observatory, Yunnan
- 3 O48  101.18154  +25.526524   1948.518 0.903223  +0.428442    China          Purple Mountain Observatory, Yaoan (0.8-m)
- 3 O49  101.18111  +25.528608   1938.630 0.903206  +0.428474    China          Purple Mountain Observatory, Yaoan Station
- 3 O50  101.43942   +3.033412     56.171 0.998617  +0.052565    Malaysia       Hin Hua Observatory, Klang
- 3 O51  101.27869  +12.734700    -25.562 0.975556  +0.218996    Thailand       Akin Observatory, Rayong
- 3 O52  100.72972  +13.578635    -26.336 0.972224  +0.233250    Thailand       Astro820, Samut Prakan
- 3 O53  101.40403  +14.669313    288.411 0.967655  +0.251610    Thailand       Pakchong, Nachonratchasima
- 3 O54  100.94939  +13.294693    -16.278 0.973370  +0.228460    Thailand       TSky Observatory, Chonburi
- 3 O55  101.85450   +2.445334     28.907 0.999100  +0.042381    Malaysia       Telok Kemang Observatory, Port Dickson
- 3 O56  101.45455  +14.698323    292.205 0.967528  +0.252097    Thailand       Jaichalad-Pailin Observatory
- 3 O68  105.33090  +37.629648   1265.425 0.793121  +0.607347    China          LW-2, NAOC-Zhongwei
- 3 O72  106.33476  +47.886134   1637.802 0.672017  +0.738399    Mongolia       OWL-Net, Songino
- 3 O75  107.05180  +47.865238   1606.859 0.672284  +0.738151    Mongolia       ISON-Hureltogoot Observatory
- 3 O85  109.21300  +34.352281    911.138 0.826583  +0.561181    China          LiShan Observatory, Lintong
- 3 P07  114.08987  -21.895687     51.267 0.928304  -0.370597    Australia/WA   Space Surveillance Telescope, HEH Station
- 3 P13  115.57333  +39.837556   1140.146 0.769058  +0.637315    China          Baihuashan Observatory, Beijing
- 3 P14  115.81167  -31.984472     -2.817 0.848989  -0.526638    Australia/WA   Nedlands Observatory, Perth
- 3 P18  116.61083  +40.898907    482.210 0.757010  +0.651328    China          Birch Forest Observatory, LaBaGouMen
- 3 P21  117.28146  -31.820553    334.732 0.850540  -0.524246    Australia/WA   6R-AUS1, Youndegin
- 3 P22  117.57588  +40.394252    886.203 0.762782  +0.644702    China          LW-3, NAOC-Xinglong
- 3 P25  118.31274  +24.432463     33.118 0.910976  +0.411089    China          Kinmen Educational Remote Observatory, Jincheng
- 3 P30  119.59708  +30.468691    931.538 0.862775  +0.504181    China          Jiangnantianchi Observatory, Anji
- 3 P31  119.59736  +30.469175    940.919 0.862772  +0.504189    China          Starlight Observatory, Tianhuangping
- 3 P34  120.32031  +31.321361      8.677 0.855040  +0.516826    China          Lvye Observatory, Suzhou
- 3 P35  120.55699  +24.093399     49.897 0.913398  +0.405722    Taiwan         Cuteip Remote Observatory, Changhua
- 3 P36  120.62669  +31.302952     13.767 0.855207  +0.516553    China          ULTRA Observatory,Suzhou
- 3 P37  120.63972  +24.153164     93.083 0.912980  +0.406672    Taiwan         HuiWen High School Observatory, Taichung City
- 3 P38  120.71429  +22.074678     26.008 0.927137  +0.373477    Taiwan         Checheng Elementary School Observatory
- 3 P40  121.53958  +25.134642    399.145 0.905916  +0.422185    Taiwan         Chinese Culture University, Taipei
- 3 P48  123.32403  -75.100395   3232.597 0.258064  -0.963413    Antarctica     ASTEP, Concordia Station
- 3 P61  126.33047  +43.824408    335.644 0.722664  +0.688958    China          Jilin Observatory
- 3 P63  126.84750  +35.228435     62.158 0.817778  +0.573621    South Korea    GSA Observatory, Gwangju
- 3 P64  127.00489  +37.308898     94.378 0.796371  +0.602805    South Korea    GSHS Observatory, Suwon
- 3 P65  127.37568  +36.397627    160.714 0.805889  +0.590124    South Korea    OWL-Net, Daedeok
- 3 P66  127.44675  +34.526296     73.809 0.824763  +0.563603    South Korea    Deokheung Optical Astronomy Observatory
- 3 P67  127.7415   +37.871793    128.603 0.79040   +0.61057     South Korea    Kangwon National University Observatory
- 3 P68  127.47440  +36.333148    175.243 0.806556  +0.589222    South Korea    DDSHS Biryong Observatory
- 3 P71  128.76108  +35.502785    142.020 0.815026  +0.577520    South Korea    Miryang Arirang Astronomical Observatory
- 3 P72  128.97595  +36.163884   1168.629 0.808423  +0.586939    South Korea    OWL-Net, Mt. Bohyun
- 3 P73  129.0820   +35.263076    138.223 0.81744   +0.57412     South Korea    BSH Byulsem Observatory, Busan
- 3 P87  132.09419  +33.954136     42.851 0.830358  +0.555374    Japan          Hirao Observatory, Yamaguchi
- 3 P93  133.54433  +34.672353    465.427 0.823371  +0.565729    Japan          Space Tracking and Communications Center, JAXA
- 3 Q02  135.49344  +34.470698    107.080 0.825315  +0.562809    Japan          Sakai Observatory, Osaka
- 3 Q06  136.49547  +35.394794    145.780 0.816116  +0.575990    Japan          Tarui Observatory, Tarui
- 3 Q10  137.32944  +34.843619     80.050 0.821623  +0.568142    Japan          Toyokawa Observatory
- 3 Q11  137.52069  +34.984299    185.236 0.820236  +0.570158    Japan          Shinshiro
- 3 Q12  137.82536  +36.476962    777.994 0.805147  +0.591292    Japan          Nagano Observatory
- 3 Q19  139.4390   +35.573820     81.308 0.81430   +0.57852     Japan          Machida
- 3 Q20  139.57008  -34.544081     53.375 0.824585  -0.563856    Australia/SA   Swan Reach Imaging, Glenalta
- 3 Q21  139.85335  +36.507360    100.066 0.804747  +0.591654    Japan          Southern Utsunomiya
- 3 Q22  140.34192  -34.269187     48.802 0.827286  -0.559911    Australia/SA   SNX-NET, Moorook
- 3 Q23  140.3864   +37.295470    314.028 0.79654   +0.60264     Japan          Sukagawa
- 3 Q24  140.52350  +35.898994     41.108 0.810991  +0.583108    Japan          Katori
- 3 Q33  142.48278  +44.373646    192.283 0.715989  +0.695814    Japan          Nayoro Observatory, Hokkaido University
- 3 Q38  143.5506   -35.352090     98.562 0.81654   -0.57538     Australia/VIC  Swan Hill
- 3 Q54  147.28772  -42.431138    639.404 0.739290  -0.671278    Australia/Tas  Harlingten Telescope, Greenhill Observatory
- 3 Q55  149.06142  -31.272133   1191.137 0.855643  -0.516191    Australia/NSW  SkyMapper, Siding Spring
- 3 Q56  148.97642  -34.864169    556.317 0.821480  -0.568478    Australia/NSW  Heaven's Mirror Observatory, Yass
- 3 Q57  149.06173  -31.271167   1170.872 0.855649  -0.516175    Australia/NSW  Korea Microlensing Telescope Network-SSO
- 3 Q58  149.07085  -31.272855   1157.659 0.855632  -0.516199    Australia/NSW  Siding Spring-LCO Clamshell #1
- 3 Q59  149.07081  -31.272936   1118.328 0.855626  -0.516197    Australia/NSW  Siding Spring-LCO Clamshell #2
- 3 Q60  149.06900  -31.272985   1121.639 0.855626  -0.516198    Australia/NSW  ISON-SSO Observatory, Siding Spring
- 3 Q61  149.0619   -31.271682   1138.363 0.85564   -0.51618     Australia/NSW  PROMPT, Siding Spring
- 3 Q62  149.06442  -31.273289   1164.482 0.855629  -0.516206    Australia/NSW  iTelescope Observatory, Siding Spring
- 3 Q63  149.07064  -31.273002   1167.592 0.855632  -0.516202    Australia/NSW  Siding Spring-LCO A
- 3 Q64  149.07078  -31.273002   1167.592 0.855632  -0.516202    Australia/NSW  Siding Spring-LCO B
- 3 Q65  149.19313  -31.276327    548.281 0.855519  -0.516201    Australia/NSW  Warrumbungle Observatory
- 3 Q66  149.06425  -31.273299   1150.268 0.855627  -0.516205    Australia/NSW  Siding Spring-Janess-G, JAXA
- 3 Q67  149.49233  -33.397063    702.366 0.835816  -0.547369    Australia/NSW  JBL Observatory, Bathurst
- 3 Q68  150.33742  -33.702135    957.276 0.832917  -0.551813    Australia/NSW  Blue Mountains Observatory, Leura
- 3 Q69  150.44933  -33.712916    681.680 0.832777  -0.551945    Australia/NSW  Hazelbrook
- 3 Q70  150.50044  -23.269456    108.324 0.919153  -0.392623    Australia/QLD  Glenlee Observatory, Glenlee
- 3 Q71  149.06980  -31.273329   1144.816 0.855626  -0.516205    Australia/NSW  SNX-NET, Siding Spring
- 3 Q73  151.64894  -32.765687     41.676 0.841722  -0.538113    Australia/NSW  Buckthorn, Thornton
- 3 Q78  152.94789  -27.605675     84.314 0.886807  -0.460619    Australia/QLD  Woogaroo Observatory, Forest Lake
- 3 Q79  152.8481   -27.368290     80.362 0.88871   -0.45696     Australia/QLD  Samford Valley Observatory
- 3 Q80  153.2160   -27.503454     22.748 0.88762   -0.45904     Australia/QLD  Birkdale
- 3 Q81  153.09622  -26.800858     49.357 0.893194  -0.448181    Australia/QLD  Caloundra West
- 3 R56  170.48389  -44.009464    736.283 0.720473  -0.691324    New Zealand    Scott Street Observatory, Lake Tekapo
- 3 R57  170.47278  -44.008206    743.211 0.720489  -0.691309    New Zealand    Aorangi Iti Observatory, Lake Tekapo
- 3 R58  170.49039  -45.864384    148.645 0.697579  -0.714138    New Zealand    Beverly-Begg Observatory, Dunedin
- 3 R65  172.34981  -43.498734    116.431 0.726556  -0.684830    New Zealand    R. F. Joyce Observatory, Christchurch
- 3 R66  172.58761  -43.495302     27.181 0.726587  -0.684777    New Zealand    Mooray Observatory, Christchurch
- 3 R78  175.09104  -38.094331    164.569 0.788021  -0.613626    New Zealand    Crystal Lake Observatory, Ngutunui
- 3 T02  203.49572  +20.900636    104.174 0.934614  +0.354517    US/Hawaii      SNX-NET, Wailuku
- 3 T03  203.74247  +20.706986   3050.490 0.936240  +0.351538    US/Hawaii      Haleakala-LCO Clamshell #3
- 3 T04  203.74249  +20.706966   3056.456 0.936241  +0.351538    US/Hawaii      Haleakala-LCO OGG B #2
- 3 T05  203.74299  +20.707553   3046.923 0.936236  +0.351547    US/Hawaii      ATLAS-HKO, Haleakala
- 3 T07  204.42387  +19.536152   3426.958 0.943290  +0.332467    US/Hawaii      ATLAS-MLO Auxiliary Camera, Mauna Loa
- 3 T08  204.42395  +19.536152   3426.958 0.943290  +0.332467    US/Hawaii      ATLAS-MLO, Mauna Loa
- 3 T09  204.52396  +19.825501   4194.602 0.941711  +0.337239    US/Hawaii      Subaru Telescope, Maunakea
- 3 T10  204.52241  +19.824136   4106.197 0.941706  +0.337212    US/Hawaii      Submillimeter Array, Maunakea (SMA)
- 3 T11  204.52965  +19.822452   4228.780 0.941734  +0.337191    US/Hawaii      United Kingdom Infrared Telescope, Maunakea
- 3 T12  204.53054  +19.823013   4244.409 0.941733  +0.337201    US/Hawaii      University of Hawaii 88-inch telescope, Maunakea
- 3 T13  204.52797  +19.826229   4196.560 0.941707  +0.337251    US/Hawaii      NASA Infrared Telescope Facility, Maunakea
- 3 T14  204.53109  +19.825438   4232.766 0.941717  +0.337240    US/Hawaii      Canada-France-Hawaii Telescope, Maunakea
- 3 T15  204.53093  +19.823815   4242.527 0.941728  +0.337214    US/Hawaii      Gemini North Observatory, Maunakea
- 3 T16  204.52526  +19.825938   4191.744 0.941708  +0.337246    US/Hawaii      W. M. Keck Observatory, Keck 1, Maunakea
- 3 T17  204.52574  +19.826558   4189.377 0.941704  +0.337256    US/Hawaii      W. M. Keck Observatory, Keck 2, Maunakea
- 3 T35  210.39020  -17.563461     80.078 0.953686  -0.299837    Tahiti         Astronomical Society of Tahiti
- 3 U52  237.45100  +41.579167    812.665 0.749240  +0.660270    US/California  Shasta Valley Observatory, Grenada
- 3 U53  237.1603   +45.450107    130.091 0.70274   +0.70909     US/Oregon      Murray Hill Observatory, Beaverton
- 3 U54  237.31286  +38.565903    336.505 0.782952  +0.620081    US/California  Hume Observatory, Santa Rosa
- 3 U55  237.41456  +49.253279     29.265 0.653977  +0.753984    Canada/BritCo  Golden Ears Observatory, Maple Ridge
- 3 U56  237.86917  +37.433102    -27.438 0.795044  +0.604511    US/California  Palo Alto
- 3 U57  237.84128  +37.366692    214.371 0.795776  +0.603616    US/California  Black Mountain Observatory, Los Altos
- 3 U63  239.19456  +47.162715    668.851 0.681217  +0.729770    US/Washington  Burnt Tree Hill Observatory, Cle Elum
- 3 U64  239.46151  +47.000247    490.714 0.683272  +0.727821    US/Washington  CWU-Lind Observatory, Ellensburg
- 3 U65  239.45983  +47.002078    475.265 0.683247  +0.727841    US/Washington  CWU Observatory, Ellensburg
- 3 U67  240.20358  +39.185603   1513.263 0.776325  +0.628595    US/Nevada      Jack C. Davis Observatory, Carson City
- 3 U68  240.58701  +37.070390   1376.643 0.799040  +0.599620    US/California  JPL SynTrack Robotic Telescope, Auberry
- 3 U69  240.5870   +37.070390   1376.643 0.79904   +0.59962     US/California  iTelescope SRO Observatory, Auberry
- 3 U70  240.5869   +37.070390   1376.643 0.79904   +0.59962     US/California  RASC Observatory, Alder Springs
- 3 U71  241.3633   +34.485863    372.598 0.82520   +0.56305     US/California  AHS Observatory, Castaic
- 3 U72  241.46000  +34.183055    214.153 0.828150  +0.558687    US/California  Tarzana
- 3 U73  241.6172   +33.821671     23.959 0.83164   +0.55346     US/California  Redondo Beach
- 3 U74  240.58720  +37.070344   1372.799 0.799040  +0.599619    US/California  JPL SynTrack Robotic Telescope 2, Auberry
- 3 U75  242.18366  +33.607628    245.509 0.833735  +0.550383    US/California  Newport Beach
- 3 U76  242.1279   +34.142213    222.780 0.82855   +0.55810     US/California  Maury Lewin Observatory, Glendora
- 3 U77  242.9181   +32.946672     82.132 0.84002   +0.54076     US/California  Rani Observatory, San Diego
- 3 U78  242.8449   +34.258673   1523.134 0.82758   +0.55989     US/California  Cedar Glen Observatory
- 3 U79  242.79187  +33.072374    141.210 0.838837  +0.542598    US/California  Cosmos Research Center, Encinitas
- 3 U80  243.6151   +34.272596    954.861 0.82737   +0.56004     US/California  CS3-DanHenge Observatory, Landers
- 3 U81  243.61514  +34.272551    928.274 0.827367  +0.560037    US/California  CS3-Trojan Station, Landers
- 3 U82  243.61519  +34.272471    929.953 0.827368  +0.560036    US/California  CS3-Palmer Divide Station, Landers
- 3 U83  243.57311  +32.842004   1824.998 0.841238  +0.539380    US/California  Mount Laguna Observatory
- 3 U86  244.53556  +31.044836   2771.394 0.857900  +0.512937    Mexico         BOOTES-5, Bajo California
- 3 U93  246.28761  +37.762811   1557.743 0.791740  +0.609209    US/Utah        Skygems Dreamscope Utah, Beryl Junction
- 3 U94  246.30250  +37.737783   1552.042 0.792006  +0.608864    US/Utah        iTelescope Observatory, Beryl Junction
- 3 U96  246.68600  +54.713670    567.954 0.579007  +0.812698    Canada/Albert  Athabasca University Geophysical Observatory
- 3 U97  248.33292  +35.202997   2191.908 0.818306  +0.573452    US/Arizona     JPL SynTrack Robotic Telescope 3, Flagstaff
- 3 U98  249.74300  +31.941291   1068.944 0.849529  +0.526090    US/Arizona     NAC Observatory, Benson
- 3 U99  247.8537   +34.064734    595.944 0.829354  +0.557017    US/Arizona     BCC Observatory, Black Canyon City
- 3 V00  248.39981  +31.963127   2030.788 0.849456  +0.526492    US/Arizona     Kitt Peak-Bok
- 3 V01  248.23911  +40.448904   1540.295 0.762243  +0.645493    US/Utah        Mountainville Observatory, Alpine
- 3 V02  248.05794  +33.399758    341.737 0.835743  +0.547377    US/Arizona     Command Module, Tempe
- 3 V03  248.3314   +37.083379   1267.045 0.79889   +0.59979     US/Utah        Big Water
- 3 V04  248.46331  +35.095868   2182.756 0.819378  +0.571927    US/Arizona     FRoST, Anderson Mesa
- 3 V05  248.63195  +33.310395    597.819 0.836631  +0.546101    US/Arizona     Rusty Mountain Observatory, Gold Canyon
- 3 V06  249.26745  +32.416873   2491.132 0.845313  +0.533209    US/Arizona     Catalina Sky Survey-Kuiper
- 3 V07  249.1219   +31.680709   2287.949 0.85208   +0.52234     US/Arizona     Whipple Observatory, Mount Hopkins-PAIRITEL
- 3 V08  249.33900  +32.079598   1029.734 0.848249  +0.528126    US/Arizona     Mountain Creek Ranch, Vail
- 3 V09  249.74202  +31.940560   1078.500 0.849537  +0.526080    US/Arizona     Moka Observatory, Benson
- 3 V10  248.32772  +35.170189   2098.552 0.818623  +0.572977    US/Arizona     Sierra Sinagua Observatory, Flagstaff
- 3 V11  249.21119  +32.208838    816.343 0.847025  +0.530011    US/Arizona     Saguaro Observatory, Tucson
- 3 V12  249.39819  +31.665610   1479.588 0.852110  +0.522050    US/Arizona     Elgin
- 3 V13  248.78278  +40.451944   2599.256 0.762335  +0.645641    US/Utah        Little Moose Observatory, Timber Lakes
- 3 V14  248.78336  +40.455730   2597.482 0.762292  +0.645691    US/Utah        Moose Springs Observatory, Timber Lakes
- 3 V15  249.21069  +32.442202   2742.485 0.845110  +0.533602    US/Arizona     OWL-Net, Mt. Lemmon
- 3 V16  251.10288  +31.946944   1317.072 0.849510  +0.526194    US/New Mexico  Dark Sky New Mexico, Animas
- 3 V17  248.98319  +32.373981    703.596 0.845476  +0.532429    US/Arizona     Leo Observatory, Tucson
- 3 V18  249.6181   +31.056034   2476.842 0.85776   +0.51308     Mexico         MASTER-OAGH Observatory, Sonora
- 3 V19  251.79086  +32.829983   1974.027 0.841371  +0.539217    US/New Mexico  Whiskey Creek Observatory
- 3 V20  251.77822  +34.327333   2272.020 0.827004  +0.560943    US/New Mexico  Killer Rocks Observatory, Pie Town
- 3 V21  251.10231  +31.946621   1302.234 0.849511  +0.526188    US/New Mexico  Cewanee Observatory at DSNM
- 3 V22  251.81550  +34.327076   2291.163 0.827009  +0.560941    US/New Mexico  Insight Remote Observatory, Pie Town
- 3 V23  252.76406  +34.147702   1961.266 0.828722  +0.558332    US/New Mexico  FOAH Observatory, Magdalena
- 3 V24  250.48403  +31.866804   1425.653 0.850261  +0.525020    US/Arizona     Sonoran Desert Skies Observatory, Pearce
- 3 V25  253.30194  +32.293068   1477.032 0.846331  +0.531305    US/New Mexico  Tortugas Mountain Observatory, Las Cruces
- 3 V26  253.39020  +24.401562    629.624 0.911283  +0.410639    Mexico         UAS-ISON Observatory, Cosala
- 3 V27  253.71819  +35.890115   2185.939 0.811354  +0.583180    US/New Mexico  North Mesa Observatory, Los Alamos
- 3 V28  254.34647  +35.331087   2183.334 0.817018  +0.575271    US/New Mexico  Deep Sky West Observatory, Rowe
- 3 V29  254.26660  +32.979417   2756.945 0.840062  +0.541466    US/New Mexico  Tzec Maun Cloudcroft Facility
- 3 V30  254.47105  +32.903532   2226.526 0.840710  +0.540313    US/New Mexico  Heaven on Earth Observatory, Mayhill
- 3 V31  254.4750   +32.913751   2200.449 0.84061   +0.54046     US/New Mexico  Hazardous Observatory, Mayhill
- 3 V32  254.47131  +32.903322   2203.848 0.840709  +0.540308    US/New Mexico  Canvas View New Mexico Skies, Mayhill
- 3 V33  254.72039  +36.380357   2654.159 0.806382  +0.590114    US/New Mexico  Finlaystone Observatory, Angel Fire
- 3 V34  255.36992  +39.004636   2245.136 0.778401  +0.626222    US/Colorado    Baker Observatory, Black Forest
- 3 V35  255.91881  +30.588443   1831.571 0.861839  +0.506046    US/Texas       Deep Sky Observatory Collaborative, Pier 5
- 3 V36  255.61742  +32.638535    992.561 0.843042  +0.536333    US/New Mexico  The Ranch Observatory, Lakewood
- 3 V37  255.98483  +30.679870   2009.519 0.861053  +0.507428    US/Texas       McDonald Observatory-LCO ELP
- 3 V38  255.98493  +30.680077   2008.312 0.861051  +0.507431    US/Texas       McDonald Observatory-LCO ELP Aqawan A #1
- 3 V39  255.98483  +30.679821   2006.265 0.861053  +0.507427    US/Texas       McDonald Observatory-LCO ELP B
- 3 V40  255.91873  +30.588443   1831.571 0.861839  +0.506046    US/Texas       Divine Creation Observatory, Fort Davis
- 3 V41  256.72578  +44.052007   1039.702 0.719992  +0.691890    US/South Dako  Rapid City
- 3 V42  254.47472  +32.913047   2180.278 0.840614  +0.540448    US/New Mexico  Dimension Point, Mayhill
- 3 V43  250.4842   +31.866835   1420.236 0.85026   +0.52502     US/Arizona     Chiricahua Skies Observatory, Sunizona
- 3 V44  251.82983  +34.321865   2267.069 0.827057  +0.560864    US/New Mexico  Coyote Watcher, Pie Town
- 3 V54  259.69219  +20.600867   2007.698 0.936737  +0.349756    Mexico         Observatoire LAURIER, El Marques
- 3 V56  260.30403  +31.937385    618.497 0.849505  +0.525995    US/Texas       Stonehenge Observatory, Novice
- 3 V57  260.61773  +31.547099    431.894 0.853050  +0.520209    US/Texas       Starfront Observatories, Rockwood
- 3 V58  260.73497  +29.778158    460.527 0.868735  +0.493762    US/Texas       Medina Dome, Medina
- 3 V59  261.0734   +30.046447    537.153 0.86642   +0.49781     US/Texas       Millwood Observatory, Comfort
- 3 V60  261.09473  +30.534071    501.120 0.862140  +0.505126    US/Texas       Putman Mountain Observatory
- 3 V61  261.05710  +30.975730    516.232 0.858216  +0.511725    US/Texas       Shed of Science South, Pontotoc
- 3 V62  261.05661  +30.975779    519.514 0.858216  +0.511726    US/Texas       Live Oak Observatory, Pontotoc
- 3 V63  261.05728  +30.975444    519.507 0.858219  +0.511721    US/Texas       Tara Observatory, Cherokee
- 3 V70  263.33572  +29.619051    100.577 0.870056  +0.491332    US/Texas       Starry Night Observatory, Columbus
- 3 V72  263.89011  +41.274124    312.106 0.752696  +0.656235    US/Nebraska    JDP Observatory, Omaha
- 3 V74  264.15689  +29.703308     17.315 0.869320  +0.492598    US/Texas       Katy Observatory, Katy
- 3 V75  264.56578  +29.044439    -21.654 0.874931  +0.482617    US/Texas       Live Oak Observatory, Lake Jackson
- 3 V78  265.10780  +45.660977    352.840 0.700141  +0.711688    US/Minnesota   Spirit Marsh Observatory. Sauk Centre
- 3 V81  265.7604   +36.095422    336.783 0.80902   +0.58590     US/Arkansas    Fayetteville
- 3 V83  266.25728  +38.677354    269.491 0.781733  +0.621590    US/Missouri    Rolling Hills Observatory, Warrensburg
- 3 V86  266.8927   +38.633315    254.931 0.78221   +0.62099     US/Missouri    Rattle Snake Observatory, Sedalia
- 3 V88  267.42811  +34.946273    208.105 0.820618  +0.569618    US/Arkansas    River Ridge Observatory, Conway
- 3 V92  268.34983  +35.234850     49.459 0.817712  +0.573711    US/Arkansas    White County Observatory, Searcy
- 3 V93  268.61611  +40.653352    167.239 0.759765  +0.648058    US/Iowa        Pin Oak Observatory, Fort Madison
- 3 V94  268.66169  +40.643752    185.038 0.759876  +0.647933    US/Iowa        Cherokeeridge Observatory, Fort Madison
- 3 W04  271.00944  +40.491610    246.144 0.761606  +0.645927    US/Illinois    Mark Evans Observatory, Bloomington
- 3 W05  271.26719  +33.347638     62.313 0.836205  +0.546596    US/Mississipp  Tree Gate Farm Observatory, Starkville
- 3 W08  271.88331  +41.758980    196.856 0.747086  +0.662545    US/Illinois    Jimginny Observatory, Naperville
- 3 W09  272.14753  +41.256136    171.344 0.752886  +0.655985    US/Illinois    Willowed Plains Observatory, Manteno
- 3 W11  272.6247   +41.270841    195.755 0.75272   +0.65618     US/Indiana     Northwest Indiana Robotic Telescope, Lowell
- 3 W13  273.47361  +38.977042    150.536 0.778448  +0.625642    US/Indiana     Star Quarry Observatory, Bedford
- 3 W14  273.24511  +34.816697    263.009 0.821914  +0.567774    US/Alabama     Harvest
- 3 W15  273.19083  +35.912496    212.370 0.810875  +0.583314    US/Tennessee   Wayne Observatory, Franklin
- 3 W16  273.76869  +34.711891    437.764 0.822976  +0.566292    US/Alabama     Pleasant Groves Observatory
- 3 W17  273.77122  +40.128199    253.519 0.765700  +0.641103    US/Indiana     Arrowhead, Sheridan
- 3 W18  274.24962  +40.008446    228.471 0.767039  +0.639505    US/Indiana     Red Fox Observatory, Pendleton
- 3 W19  274.37283  +42.300452    286.991 0.740783  +0.669559    US/Michigan    Kalamazoo
- 3 W22  275.00447  +32.459694     83.591 0.844595  +0.533635    US/Georgia     WestRock Observatory, Columbus
- 3 W23  275.38019  +39.492126    224.170 0.772786  +0.632594    US/Ohio        Hevonen Farm Observatory, Oxford
- 3 W24  275.23817  +43.830760    217.448 0.722574  +0.689025    US/Michigan    Shamrock Banks Observatory, Clare
- 3 W25  275.63506  +39.163116    235.706 0.776417  +0.628165    US/Ohio        RMS Observatory, Cincinnati
- 3 W28  276.3883   +33.982895    284.786 0.83011   +0.55581     US/Georgia     Ex Nihilo Observatory, Winder
- 3 W29  276.9939   +40.048565    230.288 0.76659   +0.64004     US/Ohio        Adena Brook Observatory, Columbus
- 3 W30  276.77117  +33.082852    121.712 0.838735  +0.542749    US/Georgia     Georgia College Observatory, Milledgeville
- 3 W31  277.23736  +33.555123    138.035 0.834226  +0.549613    US/Georgia     Deerlick Observatory, Crawfordville
- 3 W32  277.23750  +33.555538    137.927 0.834222  +0.549619    US/Georgia     Crawfordville Observatory
- 3 W33  277.83451  +35.077819    284.791 0.819315  +0.571499    US/South Caro  Transit Dreams Observatory, Campobello
- 3 W34  277.8453   +35.225393    307.927 0.81784   +0.57360     US/North Caro  Squirrel Valley Observatory, Columbus
- 3 W35  278.03910  +31.146836    -14.806 0.856610  +0.514230    US/Georgia     Buffalo Creek Observatory, Nahunta
- 3 W38  278.58531  +36.252691    922.142 0.807479  +0.588163    US/North Caro  Dark Sky Observatory, Boone
- 3 W42  279.46571  +27.764566    -19.346 0.885510  +0.463056    US/Florida     Mind's Eye Observatory, Vero Beach
- 3 W44  286.22016  +41.014860     46.725 0.755635  +0.652808    US/New York    Duo Ursi de Saltu, Scarsdale
- 3 W45  283.93827  +36.728937    -30.935 0.802431  +0.594736    US/Virginia    Benito Loyola Observatory, Virginia Beach
- 3 W46  280.41192  +35.145627    108.744 0.818614  +0.572448    US/North Caro  Foxfire Village
- 3 W47  289.23501  -30.470470   1602.574 0.862850  -0.504261    Chile          SNX-NET, Rio Hurtado
- 3 W48  280.88700  +35.831005    112.194 0.811693  +0.582156    US/North Caro  BKH Observatory, Chapel Hill
- 3 W49  281.06757  +38.952839    815.574 0.778794  +0.625380    US/West Virgi  CBA-MM Observatory, Mountain Meadows
- 3 W50  281.25404  +35.690054    120.319 0.813127  +0.580167    US/North Caro  Apex
- 3 W51  287.56544  +41.051862    -21.217 0.755204  +0.653287    US/New York    Custer Institute and Observatory
- 3 W52  283.51419  +38.985324    -32.572 0.778335  +0.625736    US/Maryland    US Naval Academy Hopper Hall Observatory
- 3 W53  282.31524  +39.639374    114.090 0.771140  +0.634559    US/Maryland    Hagerstown
- 3 W54  282.28944  +38.333748     63.391 0.785431  +0.616890    US/Virginia    Mark Slade Remote Observatory, Wilderness
- 3 W55  282.58389  +39.407774     92.019 0.773703  +0.631447    US/Maryland    Natelli Observatory, Frederick
- 3 W56  282.52583  +39.459533    193.547 0.773143  +0.632153    US/Maryland    Pineapple Observatory, Frederick
- 3 W57  289.26094  -29.255228   2378.105 0.873475  -0.486000    Chile          ESA TBT La Silla Observatory
- 3 W58  283.14964  +39.046892     21.886 0.777667  +0.626574    US/Maryland    ALPHA Observatory, South Laurel
- 3 W59  284.10758  +40.897966    349.531 0.757005  +0.651302    US/Pennsylvan  The Dark Side Observatory, Weatherly
- 3 W60  286.36626   +5.610983   2137.204 0.995574  +0.097155    Colombia       AstroExplor Observatory, Tinjaca
- 3 W61  283.74492  +44.586395     85.967 0.713380  +0.698447    Canada/Ontari  Leeside Observatory, Elgin
- 3 W62  284.13761  +40.745188    223.420 0.758729  +0.649276    US/Pennsylvan  Comet Hunter Observatory2, New Ringgold
- 3 W63  284.30958   +4.790538   1517.370 0.996767  +0.082976    Colombia       Observatorio Astronomico UTP, Pereira
- 3 W64  285.27004  +39.887267    -17.269 0.768364  +0.637863    US/New Jersey  Red Lion Observatory, Southampton Twsp
- 3 W65  284.79169  +45.850016    169.855 0.697761  +0.713966    Canada/Quebec  Observatoire GOZ, Montpellier
- 3 W66  285.05381  +40.960335    218.288 0.756278  +0.652109    US/New Jersey  SVH Observatory, Blairstown
- 3 W67  285.10211  +40.681845    262.219 0.759453  +0.648444    US/NJersey     Paul Robinson Observatory, Voorhees State Park
- 3 W68  289.23502  -30.471012   1600.963 0.862845  -0.504269    Chile          ATLAS Chile, Rio Hurtado
- 3 W69  285.98500  +40.639006     35.239 0.759912  +0.647855    US/New York    OLPH Observatory, Brooklyn
- 3 W70  285.91386  +45.792560    132.432 0.698475  +0.713264    Canada/Quebec  Loose Goose Observatory, Saint-Jerome
- 3 W71  285.99297  +44.261139    598.330 0.717404  +0.694456    US/New York    Rand II Observatory, Lake Placid
- 3 W72  286.8211   +41.243074     35.930 0.75302   +0.65580     US/Connecticu  Trumbull Observatory, Trumbull
- 3 W73  289.32156  -16.828157   3351.870 0.957949  -0.287797    Peru           Observatorio Astronomico de Moquegua, Carumas
- 3 W74  289.26245  -29.257911   2369.241 0.873451  -0.486040    Chile          Danish Telescope, La Silla
- 3 W75  289.60944  -24.616088   2479.234 0.910001  -0.414150    Chile          SPECULOOS-South Observatory, Paranal
- 3 W76  289.23695  -30.472508   1557.971 0.862826  -0.504288    Chile          CHILESCOPE Observatory, Rio Hurtado
- 3 W77  287.4010   +41.335888     90.561 0.75196   +0.65702     US/Connecticu  Skyledge Observatory, Killingworth
- 3 W78  288.88325  +42.376505     11.661 0.739859  +0.670509    US/Massachuse  Clay Telescope, Harvard University
- 3 W79  289.19535  -30.167671   2189.340 0.865587  -0.499763    Chile          Cerro Tololo-LCO Aqawan B #1
- 3 W80  288.7678   +42.247271     62.585 0.74138   +0.66885     US/Massachuse  Westwood
- 3 W81  288.99967  +43.665919    193.583 0.724557  +0.686948    US/New Hampsh  Nebula Knoll Observatoy, East Wakefield
- 3 W82  288.87804  +42.669325     71.635 0.736419  +0.674274    US/Massachuse  Mendel Observatory, Merrimack College
- 3 W83  288.69747  +42.294822     45.609 0.740821  +0.669461    US/Massachuse  Whitin Observatory, Wellesley
- 3 W84  289.19358  -30.169597   2202.786 0.865572  -0.499793    Chile          Cerro Tololo-DECam
- 3 W85  289.19519  -30.167407   2201.781 0.865591  -0.499760    Chile          Cerro Tololo-LCO A
- 3 W86  289.19533  -30.167328   2204.090 0.865592  -0.499759    Chile          Cerro Tololo-LCO B
- 3 W87  289.19532  -30.167456   2204.986 0.865591  -0.499761    Chile          Cerro Tololo-LCO C
- 3 W88  289.46570  -33.269128   1445.320 0.837136  -0.545574    Chile          Slooh.com Chile Observatory, La Dehesa
- 3 W89  289.19533  -30.167663   2203.573 0.865589  -0.499764    Chile          Cerro Tololo-LCO Aqawan A #1
- 3 W90  289.05814  +42.979452      8.475 0.732740  +0.678229    US/New Hampsh  Phillips Exeter Academy Grainger Observatory
- 3 W91  289.60257  -24.615840   2508.712 0.910007  -0.414148    Chile          VHS-VISTA, Cerro Paranal
- 3 W92  290.67357  -31.802281   2432.723 0.850987  -0.524150    Argentina      MASTER-OAFA Observatory, San Juan
- 3 W93  289.19600  -30.167216   2174.727 0.865589  -0.499755    Chile          Korea Microlensing Telescope Network-CTIO
- 3 W94  291.82019  -22.953076   2440.558 0.921646  -0.387713    Chile          MAP, San Pedro de Atacama
- 3 W95  291.82012  -22.953180   2396.958 0.921639  -0.387712    Chile          Observatorio Panameno, San Pedro de Atacama
- 3 W96  291.82006  -22.953490   2397.649 0.921637  -0.387717    Chile          CAO, San Pedro de Atacama (since 2013)
- 3 W97  291.82024  -22.953415   2401.035 0.921638  -0.387716    Chile          Atacama Desert Observatory, San Pedro de Atacama
- 3 W98  291.82030  -22.953180   2396.958 0.921639  -0.387712    Chile          Polonia Observatory, San Pedro de Atacama
- 3 W99  291.82015  -22.953415   2401.035 0.921638  -0.387716    Chile          SON, San Pedro de Atacama Station
- 3 X00  292.60125  -24.589539   3573.249 0.910349  -0.413802    Argentina      Observatorio Astronomico Tolar
- 3 X01  289.23502  -30.471033   1609.694 0.862846  -0.504270    Chile          Observatory Hurtado, El Sauce
- 3 X02  289.23517  -30.470668   1489.715 0.862833  -0.504255    Chile          Telescope Live, El Sauce
- 3 X03  289.20361  -30.533917   1572.149 0.862286  -0.505209    Chile          Observatoire SADR, Poroto
- 3 X04  291.56747  +48.469954     39.171 0.664264  +0.745000    Canada/Quebec  MCD Observatory, Saint-Anaclet
- 3 X05  289.25058  -30.244603   2683.655 0.864981  -0.500958    Chile          Simonyi Survey Telescope, Rubin Observatory
- 3 X06  289.14649  -30.526441   1734.846 0.862374  -0.505110    Chile          Skygems Chile, Rio Hurtado
- 3 X07  289.14639  -30.526391   1731.607 0.862374  -0.505109    Chile          iTelescope Deep Sky Chile, Rio Hurtado
- 3 X08  289.23500  -30.470114   1594.163 0.862852  -0.504255    Chile          ShAO Chile station, El Sauce
- 3 X09  289.14670  -30.526313   1733.861 0.862375  -0.505108    Chile          Deep Random Survey, Rio Hurtado
- 3 X10  291.82040  -22.953333   2438.761 0.921644  -0.387717    Chile          OVTLN, San Pedro de Atacama
- 3 X11  289.59604  -24.626344   2663.279 0.909953  -0.414324    Chile          VLT Survey Telescope, Paranal
- 3 X12  295.71200  -36.635593    198.160 0.803430  -0.593455    Argentina      Observatorio Los Cabezones
- 3 X13  295.4498   -31.598171   1217.340 0.85269   -0.52103     Argentina      Observatorio Remoto Bosque Alegre
- 3 X14  295.83222  -31.389999    426.088 0.854475  -0.517879    Argentina      Observatorio Orbis Tertius, Cordoba
- 3 X15  291.82053  -22.952948   2441.456 0.921647  -0.387711    Chile          ABYO, San Pedro de Atacama
- 3 X16  293.8497   -17.364775   2681.834 0.95511   -0.29667     Bolivia        Astronomia Sigma Octante, Cochabamba
- 3 X17  289.26208  -29.257419   2375.243 0.873456  -0.486033    Chile          BlackGEM
- 3 X18  291.82053  -22.952949   2434.588 0.921646  -0.387710    Chile          6R-POL2, San Pedro de Atacama
- 3 X19  290.67383  -31.802446   2451.588 0.850988  -0.524154    Argentina      Santel Observatory, El Leoncito
- 3 X20  291.82051  -22.953076   2440.558 0.921646  -0.387713    Chile          BOOTES-7, San Pedro Atacama
- 3 X31  299.47934  -31.823022     91.816 0.850485  -0.524263    Argentina      Galileo Galilei Observatory, Oro Verde
- 3 X33  299.99039   -2.997379     37.888 0.998647  -0.051941    Brazil         OARU, Manaus
- 3 X38  301.13711  -34.435686     18.196 0.825648  -0.562299    Argentina      Observatorio Pueyrredon, La Lonja
- 3 X39  301.1378   -34.385269     68.171 0.82615   -0.56158     Argentina      Observatorio Antares, Pilar
- 3 X40  301.61689  -34.747330     27.865 0.822572  -0.566762    Argentina      Cielos de Banfield, Banfield
- 3 X50  303.82419  -34.903699     76.209 0.821025  -0.568999    Uruguay        Observatorio Astronomico de Montevideo
- 3 X57  305.40626  -25.434816    186.613 0.903659  -0.426885    Brazil         Polo Astronomico CMF,Foz do Iguacu
- 3 X60  306.42556  -26.549445    600.534 0.895232  -0.444317    Brazil         Guaraciaba Observatory
- 3 X70  308.43322  -21.384967    389.102 0.931623  -0.362375    Brazil         Observatorio OATU, Tupi Paulista
- 3 X72  308.87889  -29.766926     42.220 0.868775  -0.493560    Brazil         Waccobs, Sao Leopoldo
- 3 X74  309.49422  -21.394146    417.328 0.931569  -0.362525    Brazil         Observatorio Campo dos Amarais
- 3 X77  309.92475  -25.908604    825.865 0.900184  -0.434346    Brazil         Centro Astron. Nevoeiro, Antonio Olinto
- 3 X86  312.21833  -23.393035    552.060 0.918367  -0.394621    Brazil         Ottoservatorio, Tatui
- 3 X87  312.0889   -15.891703   1044.874 0.96218   -0.27210     Brazil         Dogsheaven Observatory, Brasilia
- 3 X88  312.49131  -23.445389    596.163 0.918012  -0.395458    Brazil         Observatorio Adhara, Sorocaba
- 3 X89  312.21786  -15.844483   1024.765 0.962401  -0.271311    Brazil         Rocca Observatory, Brasilia
- 3 X90  312.13208  -15.656914   1273.159 0.963322  -0.268189    Brazil         Carina Observatory, Brasilia
- 3 X91  312.78881  -23.569491    878.799 0.917193  -0.397452    Brazil         Orion-Colesanti observatory, Mairinque
- 3 X93  313.6047   -22.628914   1078.766 0.92363   -0.38244     Brazil         Munhoz Observatory
- 3 Y00  315.21504  -20.715082   1111.997 0.935906  -0.351562    Brazil         SONEAR Observatory, Oliveira
- 3 Y01  316.01580  -19.881969    885.335 0.940890  -0.337985    Brazil         SONEAR 2 Observatory, Belo Horizonte
- 3 Y05  316.31000  -19.824252   1493.800 0.941320  -0.337075    Brazil         SONEAR Wykrota-CEAMIG, Serra da Piedade
- 3 Y16  318.68794  -21.745265      5.455 0.929268  -0.368170    Brazil         ROCG, Campos dos Goytacazes
- 3 Y28  321.3126    -8.788707    414.679 0.98840   -0.15179     Brazil         OASI, Nova Itacuruba
- 3 Y40  324.03889   -8.288643    533.510 0.989706  -0.143217    Brazil         Discovery Observatory, Caruaru
- 3 Y63  352.13368  +31.206605   2780.551 0.856447  +0.515346    Morocco        SNX-NET, Oukaimeden
- 3 Y64  343.48961  +28.298933   2424.545 0.881484  +0.471433    Canary Island  Transient Survey Telescope (TST), Teide
- 3 Y65  343.49042  +28.298730   2412.450 0.881484  +0.471429    Canary Island  Two-Meter Twin Telescope, TTT1, Teide
- 3 Y66  343.49053  +28.298730   2412.450 0.881484  +0.471429    Canary Island  Two-Meter Twin Telescope, TTT2, Teide
- 3 Y67  352.13292  +31.205945   2766.021 0.856451  +0.515335    Morocco        High Atlas Window to the Kosmos,Oukaimeden
- 3 Y70  353.37238  +38.215823    580.687 0.786766  +0.615329    Spain          ApolloIV5, Fregenal de la Sierra
- 3 Y71  353.37251  +38.215662    582.818 0.786768  +0.615327    Spain          Makroskooppi, Fregenal de la Sierra
- 3 Y75  354.58128  +38.262300    659.345 0.786275  +0.615972    Spain          Abraham Zacut, Salamanca
- 3 Y76  359.79189  +39.686387     83.941 0.770614  +0.635186    Spain          Observatorio NovaCanet, Canet de Berenguer
- 3 Y77  356.38858  +40.789626    975.196 0.758313  +0.649939    Spain          Cotos de Monterrey, Venturada
- 3 Y78  359.46617  +39.400889    198.638 0.773792  +0.631365    Spain          Tros Alt
- 3 Y79  359.99270  +45.517182    170.471 0.701911  +0.709914    France         Observatoire de la grande vallee
- 3 Y80  357.16642  +47.738795    123.965 0.673761  +0.736498    France         Brenehuen, Grand-Champ
- 3 Y81  356.5733   +55.913325    141.593 0.56175   +0.82456     UK/Scotland    Forthimage, Edinburgh
- 3 Y82  358.06548  +51.025953    135.613 0.630258  +0.773810    UK/England     LPMR Observatory, Broad Chalke
- 3 Y83  359.04761  +41.621176    341.185 0.748699  +0.660768    Spain          Observatorio Arcosur, Zaragoza
- 3 Y84  358.11972  +48.375264     78.112 0.665503  +0.743909    France         Observatoire de Saint Domineuc
- 3 Y85  351.85389  +43.456675    326.337 0.727084  +0.684321    Spain          Magalofes Observatory, Fene
- 3 Y86  357.48003  +37.351818    831.730 0.796010  +0.603469    Spain          Observatorio de Seron
- 3 Y87  353.01194  +42.222005   1313.434 0.741821  +0.668656    Spain          Trevinca Skies-Amalthea, Trevinca
- 3 Y88  353.01194  +42.222210   1316.846 0.741819  +0.668659    Spain          ASERO, Valdin
- 3 Y89  353.01189  +42.222446   1392.333 0.741825  +0.668670    Spain          Proxima Centauri Observatory, Valdin
- 3 Y90  354.5553   +43.203490    672.706 0.73015   +0.68115     Spain          Observatorio ESTELIA, Ladines
- 3 Y91  354.83350  +36.732104    756.551 0.802497  +0.594854    Spain          Ras Algethi, Ronda
- 3 Y92  354.53482  +38.177157    579.537 0.787182  +0.614800    Spain          JD Cassini, Piconcillo
- 3 Y93  355.43322  +41.798064    765.592 0.746699  +0.663112    Spain          Observatorio Azahar, Valoria la Buena
- 3 Y94  354.58571  +42.983624   1251.218 0.732833  +0.678415    Spain          LCB Lugueros observatory, Valdelugueros
- 3 Y95  357.99864  +38.348453    744.617 0.785356  +0.617157    Spain          Pradillos Ferez
- 3 Y96  358.08932  +40.417289   1590.036 0.762606  +0.645079    Spain          Observatorio de Vega del Codorno
- 3 Y97  359.64303  +44.550028     62.301 0.713822  +0.697993    France         Bommes Observatory, Bommes
- 3 Y98  358.68692  +51.927850    170.859 0.617953  +0.783613    UK/England     Southside Observatory, Steeple Aston
- 3 Y99  359.07299  +41.642025    308.796 0.748454  +0.661036    Spain          Observatorio del Lucero del Alba
- 3 Z00  353.26586  +37.104084    110.091 0.798528  +0.599968    Spain          BOOTES-1, Mazagon
- 3 Z01  352.13321  +31.206060   2855.771 0.856462  +0.515344    Morocco        OWL-Net, Oukaimeden
- 3 Z02  352.13331  +31.206172   2773.784 0.856450  +0.515339    Morocco        HAO observatory, Oukaimeden
- 3 Z03  355.73346  +40.523696    975.019 0.761330  +0.646426    Spain          Rio Cofio, Robledo de Chavela
- 3 Z04  352.98203  +33.601394    352.681 0.833809  +0.550302    Morocco        MAO, Ain Laqsab
- 3 Z05  355.36389  +36.710515    138.980 0.802644  +0.594495    Spain          Observatorio Horus, Cartama
- 3 Z06  357.67324  +38.165593   1655.349 0.787439  +0.614746    Spain          Marina Sky, Nerpio
- 3 Z07  356.36050  +37.111289    786.946 0.798537  +0.600132    Spain          Ad Astra Sangos Observatory, Alhendin
- 3 Z08  357.59139  +37.501038   1195.459 0.794477  +0.605566    Spain          Telescope Live, Oria
- 3 Z09  356.8786   +51.159629     99.288 0.62844   +0.77527     UK/England     Old Orchard Observatory, Fiddington
- 3 Z10  353.37235  +38.215823    580.687 0.786766  +0.615329    Spain          PGC, Fregenal de la Sierra
- 3 Z11  358.96669  +53.106104    112.384 0.601635  +0.796115    UK/England     Appledorne Observatory, Farnsfield
- 3 Z12  359.0961   +38.384145    497.206 0.78494   +0.61762     Spain          La Romaneta, Monovar
- 3 Z13  355.54519  +36.722641    116.245 0.802515  +0.594662    Spain          Observatorio AGP GUAM 4, Malaga
- 3 Z14  353.37226  +38.215845    639.440 0.786773  +0.615335    Spain          ART, Fregenal de la Sierra
- 3 Z15  359.65331  +51.018662     86.323 0.630352  +0.773724    UK/England     Southwater
- 3 Z16  358.95192  +37.612323    145.631 0.793166  +0.607001    Spain          Asociacion Astronomica de Cartagena
- 3 Z17  343.48827  +28.300316   2449.165 0.881476  +0.471456    Canary Island  Tenerife-LCO Aqawan A #2
- 3 Z18  342.10811  +28.756590   2325.350 0.877671  +0.478415    Canary Island  Gran Telescopio Canarias, Roque de los Muchachos
- 3 Z19  342.11094  +28.753995   2385.706 0.877701  +0.478380    Canary Island  La Palma-TNG
- 3 Z20  342.1217   +28.762012   2356.944 0.87763   +0.47850     Canary Island  La Palma-MERCATOR
- 3 Z21  343.48830  +28.300293   2440.525 0.881475  +0.471455    Canary Island  Tenerife-LCO Aqawan A #1
- 3 Z22  343.4894   +28.298890   2393.011 0.88148   +0.47143     Canary Island  MASTER-IAC Observatory, Tenerife
- 3 Z23  342.11492  +28.757277   2425.315 0.877679  +0.478433    Canary Island  Nordic Optical Telescope, La Palma
- 3 Z24  343.48848  +28.300546   2455.645 0.881475  +0.471460    Canary Island  Tenerife Observatory-LCO B, Tenerife
- 3 Z25  343.49031  +28.300012   2431.022 0.881476  +0.471450    Canary Island  Artemis Observatory, Teide
- 3 Z26  343.38969  +28.078226    355.724 0.883010  +0.467899    Canary Island  Observatorio Astronomico Arcangel, Las Zocas
- 3 Z27  343.6998   +28.472491    322.100 0.87976   +0.47393     Canary Island  Observatorio Coralito, La Laguna
- 3 Z28  357.67331  +38.165719   1658.217 0.787438  +0.614748    Spain          Northern Skygems Observatory, Nerpio
- 3 Z29  354.11944  +41.372224    872.813 0.751634  +0.657576    Spain          Observatorio Astronomico Sobradillo
- 3 Z30  355.52500  +54.178411    168.928 0.586571  +0.807215    UK/Isle of Ma  Glyn Marsh Observatory, Douglas
- 3 Z31  343.48835  +28.300421   2440.957 0.881474  +0.471457    Canary Island  Tenerife Observatory-LCO A, Tenerife
- 3 Z32  358.98372  +40.041843   2010.717 0.766879  +0.640130    Spain          Observatorio Astrofisico de Javalambre
- 3 Z33  357.67331  +38.165746   1660.581 0.787438  +0.614748    Spain          6ROADS Observatory 2, Nerpio
- 3 Z34  359.11233  +52.302083    169.150 0.612800  +0.787622    UK/England     NNHS Drummonds Observatory
- 3 Z35  358.8985   +39.945062   1327.056 0.76788   +0.63877     Spain          OAO University Observatory Station Aras
- 3 Z36  354.94553  +36.461066     84.897 0.805224  +0.591005    Spain          Cancelada
- 3 Z37  357.80426  +50.839047    124.191 0.632788  +0.771754    UK/England     Northolt Branch Observatory 3, Blandford Forum
- 3 Z38  351.15294  +39.856140     71.022 0.768722  +0.637456    Portugal       Picoto Observatory, Leiria
- 3 Z39  346.4989   +28.996159     65.802 0.87535   +0.48189     Canary Island  Observatorio Costa Teguise
- 3 Z40  355.5127   +36.733872    131.022 0.80240   +0.59482     Spain          El Manzanillo Observatory, Puerto de la Torre
- 3 Z41  356.6264   +40.561118    669.120 0.76087   +0.64689     Spain          Irydeo Observatory, Camarma de Esteruelas
- 3 Z42  357.66579  +50.934434    102.962 0.631495  +0.772801    UK/England     Rushay Farm Observatory, Sturminster Newton
- 3 Z43  357.46216  +48.434104    137.564 0.664742  +0.744597    France         Landehen
- 3 Z44  351.67248  +43.318117    159.662 0.728723  +0.682549    Spain          Observatorio Terminus, A Coruna
- 3 Z45  355.14264  +36.516212    113.061 0.804657  +0.591779    Spain          Cosmos Observatory, Marbella
- 3 Z46  356.80700  +51.514032     90.003 0.623612  +0.779131    UK/Wales       Cardiff
- 3 Z47  357.2925   +53.333337    120.050 0.59846   +0.79849     UK/England     Runcorn
- 3 Z48  359.74915  +51.500075     53.606 0.623799  +0.778975    UK/England     Northolt Branch Observatory 2, Shepherd's Bush
- 3 Z49  357.40631  +53.801041    112.780 0.591893  +0.803336    UK/England     Alston Observatory
- 3 Z50  355.28431  +42.025894    804.895 0.744053  +0.666069    Spain          Mazariegos
- 3 Z51  356.4486   +40.360654    626.823 0.76313   +0.64423     Spain          Anunaki Observatory, Rivas Vaciamadrid
- 3 Z52  359.33899  +52.915118    136.301 0.604299  +0.794113    UK/England     The Studios Observatory, Grantham
- 3 Z53  352.1336   +31.206221   2777.089 0.85645   +0.51534     Morocco        TRAPPIST-North, Oukaimeden
- 3 Z54  358.92214  +51.528801    209.752 0.623422  +0.779306    UK/England     Greenmoor Observatory, Woodcote
- 3 Z55  354.9150   +37.542483    168.550 0.79391   +0.60604     Spain          Uraniborg Observatory, Ecija
- 3 Z56  350.2119   +52.085639     29.449 0.61577   +0.78529     Ireland        Knocknaboola
- 3 Z57  355.42589  +36.656985    191.447 0.803207  +0.593753    Spain          Observatorio Zuben, Alhaurin de la Torre
- 3 Z58  355.63068  +40.454056    770.891 0.762093  +0.645483    Spain          ESA TBT Cebreros Observatory
- 3 Z59  357.71540  +53.273907    125.531 0.599292  +0.797871    UK/England     Chelford Observatory
- 3 Z60  357.8506   +43.038842    144.660 0.73205   +0.67900     Spain          Observatorio Zaldibia
- 3 Z61  359.06400  +41.629001    217.642 0.748594  +0.660857    Spain          Montecanal Observatory, Zaragoza
- 3 Z62  351.62912  +42.610591    670.063 0.737181  +0.673585    Spain          Observatorio Forcarei
- 3 Z63  358.47002  +41.830074    454.751 0.746291  +0.663495    Spain          Skybor Observatory, Borja
- 3 Z64  352.1424   +42.352174    145.107 0.74016   +0.67021     Spain          Observatorio el Miron del Cielo
- 3 Z65  352.17252  +42.249342    340.501 0.741388  +0.668906    Spain          Observatorio Astronomico Corgas
- 3 Z66  355.59156  +38.543547   1066.217 0.783284  +0.619848    Spain          DeSS Deimos Sky Survey, Niefla Mountain
- 3 Z67  353.52314  +53.414420     71.701 0.597320  +0.799328    Ireland        Dunboyne Castle Observatory
- 3 Z68  353.4003   +38.868669    206.864 0.77964   +0.62418     Spain          Observatorio Torreaguila, Barbano
- 3 Z69  353.1870   +37.131467     26.289 0.79823   +0.60034     Spain          Observatorio Mazagon Huelva
- 3 Z70  353.35711  +42.575022    520.198 0.737583  +0.673113    Spain          Ponferrada
- 3 Z71  353.60972  +39.450877    468.103 0.773272  +0.632064    Spain          Observatorio Norba Caesarina, Aldea Moret
- 3 Z72  353.88864  +53.273256     60.292 0.599295  +0.797856    Ireland        Cademuir Observatory, Dalkey
- 3 Z73  353.96731  +37.403179      9.671 0.795365  +0.604101    Spain          Observatorio Nuevos Horizontes, Camas
- 3 Z74  354.1562   +37.334107     53.923 0.79610   +0.60315     Spain          Amanecer de Arrakis
- 3 Z75  354.4676   +42.598353    970.698 0.73736   +0.67346     Spain          Observatorio Sirius, Las Lomas
- 3 Z76  354.5644   +43.481490      4.513 0.72675   +0.68460     Spain          Observatorio Carda, Villaviciosa
- 3 Z77  354.88958  +37.230879    245.687 0.797212  +0.601739    Spain          Osuna
- 3 Z78  358.32420  +38.096870    466.614 0.788031  +0.613690    Spain          Arroyo Observatory, Arroyo Hurtado
- 3 Z79  357.45327  +37.220935   2162.511 0.797556  +0.601783    Spain          Calar Alto TNO Survey
- 3 Z80  359.62808  +51.554661     58.505 0.623054  +0.779568    UK/England     Northolt Branch Observatory
- 3 Z81  355.73240  +36.720606     67.080 0.802530  +0.594629    Spain          Observatorio Estrella de Mar
- 3 Z82  355.95903  +36.759241    123.686 0.802135  +0.595173    Spain          BOOTES-2 Observatory, Algarrobo
- 3 Z83  356.2881   +40.610079    792.156 0.76033   +0.64755     Spain          Chicharronian 3C Observatory, Tres Cantos
- 3 Z84  357.45184  +37.224009   2261.560 0.797536  +0.601835    Spain          Calar Alto-Schmidt
- 3 Z85  356.75028  +36.877254   1347.963 0.801058  +0.596932    Spain          Observatorio Sierra Contraviesa
- 3 Z86  356.8900   +51.523936     20.726 0.62347   +0.77923     UK/Wales       St. Mellons
- 3 Z87  357.10210  +52.648212    110.278 0.608005  +0.791293    UK/England     Stanley Laver Observatory, Pontesbury
- 3 Z88  357.5101   +51.254536    204.251 0.62716   +0.77632     UK/England     Fosseway Observatory, Stratton-on-the-Fosse
- 3 Z89  357.8281   +53.264567     97.494 0.59942   +0.79777     UK/England     Macclesfield
- 3 Z90  357.8482   +37.405564    493.072 0.79540   +0.60418     Spain          Albox
- 3 Z91  358.74999  +50.916485     31.749 0.631731  +0.772595    UK/England     Curdridge
- 3 Z92  358.39222  +53.837615    114.550 0.591378  +0.803713    UK/England     Almalex Observatory, Leeds
- 3 Z93  359.85589  +38.617299    222.134 0.782380  +0.620769    Spain          Observatorio Polop, Alicante
- 3 Z94  358.8565   +51.247283    115.859 0.62725   +0.77623     UK/England     Kempshott
- 3 Z95  358.8909   +39.949917   1279.393 0.76782   +0.63883     Spain          Astronomia Para Todos Remote Observatory
- 3 Z96  359.19369  +41.696118    225.655 0.747818  +0.661731    Spain          Observatorio Cesaraugusto
- 3 Z97  359.41647  +45.302074     58.177 0.704568  +0.707270    France         OPERA Observatory, Saint Palais
- 3 Z98  359.5216   +39.601465    107.275 0.77156   +0.63405     Spain          Observatorio TRZ, Betera
- 3 Z99  359.97874  +53.546062      8.159 0.595468  +0.800687    UK/England     Clixby Observatory, Cleethorpes
+Code  Long.   cos      sin    Name
+000   0.0000 0.62411 +0.77873 Greenwich
+001   0.1542 0.62992 +0.77411 Crowborough
+002   0.62   0.622   +0.781   Rayleigh
+003   3.90   0.725   +0.687   Montpellier
+004   1.4625 0.72520 +0.68627 Toulouse
+005   2.231000.659891+0.748875Meudon
+006   2.124170.751042+0.658129Fabra Observatory, Barcelona
+007   2.336750.659470+0.749223Paris
+008   3.0355 0.80172 +0.59578 Algiers-Bouzareah
+009   7.4417 0.6838  +0.7272  Berne-Uecht
+010   6.921240.723655+0.688135Caussols
+011   8.7975 0.67920 +0.73161 Wetzikon
+012   4.358210.633333+0.771306Uccle
+013   4.483970.614813+0.786029Leiden
+014   5.395090.728859+0.682384Marseilles
+015   5.129290.615770+0.785285Utrecht
+016   5.9893 0.68006 +0.73076 Besancon
+017   6.849240.641946+0.764282Hoher List
+018   6.7612 0.62779 +0.77578 Dusseldorf-Bilk
+019   6.9575 0.68331 +0.72779 Neuchatel
+020   7.3004 0.72391 +0.68767 Nice
+021   8.3855 0.65701 +0.75138 Karlsruhe
+022   7.7748 0.70790 +0.70409 Pino Torinese
+023   8.2625 0.64299 +0.76335 Wiesbaden
+024   8.7216 0.65211 +0.75570 Heidelberg-Konigstuhl
+025   9.196500.660205+0.748637Stuttgart
+026   7.465110.684884+0.726402Berne-Zimmerwald
+027   9.1912 0.70254 +0.70929 Milan
+028   9.9363 0.64686 +0.76009 Wurzburg
+029  10.2406 0.59640 +0.80000 Hamburg-Bergedorf
+030  11.254460.723534+0.688012Arcetri Observatory, Florence
+031  11.189850.639061+0.766705Sonneberg
+032  11.582950.631624+0.772706Jena
+033  11.711240.630904+0.773338Karl Schwarzschild Observatory, Tautenburg
+034  12.452460.745176+0.664656Monte Mario Observatory, Rome
+035  12.575920.565008+0.822321Copenhagen
+036  12.650400.747247+0.662420Castel Gandolfo
+037  13.7333 0.73660 +0.67416 Collurania Observatory, Teramo
+038  13.7704 0.70033 +0.71144 Trieste
+039  13.1874 0.56485 +0.82243 Lund
+040  13.7298 0.63019 +0.77387 Lohrmann Institute, Dresden
+041  11.380830.679862+0.731012Innsbruck
+042  13.064280.611721+0.788439Potsdam
+043  11.526430.697656+0.714269Asiago Astrophysical Observatory, Padua
+044  14.2559 0.75738 +0.65082 Capodimonte Observatory, Naples
+045  16.3390 0.66739 +0.74227 Vienna (since 1879)
+046  14.2881 0.65922 +0.74965 Klet Observatory, Ceske Budejovice
+047  16.8782 0.61146 +0.78864 Poznan
+048  15.840800.641709+0.764432Hradec Kralove
+049  17.6067 0.5088  +0.8580  Uppsala-Kvistaberg
+050  18.0582 0.51118 +0.85660 Stockholm (before 1931)
+051  18.4766 0.83055 -0.55508 Royal Observatory, Cape of Good Hope
+052  18.3083 0.51224 +0.85597 Stockholm-Saltsjobaden
+053  18.9642 0.67688 +0.73373 Konkoly Observatory, Budapest (since 1933)
+054  11.6654 0.56595 +0.82169 Brorfelde
+055  19.9596 0.64321 +0.76316 Cracow
+056  20.234180.655001+0.753470Skalnate Pleso
+057  20.5133 0.71074 +0.70116 Belgrade
+058  20.4950 0.57897 +0.81262 Kaliningrad
+059  20.2201 0.65500 +0.75364 Lomnicky Stit
+060  21.4200 0.61572 +0.78535 Warsaw-Ostrowik
+061  22.298500.662142+0.746904Uzhhorod
+062  22.2293 0.49440 +0.86632 Turku
+063  22.4450 0.49496 +0.86601 Turku-Tuorla
+064  22.7500 0.49489 +0.86605 Turku-Kevola
+065  12.6318 0.67222 +0.73800 Traunstein
+066  23.718170.789321+0.611946Athens
+067  24.0297 0.64632 +0.76058 Lviv University Observatory
+068  24.0142 0.64627 +0.76062 Lviv Polytechnic Institute
+069  24.4042 0.54925 +0.83287 Baldone
+070  25.2865 0.57940 +0.81233 Vilnius (before 1939)
+071  24.737820.74803 +0.66185 NAO Rozhen, Smolyan
+072   7.17   0.629   +0.774   Scheuren Observatory
+073  26.093910.715515+0.696285Bucharest
+074  26.4058 0.87518 -0.48263 Boyden Observatory, Bloemfontein
+075  26.7216 0.52557 +0.84791 Tartu
+076  27.8768 0.90127 -0.43225 Johannesburg-Hartbeespoort
+077  28.0292 0.89819 -0.43876 Yale-Columbia Station, Johannesburg
+078  28.0750 0.89824 -0.43868 Johannesburg
+079  28.2288 0.90120 -0.43251 Radcliffe Observatory, Pretoria
+080  28.9667 0.75566 +0.65278 Istanbul
+081  27.8768 0.90127 -0.43225 Leiden Station, Johannesburg
+082  15.7561 0.66929 +0.74063 St. Polten
+083  30.5056 0.63918 +0.76651 Holosiivskyi district-Kyiv
+084  30.3274 0.50471 +0.86041 Pulkovo
+085  30.5023 0.63800 +0.76749 Kyiv
+086  30.7582 0.68987 +0.72152 Odesa
+087  31.3411 0.86799 +0.49495 Helwan
+088  31.827690.867391+0.496114Kottomia
+089  31.9747 0.68359 +0.72743 Mykolaiv
+090   8.25   0.645   +0.762   Mainz
+091   4.209190.703630+0.708287Observatoire de Nurol, Aurec sur Loire
+092  18.5546 0.60177 +0.79601 Torun-Piwnice
+093  20.3647 0.3537  +0.9322  Skibotn
+094  33.9974 0.71565 +0.69620 Crimea-Simeiz
+095  34.0160 0.71172 +0.70024 Crimea-Nauchnyi
+096   9.4283 0.69967 +0.71215 Merate
+097  34.7625 0.86165 +0.50608 Wise Observatory, Mitzpeh Ramon
+098  11.569000.697916+0.714090Asiago Observatory, Cima Ekar
+099  25.535290.484073+0.872114Lahti
+100  24.141450.461165+0.884370Ahtari
+101  36.2322 0.64403 +0.76246 Kharkiv
+102  36.759530.564841+0.822468Zvenigorod
+103  14.527740.695365+0.716346Ljubljana
+104  10.803750.719842+0.692040San Marcello Pistoiese
+105  37.5706 0.56403 +0.82302 Moscow
+106  14.0711 0.69662 +0.71519 Crni Vrh
+107  11.0030 0.70998 +0.70186 Cavezzo
+108  11.0278 0.72367 +0.68784 Montelupo
+109   3.0705 0.80241 +0.59481 Algiers-Kouba
+110  39.4150 0.54316 +0.83683 Rostov
+111  10.9721 0.72439 +0.68710 Piazzano Observatory, Florence
+112  10.9039 0.70232 +0.70950 Pleiade Observatory, Verona
+113  13.0166 0.63502 +0.77001 Volkssternwarte Drebach, Schoenbrunn
+114  41.4277 0.72489 +0.68702 Engelhardt Observatory, Zelenchukskaya Station
+115  41.440670.725004+0.686912Zelenchukskaya
+116  11.5958 0.66893 +0.74094 Giesing
+117  11.5385 0.66897 +0.74092 Sendling
+118  17.2740 0.66558 +0.74394 Astronomical and Geophysical Observatory, Modra
+119  42.8200 0.74731 +0.66262 Abastuman
+120  13.7261 0.70489 +0.70699 Visnjan
+121  36.934030.648856+0.758394Kharkiv University, Chuguevskaya Station
+122   3.5035 0.72017 +0.69176 Pises Observatory
+123  44.2917 0.76352 +0.64398 Byurakan
+124   2.2550 0.72534 +0.68612 Castres
+125  44.789500.747594+0.662026Tbilisi
+126   9.790150.718943+0.692828Monte Viseggi L. Zannoni Observatory
+127   6.9797 0.63385 +0.77088 Bornheim
+128  46.006610.623279+0.779393Saratov
+129  45.92   0.777   +0.628   Ordubad
+130  10.239630.700148+0.711796Lumezzane
+131   4.725  0.7123  +0.6996  Observatoire de l'Ardeche
+132   5.2461 0.71919 +0.69260 Bedoin
+133   5.0906 0.72819 +0.68309 Les Tardieux
+134  11.482450.631607+0.772773Groszschwabhausen
+135  49.1210 0.56353 +0.82334 Kasan
+136  48.8156 0.56282 +0.82383 Engelhardt Observatory, Kasan
+137  34.8147 0.84821 +0.52790 Givatayim Observatory
+138   7.5717 0.67550 +0.73494 Village-Neuf
+139   7.1108 0.72526 +0.68618 Antibes
+140   3.6294 0.69945 +0.71241 Augerolles
+141   7.3672 0.65646 +0.75189 Hottviller
+142   7.1874 0.62156 +0.78075 Sinsen
+143   9.024060.692986+0.718590Gnosca
+144   1.6660 0.65549 +0.75268 Bray et Lu
+145   4.5597 0.62734 +0.77614 's-Gravenwezel
+146  10.6673 0.71715 +0.69487 Frignano
+147   8.573910.700430+0.711392Osservatorio Astronomico di Suno
+148   2.0375 0.72481 +0.68667 Guitalens
+149   4.2236 0.65403 +0.75396 Beine-Nauroy
+150   2.1572 0.65806 +0.75045 Maisons Laffitte
+151   8.7440 0.67719 +0.73346 Eschenberg Observatory, Winterthur
+152  25.5633 0.57036 +0.81868 Moletai Astronomical Observatory
+153   9.1747 0.66080 +0.74814 Stuttgart-Hoffeld
+154  12.1043 0.68923 +0.72250 Cortina
+155  10.1971 0.55864 +0.82664 Ole Romer Observatory, Aarhus
+156  15.0858 0.79431 +0.60549 Catania Astrophysical Observatory
+157  12.8117 0.74166 +0.66864 Frasso Sabino
+158   7.6033 0.69871 +0.71333 Promiod
+159  10.5153 0.72065 +0.69115 Monte Agliale
+160  10.841440.722651+0.688913Castelmartini
+161   8.1605 0.70725 +0.70467 Cerrina Tololo Observatory
+162  15.7805 0.75988 +0.64808 Potenza
+163   6.1492 0.65017 +0.75731 Roeser Observatory, Luxembourg
+164   6.8861 0.66631 +0.74325 St. Michel sur Meurthe
+165   1.7553 0.74984 +0.65946 Piera Observatory, Barcelona
+166  16.0117 0.63730 +0.76812 Upice
+167   8.5727 0.67662 +0.73398 Bulach Observatory
+168  59.5472 0.54541 +0.83541 Kourovskaya
+169   8.4016 0.70737 +0.70453 Airali Observatory
+170   1.9206 0.75217 +0.65711 Observatorio de Begues
+171  14.4697 0.81089 +0.58327 Flarestar Observatory, San Gwann
+172   7.0364 0.68593 +0.72539 Onnens
+173  55.5061 0.93464 -0.35447 St. Clotilde, Reunion
+174  25.5131 0.46536 +0.88219 Nyrola Observatory, Jyvaskyla
+175   7.6083 0.6932  +0.7188  F.-X. Bagnoud Observatory, St-Luc
+176   2.8225 0.77098 +0.63475 Observatorio Astronomico de Consell
+177   3.9414 0.72477 +0.68669 Le Cres
+178   6.1344 0.69423 +0.71745 Collonges
+179   9.0175 0.69694 +0.71507 Monte Generoso
+180   3.9519 0.72571 +0.68570 Mauguio
+181  55.4100 0.93288 -0.35941 Observatoire des Makes, Saint-Louis
+182  55.2586 0.93394 -0.35634 St. Paul, Reunion
+183  41.4200 0.72496 +0.68695 Starlab Observatory, Karachay-Cherkessia
+184   6.0361 0.72081 +0.69097 Valmeca Observatory, Puimichel
+185   7.4219 0.67876 +0.73200 Observatoire Astronomique Jurassien-Vicques
+186  66.8821 0.77679 +0.62781 Kitab
+187  17.0733 0.61314 +0.78735 Astronomical Observatory, Borowiec
+188  66.895550.782059+0.621762Majdanak
+189   6.1514 0.69340 +0.71823 Geneva (before 1967)
+190  68.6819 0.78382 +0.61909 Gissar
+191  68.7811 0.78306 +0.62006 Dushanbe
+192  69.2936 0.75213 +0.65692 Tashkent
+193  69.2178 0.78648 +0.61610 Sanglok
+194  18.0094 0.91807 -0.39579 Tivoli
+195  11.4492 0.66804 +0.74174 Untermenzing Observatory, Munich
+196   7.3331 0.65296 +0.75490 Homburg-Erbach
+197  12.1836 0.71739 +0.69434 Bastia
+198   8.756740.662195+0.746924Wildberg
+199   2.4380 0.66659 +0.74294 Telescope Jean-Marc Salomon, Buthiers
+200   4.3036 0.63385 +0.77088 Beersel Hills Observatory
+201   7.6033 0.69871 +0.71332 Jonathan B. Postel Observatory
+202   5.8997 0.73137 +0.67971 Tamaris Observatoire, La Seyne sur Mer
+203   8.995480.701614+0.710215GiaGa Observatory
+204   8.769720.697648+0.714307Schiaparelli Observatory
+205  11.2731 0.71478 +0.69703 Obs. Casalecchio di Reno, Bologna
+206  10.5667 0.4922  +0.8677  Haagaar Observatory, Eina
+207   9.3065 0.70156 +0.71025 Osservatorio Antonio Grosso
+208   9.5875 0.70893 +0.70294 Rivalta
+209  11.568830.697904+0.714100Asiago Observatory, Cima Ekar-ADAS
+210  76.9573 0.73042 +0.68104 Alma-Ata
+211  11.1764 0.72338 +0.68815 Scandicci
+212 355.357470.803253+0.593708Observatorio La Dehesilla
+213   2.385390.749843+0.659421Observatorio Montcabre
+214  11.6569 0.66709 +0.74258 Garching Observatory
+215  10.7328 0.67021 +0.73981 Buchloe
+216   5.6914 0.65732 +0.75114 Observatoire des Cote de Meuse
+217  77.871140.730114+0.681643Assah
+218  78.4541 0.95444 +0.29768 Hyderabad
+219  78.7283 0.95618 +0.29216 Japal-Rangapur
+220  78.8263 0.97627 +0.21634 Vainu Bappu Observatory, Kavalur
+221  16.361700.919631-0.392203IAS Observatory, Hakos
+222   2.4939 0.66113 +0.74777 Yerres-Canotiers
+223  80.2464 0.97427 +0.22465 Madras
+224   7.501710.673178+0.737048Ottmarsheim
+225 288.8250 0.7298  +0.6814  Northwood Ridge Observatory
+226  11.8858 0.70293 +0.70888 Guido Ruggieri Observatory, Padua
+227 281.2853 0.73683 +0.67392 OrbitJet Observatory, Colden
+228  13.8750 0.70038 +0.71147 Bruno Zugna Observatory, Trieste
+229  14.9743 0.75936 +0.64857 G. C. Gloriosi Astronomical Observatory, Salerno
+230  12.0133 0.6744  +0.7363  Mt. Wendelstein Observatory
+231   5.3983 0.64403 +0.76253 Vesqueville
+232   1.3317 0.7500  +0.6593  Masquefa Observatory
+233  10.5403 0.72226 +0.68931 Sauro Donati Astronomical Observatory, San Vito
+234   1.128330.614951+0.785931Coddenham Observatory
+235  13.113520.696669+0.714993CAST Observatory, Talmassons
+236  84.9465 0.55370 +0.82995 Tomsk
+237   2.7333 0.6822  +0.7288  Baugy
+238  10.9094 0.50204 +0.86197 Grorudalen Optical Observatory
+239   8.4114 0.64506 +0.76159 Trebur
+240   8.833170.662308+0.746832Herrenberg Sternwarte
+241  13.4700 0.66465 +0.74474 Schaerding
+242   1.6956 0.72681 +0.68460 Varennes
+243   9.4130 0.59572 +0.80050 Umbrella Observatory, Fredenbeck
+244   0.000000.000000 0.000000Geocentric Occultation Observation
+245                           Spitzer Space Telescope
+246  14.284760.659216+0.749664Klet Observatory-KLENOT
+247                           Roving Observer
+248   0.000000.000000 0.000000Hipparcos
+249                           SOHO
+250                           Hubble Space Telescope
+251 293.246920.949577+0.312734Arecibo
+252 243.205120.817719+0.573979Goldstone DSS 13, Fort Irwin
+253 243.110470.815913+0.576510Goldstone DSS 14, Fort Irwin
+254 288.511280.736973+0.673692Haystack, Westford
+255  33.186890.705965+0.705886Yevpatoriya
+256 280.160170.784451+0.618320Green Bank
+257 243.124610.816796+0.575252Goldstone DSS 25, Fort Irwin
+258                           Gaia
+259  19.225860.349828+0.933688EISCAT Tromso UHF
+260 149.0661 0.85560 -0.51626 Siding Spring Observatory-DSS
+261 243.140220.836325+0.546877Palomar Mountain-DSS
+262 289.266260.873440-0.486052European Southern Observatory, La Silla-DSS
+266 204.523960.941711+0.337239New Horizons KBO Search-Subaru
+267 204.531090.941717+0.337240New Horizons KBO Search-CFHT
+268 289.308030.875516-0.482342Magellan-Clay Telescope
+269 289.309140.875510-0.482349Magellan-Baade Telescope
+270                           Unistellar Network, Roving Observer
+273                           Euclid
+274                           James Webb Space Telescope
+275                           Non-geocentric Occultation Observation
+276  20.382790.608295+0.791076Plonsk
+277 356.8175 0.56158 +0.82467 Royal Observatory, Blackford Hill, Edinburgh
+278 116.4494 0.76818 +0.63809 Peking, Transit of Venus site
+279  10.728220.631526+0.772827Seeberg Observatory, Gotha (1787-1857)
+280   8.9118 0.60114 +0.79646 Lilienthal
+281  11.3522 0.71448 +0.69733 Bologna
+282   4.3603 0.72245 +0.68912 Nimes
+283   8.8163 0.60204 +0.79579 Bremen
+284  15.8311 0.60536 +0.79329 Driesen
+285   2.3708 0.66135 +0.74759 Flammarion Observatory, Juvisy
+286 102.7883 0.90694 +0.42057 Yunnan Observatory
+290 250.107990.842743+0.537438Mt. Graham-VATT
+291 248.400240.849471+0.526470LPL/Spacewatch II
+292 285.1058 0.76630 +0.64033 Burlington, New Jersey
+293 285.5899 0.76936 +0.63668 Burlington remote site
+294 285.8467 0.76031 +0.64739 Astrophysical Obs., College of Staten Island
+295 283.0000 0.7789  +0.6251  Catholic University Observatory, Washington
+296 286.2200 0.73660 +0.67407 Dudley Observatory, Albany (after 1893)
+297 286.819  0.7203  +0.6913  Middlebury
+298 287.3408 0.74943 +0.65988 Van Vleck Observatory
+299 107.6160 0.99316 -0.11808 Bosscha Observatory, Lembang
+300 133.544440.823370+0.565720Bisei Spaceguard Center-BATTeRS
+301 288.8467 0.70279 +0.70926 Mont Megantic
+302 288.88   0.990   +0.150   University of the Andes station
+303 289.1296 0.98890 +0.15185 OAN de Llano del Hato, Merida
+304 289.308580.875513-0.482346Las Campanas Observatory
+305 109.5514 0.82066 +0.56963 Purple Mountain, Hainan Island station
+306 290.6769 0.98477 +0.17381 Observatorio Taya Beixo, Barquisimeto
+307 287.7166 0.72410 +0.68743 Shattuck Observatory, Hanover
+309 289.595690.909943-0.414336Cerro Paranal
+310 288.871640.739802+0.670574Minor Planet Center Test Code
+312 112.334  0.9574  +0.2877  Tsingtao field station, Xisha Islands
+318 115.691  0.85206 -0.52170 Quinns Rock
+319 116.1350 0.84883 -0.52702 Perth Observatory, Perth-Lowell Telescope
+320 116.4381 0.85859 -0.51102 Chiro Observatory
+321 115.7571 0.85078 -0.52378 Craigie
+322 116.1340 0.84882 -0.52703 Perth Observatory, Bickley-MCT
+323 116.1350 0.84882 -0.52703 Perth Observatory, Bickley
+324 116.3277 0.76598 +0.64072 Peking Observatory, Shaho Station
+327 117.5750 0.76278 +0.64470 Peking Observatory, Xinglong Station
+330 118.8209 0.84828 +0.52788 Purple Mountain Observatory, Nanking
+333 249.5236 0.84936 +0.52642 Desert Eagle Observatory
+334 120.3196 0.80925 +0.58552 Tsingtao
+337 121.1843 0.85708 +0.51348 Sheshan, formerly Zo-Se
+340 135.4853 0.82199 +0.56762 Toyonaka
+341 137.9486 0.80669 +0.58923 Akashina
+342 134.3189 0.83425 +0.54955 Shishikui
+343 127.1258 0.78688 +0.61507 Younchun
+344 128.9767 0.80841 +0.58695 Bohyunsan Optical Astronomy Observatory
+345 128.4575 0.80046 +0.59773 Sobaeksan Optical Astronomy Observatory
+346 127.3854 0.80474 +0.59166 KNUE Astronomical Observatory
+347 139.9086 0.80417 +0.59244 Utsunomiya-Imaizumi
+348 135.2669 0.81698 +0.57475 Ayabe
+349 139.566220.810402+0.583916Ageo
+350 139.2635 0.80504 +0.59132 Kurohone
+351 135.8678 0.81939 +0.57135 Sakamoto
+352 136.1778 0.82061 +0.56963 Konan
+353 135.0648 0.82265 +0.56669 Nishi Kobe
+354 140.0206 0.80109 +0.59674 Kawachi
+355 139.2133 0.81618 +0.57590 Hadano
+356 141.0867 0.78319 +0.61970 Kogota
+357 140.0064 0.80807 +0.58712 Shimotsuma
+358 140.1586 0.78856 +0.61296 Nanyo
+359 135.1719 0.82782 +0.55912 Wakayama
+360 132.9442 0.83314 +0.55138 Kuma Kogen
+361 134.8933 0.82649 +0.56106 Sumoto
+362 140.6550 0.73673 +0.67398 Ray Observatory
+363 130.7703 0.83416 +0.54967 Yamada
+364 130.5747 0.85213 +0.52164 YCPM Kagoshima Station
+365 135.9579 0.82597 +0.56196 Uto Observatory
+366 138.3003 0.81147 +0.58267 Miyasaka Observatory
+367 133.1670 0.81504 +0.57747 Yatsuka
+368 138.8117 0.81213 +0.58191 Ochiai
+369 139.1500 0.8101  +0.5844  Chichibu
+370 133.5273 0.83424 +0.54956 Kochi
+371 133.5965 0.82433 +0.56431 Tokyo-Okayama
+372 133.8276 0.83450 +0.54920 Geisei
+373 135.3397 0.82866 +0.55797 Oishi
+374 134.7196 0.81915 +0.57174 Minami-Oda Observatory
+375 134.8708 0.8206  +0.5697  Uzurano
+376 139.0392 0.81321 +0.58022 Uenohara
+377 135.7933 0.82014 +0.57031 Kwasan Observatory, Kyoto
+378 136.0142 0.82437 +0.56426 Murou
+379 137.6279 0.82300 +0.56613 Hamamatsu-Yuto
+380 137.0349 0.82190 +0.56772 Ishiki
+381 137.625420.812172+0.581777Tokyo-Kiso
+382 137.5553 0.80915 +0.58639 Tokyo-Norikura
+383 137.8959 0.80218 +0.59526 Chirorin
+384 138.1792 0.8219  +0.5678  Shimada
+385 138.4680 0.82039 +0.56997 Nihondaira Observatory
+386 138.3217 0.81121 +0.58309 Yatsugatake-Kobuchizawa
+387 139.1944 0.81000 +0.58469 Tokyo-Dodaira
+388 139.5421 0.81330 +0.57991 Tokyo-Mitaka
+389 139.7447 0.81347 +0.57965 Tokyo (before 1938)
+390 139.8725 0.80425 +0.59234 Utsunomiya
+391 140.778430.786177+0.615960Sendai Observatory, Ayashi Station
+392 141.3667 0.73355 +0.67741 JCPM Sapporo Station
+393 140.1292 0.8090  +0.5858  JCPM Sakura Station
+394 142.3208 0.70692 +0.70493 JCPM Hamatonbetsu Station
+395 142.3583 0.7224  +0.6891  Tokyo-Asahikawa
+396 142.4208 0.7236  +0.6879  Asahikawa
+397 141.4761 0.73210 +0.67892 Sapporo Science Center
+398 139.1080 0.80870 +0.58630 Nagatoro
+399 144.5900 0.73158 +0.67950 Kushiro
+400 143.7827 0.72344 +0.68811 Kitami
+401 139.4208 0.8088  +0.5861  Oosato
+402 136.3078 0.81800 +0.57335 Dynic Astronomical Observatory
+403 137.0556 0.81593 +0.57625 Kani
+404 140.9292 0.7909  +0.6099  Yamamoto
+405 139.3292 0.8069  +0.5887  Kamihoriguchi
+406 141.8233 0.72946 +0.68174 Bibai
+407 140.3099 0.78426 +0.61837 Kahoku
+408 138.1747 0.81121 +0.58328 Nyukasa
+409 139.5211 0.81234 +0.58124 Kiyose and Mizuho
+410 134.8910 0.81883 +0.57222 Sengamine
+411 139.4170 0.80739 +0.58805 Oizumi
+412 140.5991 0.80011 +0.59803 Iwaki
+413 149.066080.855595-0.516262Siding Spring Observatory
+414 149.0077 0.81694 -0.57499 Mount Stromlo
+415 149.0636 0.81615 -0.57606 Kambah
+416 149.1336 0.81701 -0.57485 Barton
+417 137.1371 0.79611 +0.60317 Yanagida Astronomical Observatory
+418 150.940340.857259-0.513294Tamworth
+419 150.8329 0.83370 -0.55038 Windsor
+420 151.2050 0.83126 -0.55404 Sydney
+421 133.7650 0.83244 +0.55262 Mt. Kajigamori, Otoyo
+422 151.0461 0.85503 -0.51709 Loomberah
+423 151.124730.831807-0.553222North Ryde
+424 149.0658 0.81758 -0.57405 Macquarie
+425 152.9316 0.88796 -0.45843 Taylor Range Observatory, Brisbane
+426 136.8217 0.85618 -0.51498 Woomera
+427 138.7283 0.82667 -0.56084 Stockport
+428 153.3970 0.88271 -0.46837 Reedy Creek
+429 149.0400 0.81761 -0.57402 Hawker
+430 149.2123 0.85550 -0.51623 Rainbow Observatory, near Coonabarabran
+431 149.7578 0.83548 -0.54793 Mt. Tarana Observatory, Bathurst
+432 153.082220.863790-0.502166Boambee
+433 152.1078 0.84197 -0.53771 Bagnall Beach Observatory
+434  10.9206 0.70765 +0.70419 S. Benedetto Po
+435  11.8936 0.70330 +0.70852 G. Colombo Astronomical Observatory, Padua
+436  11.3356 0.71658 +0.69528 Osservatorio di Livergnano
+437 284.6971 0.76700 +0.63953 Haverford
+438 287.3621 0.74059 +0.66978 Smith College Observatory, Northampton
+439 253.2539 0.81156 +0.58288 ROTSE-III, Los Alamos
+440 278.6842 0.73025 +0.68097 Elginfield Observatory
+441 357.1697 0.55559 +0.82867 Swilken Brae, St. Andrews
+442 357.4822 0.7477  +0.6619  Gualba Observatory
+443 301.4656 0.82370 -0.56513 Obs. Astronomico Plomer, Buenos Aires
+444 243.2794 0.83507 +0.54868 Star Cruiser Observatory
+445 359.4200 0.7802  +0.6235  Observatorio d'Ontinyent
+446 262.1666 0.87049 +0.49058 Kingsnake Observatory, Seguin
+447 255.2056 0.77154 +0.63448 Centennial Observatory
+448 253.2801 0.84543 +0.53268 Desert Moon Observatory, Las Cruces
+449 279.6503 0.82617 +0.56156 Griffin Hunter Observatory, Bethune
+450 279.3339 0.81857 +0.57254 Carla Jane Observatory, Charlotte
+451 262.7569 0.79447 +0.60536 West Skies Observatory, Mulvane
+452 279.1063 0.8980  +0.4385  Big Cypress Observatory, Fort Lauderdale
+453 242.1331 0.82030 +0.57021 Edwards Raven Observatory
+454 283.376780.774542+0.630425Maryland Space Grant Consortium Observatory
+455 237.9636 0.78912 +0.61218 CBA Concord
+456 358.8278 0.61348 +0.78709 Daventry Observatory
+457  18.3403 0.66221 +0.74685 Partizanske
+458 355.9806 0.75992 +0.64805 Guadarrama Observatory
+459 288.1172 0.72607 +0.68538 Smith River Observatory, Danbury
+460 265.9981 0.83010 +0.55579 Area 52 Observatory, Nashville
+461  19.893670.671543+0.738689University of Szeged, Piszkesteto Stn. (Konkoly)
+462 283.0842 0.77905 +0.62488 Mount Belleview Observatory
+463 254.7375 0.76726 +0.63959 Sommers-Bausch Observatory, Boulder
+464 288.5013 0.75109 +0.65799 Toby Point Observatory, Narragansett
+465 174.7801 0.80166 -0.59578 Takapuna
+466 174.8487 0.8002  -0.5977  Mount Molehill Observatory, Auckland
+467 174.7766 0.80058 -0.59724 Auckland Observatory
+468  13.3296 0.74652 +0.66349 Astronomical Observatory, Campo Catino
+469   7.3820 0.67873 +0.73205 Courroux
+470  13.327560.749268+0.660088Ceccano
+471   8.2389 0.56364 +0.82325 Houstrup
+472   6.3203 0.71225 +0.69998 Merlette
+473  13.316610.694793+0.716822Remanzacco
+474 170.464960.720773-0.691079Mount John Observatory, Lake Tekapo
+475   7.6965 0.70747 +0.70443 Turin (before 1913)
+476   7.140740.706597+0.705359Grange Observatory, Bussoleno
+477   0.4856 0.62103 +0.78117 Galleywood
+478   3.0896 0.72548 +0.68597 Lamalou-les-Bains
+479   6.0505 0.73020 +0.68096 Sollies-Pont
+480   0.7733 0.61466 +0.78616 Cockfield
+481   7.930670.595365+0.800771Moorwarfen
+482 357.1854 0.55560 +0.82866 St. Andrews
+483 173.8036 0.74734 -0.66254 Carter Observatory, Black Birch Station
+484 174.7594 0.75191 -0.65706 Happy Valley, Wellington
+485 174.7654 0.75256 -0.65635 Carter Observatory, Wellington
+486 175.47   0.765   -0.643   Palmerston North
+487 355.4444 0.56858 +0.81989 Macnairston Observatory
+488 358.3664 0.57486 +0.81553 Newcastle-upon-Tyne
+489 359.87   0.612   +0.788   Hemingford Abbots
+490 358.00   0.633   +0.772   Wimborne Minster
+491 356.9000 0.76131 +0.64644 Centro Astronomico de Yebes
+492 358.47   0.605   +0.795   Mickleover
+493 357.4542 0.79753 +0.60182 Calar Alto
+494 357.8361 0.61126 +0.78879 Stakenbridge
+495 357.662470.597857+0.798936Altrincham
+496 358.6860 0.6311  +0.7731  Bishopstoke
+497 359.294490.622323+0.780160Loudwater
+498 359.2581 0.61334 +0.78718 Earls Barton
+499 359.790780.625578+0.777562Cheam
+500   0.000000.000000 0.000000Geocentric
+501   0.3475 0.63237 +0.77208 Herstmonceux
+502   0.847930.618111+0.783475Colchester
+503   0.0948 0.61400 +0.78667 Cambridge
+504   4.3944 0.68553 +0.72570 Le Creusot
+505   4.5639 0.6229  +0.7797  Simon Stevin
+506   9.96   0.598   +0.797   Bendestorf
+507   5.22   0.617   +0.783   Nyenheim
+508   5.29   0.617   +0.783   Zeist
+509   5.8725 0.73132 +0.67976 La Seyne sur Mer
+510   8.0256 0.63185 +0.77257 Siegen
+511   5.7157 0.72140 +0.69034 Haute Provence
+512   4.4893 0.61477 +0.78606 Leiden (before 1860)
+513   4.7855 0.69971 +0.71209 Lyons
+514   8.438  0.6513  +0.7563  Mundenheim (1907-1913)
+515   7.4956 0.64656 +0.76038 Volkssternwarte Dhaun, near Kirn
+516   9.973210.595399+0.800741Hamburg (before 1909)
+517   6.1358 0.69201 +0.71957 Geneva (from 1967)
+518   9.9727 0.59545 +0.80071 Marine Observatory, Hamburg
+519   8.2867 0.62598 +0.77729 Meschede
+520   7.0966 0.63427 +0.77053 Bonn
+521  10.887940.645624+0.761154Remeis Observatory, Bamberg
+522   7.7677 0.66279 +0.74633 Strasbourg
+523   8.6512 0.64251 +0.76374 Frankfurt
+524   8.4605 0.6509  +0.7566  Mannheim
+525   8.769170.633171+0.771473Marburg
+526  10.1477 0.58426 +0.80886 Kiel
+527   9.9431 0.5955  +0.8007  Altona
+528   9.9426 0.62340 +0.77931 Gottingen
+529  10.7229 0.50259 +0.86163 Christiania
+530  10.6898 0.5911  +0.8039  Lubeck
+531  12.4797 0.74545 +0.66434 Collegio Romano, Rome
+532  11.6084 0.66853 +0.74130 Munich
+533  11.8715 0.70335 +0.70847 Padua
+534  12.3913 0.62606 +0.77719 Leipzig (since 1861)
+535  13.3578 0.78782 +0.61386 Palermo
+536  13.1062 0.61135 +0.78873 Berlin-Babelsberg
+537  13.3642 0.6097  +0.7900  Urania Observatory, Berlin
+538  13.8461 0.70998 +0.70187 Pola
+539  14.1316 0.66968 +0.74024 Kremsmunster
+540  14.2753 0.66470 +0.74477 Linz
+541  14.3953 0.64306 +0.76331 Prague
+542  13.0374 0.6091  +0.7904  Falkensee
+543  12.3688 0.6260  +0.7772  Leipzig (before 1861)
+544  13.351310.610644+0.789263Wilhelm Foerster Observatory, Berlin
+545  16.3817 0.66767 +0.74200 Vienna (before 1879)
+546  16.3549 0.66760 +0.74207 Oppolzer Observatory, Vienna
+547  17.0363 0.62904 +0.77479 Breslau
+548  13.3950 0.60999 +0.78976 Berlin (1835-1913)
+549  17.6257 0.50341 +0.86116 Uppsala
+550  11.4196 0.5943  +0.8015  Schwerin
+551  18.1895 0.67201 +0.73808 Hurbanovo, formerly O'Gyalla
+552  11.3418 0.71485 +0.69700 Osservatorio S. Vittore, Bologna
+553  18.9938 0.64002 +0.76574 Chorzow
+554   8.3959 0.63684 +0.76845 Burgsolms Observatory, Wetzlar
+555  19.8263 0.64336 +0.76306 Cracow-Fort Skala
+556  11.26   0.675   +0.734   Reintal, near Munich
+557  14.779610.645250+0.761529Ondrejov
+558  21.0303 0.61396 +0.78672 Warsaw
+559  14.98   0.793   +0.607   Serra La Nave
+560  10.931000.703262+0.708561Madonna di Dossobuono
+561  19.893670.671543+0.738689Piszkesteto Stn. (Konkoly)
+562  15.9236 0.66938 +0.74062 Figl Observatory, Vienna
+563  13.60   0.671   +0.739   Seewalchen
+564  11.19   0.671   +0.741   Herrsching
+565  10.1344 0.70437 +0.70746 Bassano Bresciano
+566 203.7424 0.93623 +0.35156 Haleakala-NEAT/GEODSS
+567  12.7117 0.69783 +0.71387 Chions
+568 204.5278 0.94171 +0.33725 Maunakea
+569  24.9587 0.49891 +0.86375 Helsinki
+570  25.2990 0.5794  +0.8123  Vilnius (since 1939)
+571  10.63   0.704   +0.708   Cavriana
+572   6.89   0.631   +0.772   Cologne
+573   9.6612 0.6145  +0.7862  Eldagsen
+574  10.2667 0.70463 +0.70721 Gottolengo
+575   6.808  0.68219 +0.72894 La Chaux de Fonds
+576   0.3760 0.63067 +0.77346 Burwash
+577   7.50   0.678   +0.734   Metzerlen Observatory
+578  27.99   0.898   -0.439   Linden Observatory
+579   8.85   0.711   +0.701   Novi Ligure
+580  15.4936 0.68242 +0.72862 Graz
+581  22.80   0.830   -0.556   Sedgefield
+582   1.2408 0.61682 +0.78447 Orwell Park
+583  30.2717 0.69087 +0.72056 Odesa-Mayaky
+584  30.2946 0.50213 +0.86189 Leningrad
+585  30.524620.640067+0.765748Kyiv comet station
+586   0.1423 0.73358 +0.67799 Pic du Midi
+587   9.229180.697459+0.714479Sormano
+588  11.25   0.715   +0.697   Eremo di Tizzano
+589  12.643690.738223+0.672386Santa Lucia Stroncone
+590   7.46   0.678   +0.734   Metzerlen
+591   9.6258 0.60995 +0.78979 Resse Observatory
+592   7.021140.628245+0.775437Solingen
+593  11.17   0.739   +0.671   Monte Argentario
+594  13.2033 0.74497 +0.66529 Monte Autore
+595  13.525780.696925+0.714749Farra d'Isonzo
+596  12.6183 0.74446 +0.66545 Colleverde di Guidonia
+597   9.6631 0.61461 +0.78621 Springe
+598  11.334090.717444+0.694448Loiano
+599  13.557640.739311+0.671604Campo Imperatore-CINEOS
+600  11.4708 0.71618 +0.69564 TLC Observatory, Bologna
+601  13.7281 0.63009 +0.77394 Engelhardt Observatory, Dresden
+602  16.3854 0.66764 +0.74203 Urania Observatory, Vienna
+603  10.1300 0.58622 +0.80745 Bothkamp
+604  13.475240.610235+0.789572Archenhold Sternwarte, Berlin-Treptow
+605   7.1130 0.62142 +0.78086 Marl
+606   9.9956 0.59353 +0.80212 Norderstedt
+607   8.0000 0.6277  +0.7760  Hagen Observatory, Ronkhausen
+608 203.7420 0.93623 +0.35156 Haleakala-AMOS
+609  12.8533 0.73772 +0.67314 Osservatorio Polino
+610  11.3431 0.71577 +0.69604 Pianoro
+611   8.6531 0.64877 +0.75848 Starkenburg Sternwarte, Heppenheim
+612   7.10   0.625   +0.778   Lenkerbeck
+613   7.0709 0.62504 +0.77800 Heisingen
+614   2.467  0.6621  +0.7469  Soisy-sur-Seine
+615   6.9067 0.71233 +0.70014 St. Veran
+616  16.583480.654655+0.753466Brno
+617   2.5725 0.66496 +0.74437 Arbonne la Foret
+618   5.0077 0.72750 +0.68382 Martigues
+619   2.090130.749506+0.659828Sabadell
+620   2.9517 0.77110 +0.63463 Observatorio Astronomico de Mallorca
+621   7.485030.629461+0.774501Bergisch Gladbach
+622   7.5680 0.68778 +0.72358 Oberwichtrach
+623   5.5667 0.63577 +0.76932 Liege
+624   9.6167 0.64723 +0.75977 Dertingen
+625 203.5683 0.93557 +0.35201 Kihei-AMOS Remote Maui Experimental Site
+626   4.9864 0.62847 +0.77524 Geel
+627   5.2146 0.72002 +0.69168 Blauvac
+628   6.843660.624789+0.778184Mulheim-Ruhr
+629  20.1511 0.69273 +0.71880 Szeged Observatory
+630   7.2367 0.67051 +0.73951 Osenbach
+631  10.022930.595992+0.800307Hamburg-Georgswerder
+632  11.1739 0.72380 +0.68773 San Polo A Mosciano
+633   9.9339 0.71930 +0.69238 Romito
+634   5.1456 0.70182 +0.71007 Crolles
+635   2.9019 0.73605 +0.67467 Pergignan
+636   6.9794 0.62524 +0.77783 Essen
+637  10.0903 0.59326 +0.80232 Hamburg-Himmelsmoor
+638   8.8933 0.61778 +0.78374 Detmold
+639  13.7233 0.62933 +0.77456 Dresden
+640  13.5996 0.6429  +0.7634  Senftenberger Sternwarte
+641  20.0272 0.82468 -0.56374 Overberg
+642 236.6850 0.6648  +0.7445  Oak Bay, Victoria
+643 243.2794 0.83507 +0.54868 OCA-Anza Observatory
+644 243.140220.836325+0.546877Palomar Mountain/NEAT
+645 254.179420.841945+0.538563Apache Point-Sloan Digital Sky Survey
+646 242.4369 0.82999 +0.55603 Santana Observatory, Rancho Cucamonga
+647 245.9683 0.6337  +0.7712  Stone Finder Observatory, Calgary
+648 249.398220.852115+0.522053Winer Observatory, Sonoita
+649 265.3003 0.78207 +0.62117 Powell Observatory, Louisburg
+650 242.9028 0.83510 +0.54836 Temecula
+651 249.419160.852069+0.522123Grasslands Observatory, Tucson
+652 245.9333 0.6291  +0.7749  Rock Finder Observatory, Calgary
+653 237.8678 0.68091 +0.72996 Torus Observatory, Buckley
+654 242.318410.826471+0.561727Table Mountain Observatory, Wrightwood-PHMC
+655 236.383  0.6656  +0.7438  Sooke
+656 236.3921 0.66580 +0.74367 Victoria
+657 236.6903 0.66437 +0.74491 Climenhaga Observatory, Victoria
+658 236.583000.663631+0.745601Dominion Astrophysical Observatory
+659 237.0514 0.66257 +0.74650 Heron Cove Observatory, Orcas
+660 237.7379 0.79038 +0.61059 Leuschner Observatory, Berkeley
+661 245.7117 0.63251 +0.77222 Rothney Astrophysical Observatory, Priddis
+662 238.3545 0.79619 +0.60335 Lick Observatory, Mount Hamilton
+663 248.3136 0.83483 +0.54879 Red Mountain Observatory
+664 239.2775 0.6840  +0.7273  Manastash Ridge Observatory
+665 240.9903 0.82215 +0.56781 Wallis Observatory
+666 241.1692 0.8270  +0.5604  Moorpark College Observatory
+667 240.009210.684483+0.726626Wanapum Dam
+668 240.82   0.821   +0.568   San Emigdio Peak
+669 240.8238 0.82540 +0.56279 Ojai
+670 240.9558 0.82775 +0.55922 Camarillo
+671 242.001980.827184+0.560523Stony Ridge
+672 241.9436 0.82794 +0.55942 Mount Wilson
+673 242.317830.826474+0.561722Table Mountain Observatory, Wrightwood
+674 242.336050.826464+0.561730Ford Observatory, Wrightwood
+675 243.137460.836357+0.546831Palomar Mountain
+676 242.3907 0.83553 +0.54762 San Clemente
+677 242.8281 0.82746 +0.56012 Lake Arrowhead
+678 248.2597 0.83352 +0.55083 Fountain Hills
+679 244.5367 0.85792 +0.51292 San Pedro Martir
+680 244.78   0.833   +0.554   Los Angeles
+681 245.8858 0.62954 +0.77459 Calgary
+682 247.6381 0.79932 +0.59932 Kanab
+683 248.9182 0.84751 +0.52922 Goodricke-Pigott Observatory, Tucson
+684 247.5100 0.82512 +0.56356 Prescott
+685 247.84   0.816   +0.575   Williams
+686 249.2092 0.84512 +0.53359 U. of Minn. Infrared Obs., Mt. Lemmon
+687 248.3473 0.81848 +0.57318 Northern Arizona University, Flagstaff
+688 248.4645 0.81938 +0.57193 Lowell Observatory, Anderson Mesa Station
+689 248.2601 0.81851 +0.57319 U.S. Naval Observatory, Flagstaff
+690 248.3367 0.81832 +0.57344 Lowell Observatory, Flagstaff
+691 248.399660.849466+0.526479Steward Observatory, Kitt Peak-Spacewatch
+692 249.0513 0.84679 +0.53036 Steward Observatory, Tucson
+693 249.267450.845313+0.533209Catalina Station, Tucson
+694 248.9943 0.84700 +0.53009 Tumamoc Hill, Tucson
+695 248.405330.849504+0.526425Kitt Peak
+696 249.1154 0.85205 +0.52249 Whipple Observatory, Mt. Hopkins
+697 248.383810.849546+0.526308Kitt Peak, McGraw-Hill
+698 249.267360.845316+0.533212Mt. Bigelow
+699 248.463310.819380+0.571930Lowell Observatory-LONEOS
+700 250.3817 0.80656 +0.58960 Chinle
+701 249.797160.853823+0.519224Junk Bond Observatory, Sierra Vista
+702 252.8117 0.8305  +0.5561  Joint Obs. for cometary research, Socorro
+703 249.267360.845311+0.533211Catalina Sky Survey
+704 253.340930.831869+0.553542Lincoln Laboratory ETS, New Mexico
+705 254.179420.841945+0.538563Apache Point
+706 253.9366 0.78294 +0.62043 Salida
+707 254.56   0.774   +0.633   Chamberlin field station
+708 255.0475 0.77092 +0.63520 Chamberlin Observatory, Denver
+709 254.228820.840250+0.541096W & B Observatory, Cloudcroft
+710 254.7336 0.77980 +0.62458 MPO Observatory, Florissant
+711 255.9785 0.86114 +0.50731 McDonald Observatory, Fort Davis
+712 255.118670.778365+0.626250USAF Academy Observatory, Colorado Springs
+713 254.9897 0.76865 +0.63793 Thornton
+714 246.8173 0.82444 +0.56439 Bagdad
+715 253.2759 0.84546 +0.53264 Jornada Observatory, Las Cruces
+716 255.2489 0.77753 +0.62731 Palmer Divide Observatory, Colorado Springs
+717 256.0481 0.86160 +0.50636 Prude Ranch
+718 247.7042 0.76004 +0.64802 Tooele
+719 253.086080.829384+0.557204Etscorn Observatory
+720 259.6261 0.90216 +0.43018 Universidad de Monterrey
+721 259.7312 0.76271 +0.64476 Lime Creek
+722 264.4192 0.87017 +0.49110 Missouri City
+723 263.3300 0.82134 +0.56861 Cottonwood Observatory, Ada
+724 260.8053 0.94388 +0.33026 National Observatory, Tacubaya
+725 261.3453 0.86883 +0.49358 Fair Oaks Ranch
+726 265.6933 0.69024 +0.72120 Brainerd
+727 262.538720.813941+0.579096Zeno Observatory, Edmond
+728 262.6084 0.88610 +0.46194 Corpus Christi
+729 262.878580.648804+0.758451Glenlea Astronomical Observatory, Winnipeg
+730 262.841430.671544+0.738537University of North Dakota, Grand Forks
+731 272.6711 0.77290 +0.63244 Rose-Hulman Observatory, Terre Haute
+732 263.2300 0.95591 +0.29359 Oaxaca
+733 263.3546 0.83802 +0.54387 Allen, Texas
+734 263.997580.779425+0.624489Farpoint Observatory, Eskridge
+735 264.406400.872133+0.487634George Observatory, Needville
+736 263.3357 0.87006 +0.49132 Houston
+737 275.6633 0.8282  +0.5586  New Bullpen Observatory, Alpharetta
+738 267.6733 0.7788  +0.6252  Observatory of the State University of Missouri
+739 265.2440 0.77965 +0.62419 Sunflower Observatory, Olathe
+740 265.3383 0.8511  +0.5233  SFA Observatory, Nacogdoches
+741 266.8503 0.71493 +0.69692 Goodsell Observatory, Northfield
+742 266.312160.748989+0.660428Drake University, Des Moines
+743 267.761480.708545+0.703382University of Minnesota, Minneapolis
+744 273.8378 0.76884 +0.63735 Doyan Rose Observatory, Indianapolis
+745 267.1747 0.77569 +0.62906 Morrison Obervatory, Glasgow
+746 275.2254 0.72551 +0.68597 Brooks Observatory, Mt. Pleasant
+747 268.9292 0.86373 +0.50227 Highland Road Park Observatory
+748 268.4680 0.75014 +0.65912 Van Allen Observatory, Iowa City
+749 276.1642 0.82795 +0.55902 Oakwood
+750 268.7282 0.71059 +0.70131 Hobbs Observatory, Fall Creek
+751 269.2439 0.78038 +0.62324 Lake Saint Louis
+752 275.4647 0.82278 +0.56659 Puckett Observatory, Mountain Town
+753 270.590690.731622+0.679491Washburn Observatory, Madison
+754 271.4432 0.73762 +0.67303 Yerkes Observatory, Williams Bay
+755 274.6478 0.73353 +0.67743 Optec Observatory
+756 272.325670.743605+0.666407Dearborn Observatory, Evanston (bef. July 1939)
+757 280.0050 0.8096  +0.5851  High Point
+758 279.2379 0.88044 +0.47257 BCC Observatory, Cocoa
+759 273.1947 0.80946 +0.58530 Nashville
+760 273.6048 0.77216 +0.63337 Goethe Link Observatory, Brooklyn
+761 277.6456 0.88138 +0.47083 Zephyrhills
+762 274.2008 0.70885 +0.70304 Four Winds Observatory, Lake Leelanau
+763 280.4658 0.72157 +0.69009 King City
+764 275.1439 0.83264 +0.55205 Puckett Observatory, Stone Mountain
+765 275.5775 0.77669 +0.62784 Cincinnati
+766 275.5167 0.73600 +0.67477 Michigan State University Obs., East Lansing
+767 276.2697 0.74102 +0.66930 Ann Arbor
+768 272.324880.743585+0.666430Dearborn Observatory, Evanston (aft. Oct. 1939)
+769 276.9892 0.76716 +0.63936 McMillin Observatory, Columbus
+770 274.0786 0.77573 +0.62900 Crescent Moon Observatory, Columbus
+771 277.57   0.922   +0.389   Boyeros Observatory, Havana
+772 284.0865 0.70517 +0.70669 Boltwood Observatory, Stittsville
+773 278.4318 0.74966 +0.65966 Warner and Swasey Observatory, Cleveland
+774 278.9250 0.74905 +0.66039 Warner and Swasey Nassau Station, Chardon
+775 284.6168 0.76029 +0.64743 Sayre Observatory, South Bethlehem
+776 284.4669 0.73472 +0.67619 Foggy Bottom, Hamilton
+777 280.6017 0.72454 +0.68695 Toronto
+778 279.9778 0.76172 +0.64582 Allegheny Observatory, Pittsburgh
+779 280.5779 0.72219 +0.68943 David Dunlap Observatory, Richmond Hill
+780 281.4778 0.78868 +0.61280 Leander McCormick Observatory, Charlottesville
+781 281.5075 1.00045 -0.00405 Quito
+782 281.65   0.999   +0.000   Quito, comet astrograph station
+783 282.02   0.783   +0.622   Rixeyville
+784 282.2146 0.74140 +0.66895 Stull Observatory, Alfred University
+785 285.3542 0.76323 +0.64397 Fitz-Randolph Observatory, Princeton
+786 282.9345 0.77906 +0.62487 U.S. Naval Obs., Washington (since 1893)
+787 282.9494 0.77934 +0.62451 U.S. Naval Obs., Washington (before 1893)
+788 284.3667 0.76953 +0.63650 Mount Cuba Observatory, Wilmington
+789 284.5940 0.73188 +0.67922 Litchfield Observatory, Clinton
+790 284.2835 0.70343 +0.70840 Dominion Observatory, Ottawa
+791 284.5236 0.76713 +0.63937 Flower and Cook Observatory, Philadelphia
+792 288.299050.751746+0.657236University of Rhode Island, Quonochontaug
+793 286.2515 0.7365  +0.6742  Dudley Observatory, Albany (before 1893)
+794 286.1100 0.74789 +0.66161 Vassar College Observatory, Poughkeepsie
+795 286.038610.757969+0.650106Rutherford
+796 286.45   0.755   +0.654   Stamford
+797 287.0751 0.75218 +0.65676 Yale Observatory, New Haven
+798 287.0154 0.75093 +0.65822 Yale Observatory, Bethany
+799 288.8650 0.73896 +0.67150 Winchester
+800 288.4511 0.96006 -0.28021 Harvard Observatory, Arequipa
+801 288.442330.738364+0.672183Oak Ridge Observatory
+802 288.871640.739802+0.670574Harvard Observatory, Cambridge
+803 288.9167 0.74543 +0.66436 Taunton
+804 289.3121 0.83421 -0.54976 Santiago-San Bernardo
+805 288.9800 0.83997 -0.54145 Santiago-Cerro El Roble
+806 289.4513 0.83584 -0.54738 Santiago-Cerro Calan
+807 289.1941 0.86560 -0.49980 Cerro Tololo Observatory, La Serena
+808 290.6708 0.85098 -0.52414 El Leoncito
+809 289.266260.873440-0.486052European Southern Observatory, La Silla
+810 288.5154 0.73712 +0.67352 Wallace Observatory, Westford
+811 289.895650.752586+0.656289Maria Mitchell Observatory, Nantucket
+812 288.4543 0.83992 -0.54093 Vina del Mar
+813 289.3083 0.83533 -0.54805 Santiago-Quinta Normal (1862-1920)
+814 288.419170.746007+0.663734North Scituate
+815 289.3479 0.83539 -0.54799 Santiago-Santa Lucia (1849-1861)
+816 285.7583 0.71645 +0.69542 Rand Observatory
+817 288.6104 0.74018 +0.67017 Sudbury
+818 286.4167 0.7040  +0.7079  Gemeaux Observatory, Laval
+819 284.3850 0.69720 +0.71451 Val-des-Bois
+820 295.375810.930491-0.365872Tarija
+821 295.450410.852688-0.521032Cordoba-Bosque Alegre
+822 295.801370.854203-0.518325Cordoba
+823 288.1691 0.73715 +0.67354 Fitchburg
+824 285.7528 0.71641 +0.69546 Lake Clear
+825 288.2595 0.74033 +0.67003 Granville
+826 288.2282 0.69312 +0.71843 Plessissville
+827 287.5393 0.66190 +0.74710 Saint-Felicien
+828 288.9758 0.74656 +0.66310 Assonet
+829 290.6979 0.85102 -0.52411 Complejo Astronomico El Leoncito
+830 288.5697 0.73491 +0.67590 Hudson
+831 277.4134 0.87191 +0.48804 Rosemary Hill Observatory, University of Florida
+832 283.1850 0.7653  +0.6416  Etters
+833 301.4633 0.82373 -0.56508 Obs. Astronomico de Mercedes, Buenos Aires
+834 301.5654 0.82398 -0.56473 Buenos Aires-AAAA
+835 288.6428 0.73709 +0.67354 Drum Hill Station, Chelmsford
+836 288.5011 0.74708 +0.66252 Furnace Brook Observatory, Cranston
+837 279.7553 0.89228 +0.44996 Jupiter
+838 275.8628 0.77000 +0.63596 Dayton
+839 302.0678 0.82097 -0.56906 La Plata
+840 276.2833 0.73235 +0.67870 Flint
+841 279.442330.796229+0.603220Martin Observatory, Blacksburg
+842 282.7678 0.76901 +0.63713 Gettysburg College Observatory
+843 273.0648 0.82481 +0.56357 Emerald Lane Observatory, Decatur
+844 303.809820.822499-0.566884Observatorio Astronomico Los Molinos
+845 283.5058 0.73942 +0.67107 Ford Observatory, Ithaca
+846 269.655010.779842+0.623926Principia Astronomical Observatory, Elsah
+847 275.9750 0.7078  +0.7041  Lunar Cafe Observator, Flint
+848 237.0219 0.72412 +0.68741 Tenagra Observatory, Cottage Grove
+849 265.1694 0.77927 +0.62467 Everstar Observatory, Olathe
+850 274.0802 0.81810 +0.57333 Cordell-Lorenz Observatory, Sewanee
+851 296.419620.712830+0.698986Burke-Gaffney Observatory, Halifax
+852 269.4050 0.7805  +0.6231  River Moss Observatory, St. Peters
+853 249.1517 0.84365 +0.53544 Biosphere 2 Observatory
+854 249.179950.846183+0.531351Sabino Canyon Observatory, Tucson
+855 266.5383 0.7093  +0.7026  Wayside Observatory, Minnetonka
+856 242.5540 0.8300  +0.5560  Riverside
+857 249.3992 0.85213 +0.52204 Iowa Robotic Observatory, Sonoita
+858 253.7800 0.8194  +0.5719  Tebbutt Observatory, Edgewood
+859 316.3097 0.94132 -0.33707 Wykrota Observatory-CEAMIG
+860 313.0347 0.92108 -0.38842 Valinhos
+861 312.9204 0.92253 -0.38487 Barao Geraldo
+862 138.5262 0.80861 +0.58658 Saku
+863 137.18   0.807   +0.588   Furukawa
+864 130.7533 0.84257 +0.53680 Kumamoto
+865 285.8792 0.74765 +0.66189 Emmy Observatory, New Paltz
+866 283.5100 0.7784  +0.6257  U.S. Naval Academy, Michelson
+867 134.1222 0.81671 +0.57522 Saji Observatory
+868 135.1359 0.83066 +0.55492 Hidaka Observatory
+869 133.4298 0.83480 +0.54870 Tosa
+870 313.174110.921798-0.386786Campinas
+871 134.3925 0.82256 +0.56678 Akou
+872 134.2411 0.82904 +0.55734 Tokushima
+873 133.7717 0.82410 +0.56455 Kurashiki Observatory
+874 314.417350.924359-0.380986Observatorio do Pico dos Dias, Itajuba
+875 139.2353 0.80896 +0.58593 Yorii
+876 139.2467 0.80762 +0.58774 Honjo
+877 139.0828 0.81194 +0.58196 Okutama
+878 136.9142 0.82019 +0.57019 Kagiya
+879 137.3535 0.81970 +0.57099 Tokai
+880 316.7771 0.92169 -0.38664 Rio de Janeiro
+881 137.2571 0.81872 +0.57230 Toyota
+882 137.3558 0.81842 +0.57281 JCPM Oi Station
+883 138.4215 0.81986 +0.57065 Shizuoka
+884 138.0792 0.8187  +0.5724  Kawane
+885 138.4667 0.82049 +0.56975 JCPM Yakiimo Station
+886 138.9367 0.81836 +0.57280 Mishima
+887 139.3367 0.80745 +0.58798 Ojima
+888 138.9952 0.81885 +0.57217 Gekko
+889 140.1427 0.80322 +0.59372 Karasuyama
+890 140.2500 0.8108  +0.5834  JCPM Tone Station
+891 140.8633 0.78606 +0.61609 JCPM Kimachi Station
+892 139.4753 0.80852 +0.58650 YGCO Hoshikawa and Nagano Stations
+893 140.862220.786233+0.615870Sendai Municipal Observatory
+894 138.4476 0.81113 +0.58321 Kiyosato
+895 140.7203 0.78573 +0.61658 Hatamae
+896 138.3678 0.81132 +0.58292 Yatsugatake South Base Observatory
+897 139.4929 0.80797 +0.58725 YGCO Chiyoda Station
+898 138.1883 0.82107 +0.56899 Fujieda
+899 142.5500 0.7224  +0.6891  Toma
+900 135.989940.819572+0.571083Moriyama
+901 137.0877 0.81664 +0.57525 Tajimi
+902 132.2208 0.82775 +0.55922 Ootake
+903 135.174230.817354+0.574227Fukuchiyama and Kannabe
+904 135.12   0.824   +0.565   Go-Chome and Kobe-Suma
+905 135.9246 0.83368 +0.55040 Nachi-Katsuura Observatory
+906 145.667  0.8113  -0.5837  Cobram
+907 144.9758 0.79082 -0.61001 Melbourne
+908 137.2467 0.80352 +0.59330 Toyama
+909 237.8717 0.6711  +0.7389  Snohomish Hilltop Observatory
+910   6.9267 0.72368 +0.68811 Caussols-ODAS
+911 282.9233 0.7429  +0.6672  Collins Observatory, Corning Community College
+912 288.2342 0.74769 +0.66186 Carbuncle Hill Observatory, Greene
+913 303.8161 0.82093 -0.56912 Observatorio Kappa Crucis, Montevideo
+914 288.0108 0.73809 +0.67254 Underwood Observatory, Hubbardston
+915 261.8789 0.86861 +0.49393 River Oaks Observatory, New Braunfels
+916 272.6836 0.77287 +0.63248 Oakley Observatory, Terre Haute
+917 237.5522 0.68140 +0.72948 Pacific Lutheran University Keck Observatory
+918 257.8694 0.72071 +0.69110 Badlands Observatory, Quinn
+919 248.3183 0.8419  +0.5379  Desert Beaver Observatory
+920 282.3353 0.73161 +0.67947 RIT Observatory, Rochester
+921 254.4725 0.83988 +0.54159 SW Institute for Space Research, Cloudcroft
+922 272.8333 0.82335 +0.56569 Timberland Observatory, Decatur
+923 284.6300 0.76655 +0.64006 The Bradstreet Observatory, St. Davids
+924 287.6769 0.68988 +0.72150 Observatoire du Cegep de Trois-Rivieres
+925 249.8589 0.85450 +0.51811 Palominas Observatory
+926 249.1209 0.85394 +0.51902 Tenagra II Observatory, Nogales
+927 270.561940.735007+0.675850Madison-YRS
+928 286.6761 0.75688 +0.65136 Moonedge Observatory, Northport
+929 268.7758 0.86319 +0.50319 Port Allen
+930 210.412240.953752-0.299638S. S. Observatory, Pamatai
+931 210.3842 0.95330 -0.30100 Puna'auia
+932 286.574010.749767+0.659494John J. McCarthy Obs., New Milford
+933 249.7342 0.85383 +0.51924 Rockland Observatory, Sierra Vista
+934 242.9572 0.83985 +0.54108 Poway Valley
+935 282.3394 0.77977 +0.62400 Wyrick Observatory, Haymarket
+936 263.3792 0.77614 +0.62852 Ibis Observatory, Manhattan
+937 358.6900 0.58065 +0.81143 Bradbury Observatory, Stockton-on-Tees
+938 351.6162 0.77243 +0.63299 Linhaceira
+939 359.6033 0.76982 +0.63619 Observatorio Rodeno
+940 358.9611 0.63199 +0.77238 Waterlooville
+941 359.6139 0.76988 +0.63608 Observatorio Pla D'Arguines
+942 359.3636 0.60413 +0.79423 Grantham
+943 355.8664 0.63881 +0.76679 Peverell
+944 354.083150.796657+0.602418Observatorio Geminis, Dos Hermanas
+945 354.3986 0.72671 +0.68474 Observatorio Monte Deva
+946   0.7931 0.75662 +0.65170 Ametlla de Mar
+947   2.1244 0.65268 +0.75511 Saint-Sulpice
+948   0.2189 0.61048 +0.78937 Pymoor
+949 359.8169 0.67454 +0.73577 Durtal
+950 342.1176 0.87764 +0.47847 La Palma
+951 358.2983 0.62194 +0.78046 Highworth
+952 359.7583 0.7787  +0.6253  Marxuquera
+953   2.1339 0.74602 +0.66393 Montjoia
+954 343.4906 0.88148 +0.47142 Teide Observatory
+955 350.6739 0.78146 +0.62188 Sassoeiros
+956 356.1908 0.76224 +0.64530 Observatorio Pozuelo
+957 359.3506 0.71047 +0.70137 Merignac
+958 358.969470.724214+0.687282Observatoire de Dax
+959   1.4653 0.72596 +0.68548 Ramonville Saint Agne
+960   0.6108 0.63016 +0.77387 Rolvenden
+961 356.8206 0.56112 +0.82498 City Observatory, Calton Hill, Edinburgh
+962 359.8188 0.77845 +0.62561 Gandia
+963 359.7333 0.6084  +0.7909  Werrington
+964 358.8433 0.62471 +0.77826 Southend Bradfield
+965 351.4008 0.79761 +0.60118 Observacao Astronomica no Algarve, Portimao
+966 357.204230.609591+0.790100Church Stretton
+967 358.9778 0.61508 +0.78585 Greens Norton
+968   0.4250 0.6158  +0.7853  Haverhill
+969 359.8454 0.6235  +0.7792  London-Regents Park
+970   0.4954 0.62045 +0.78162 Chelmsford
+971 350.812490.781336+0.622040Lisbon
+972 357.5833 0.54359 +0.83656 Dun Echt
+973 359.6671 0.62271 +0.77983 Harrow
+974   8.844310.715243+0.696571Genoa Observatory
+975 359.6333 0.77292 +0.63239 Observatorio Astronomico de Valencia
+976 358.4669 0.61258 +0.78778 Leamington Spa
+977 351.5483 0.58660 +0.80717 Markree
+978 357.245410.588685+0.805673Conder Brow
+979 358.6697 0.62896 +0.77485 South Wonston
+980 357.2200 0.58864 +0.80570 Lancaster
+981 353.3522 0.58409 +0.80898 Armagh
+982 353.6621 0.59771 +0.79904 Dunsink Observatory, Dublin
+983 353.795250.805167+0.591067San Fernando
+984 357.269750.631671+0.772658Eastfield
+985 357.5317 0.60801 +0.79130 Telford
+986 359.360530.625049+0.777992Ascot
+987 355.3735 0.58658 +0.80721 Isle of Man Observatory, Foxdale
+988 355.7060 0.56225 +0.82421 Glasgow
+989 357.405820.591888+0.803341Wilfred Hall Observatory, Preston
+990 356.3121 0.76260 +0.64487 Madrid
+991 356.9278 0.59750 +0.79919 Liverpool (since 1867)
+992 356.9995 0.5973  +0.7993  Liverpool (before 1867)
+993 357.495560.629975+0.774031Woolston Observatory
+994 359.3878 0.62827 +0.77540 Godalming
+995 358.4177 0.57819 +0.81319 Durham
+996 358.7483 0.62025 +0.78179 Oxford
+997 359.15   0.619   +0.783   Hartwell
+998 359.757530.622254+0.780206London-Mill Hill
+999 359.4725 0.71033 +0.70153 Bordeaux-Floirac
+A00   0.3770 0.62475 +0.77821 Gravesend
+A01   0.7441 0.74414 +0.66596 Masia Cal Maciarol Modul 2
+A02   0.7441 0.74414 +0.66596 Masia Cal Maciarol Modul 8
+A03   1.4000 0.7541  +0.6546  Torredembarra
+A04   1.7181 0.72206 +0.68956 Saint-Caprais
+A05   1.8175 0.72721 +0.68417 Belesta
+A06   2.4417 0.74922 +0.66012 Mataro
+A07   2.7444 0.66070 +0.74815 Gretz-Armainvilliers
+A08   2.8847 0.72735 +0.68406 Malibert
+A09   1.1803 0.65037 +0.75711 Quincampoix
+A10   1.9281 0.75278 +0.65613 Observatorio Astronomico de Corbera
+A11   2.4718 0.63222 +0.77219 Wormhout
+A12   8.747680.703404+0.708434Stazione Astronomica di Sozzago
+A13   7.1394 0.68632 +0.72501 Observatoire Naef, Ependes
+A14   5.1864 0.72028 +0.69143 Les Engarouines Observatory
+A15   6.7972 0.61903 +0.78275 Josef Bresser Sternwarte, Borken
+A16   7.1922 0.68622 +0.72511 Tentlingen
+A17   8.681470.650133+0.757328Guidestar Observatory, Weinheim
+A18   7.1761 0.62342 +0.77928 Herne
+A19   7.0744 0.63164 +0.77267 Koln
+A20   7.518870.605274+0.793357Sogel
+A21   8.0581 0.63667 +0.76862 Irmtraut
+A22   8.6531 0.64877 +0.75848 Starkenburg Sternwarte-SOHAS
+A23   8.6677 0.65027 +0.75719 Weinheim
+A24   8.9481 0.69995 +0.71185 New Millennium Observatory, Mozzate
+A25   9.1925 0.70104 +0.71077 Nova Milanese
+A26   8.657360.646597+0.760303Darmstadt
+A27  10.3236 0.61823 +0.78341 Eridanus Observatory, Langelsheim
+A28  10.3342 0.67398 +0.73642 Kempten
+A29  10.6733 0.72369 +0.68782 Santa Maria a Monte
+A30  11.223080.700397+0.711555Crespadoro
+A31  11.4186 0.70024 +0.71155 Corcaroli Observatory
+A32  10.5517 0.58423 +0.80887 Panker
+A33  11.0157 0.63231 +0.77217 Volkssternwarte Kirchheim
+A34  10.7911 0.64944 +0.75793 Grosshabersdorf
+A35  12.8978 0.63511 +0.76995 Hormersdorf Observatory
+A36   9.7911 0.69856 +0.71340 Ganda di Aviatico
+A37  13.6634 0.61128 +0.78877 Mueggelheim
+A38  13.3747 0.74706 +0.66266 Campocatino Automated Telescope, Collepardo
+A39  12.4186 0.63084 +0.77336 Altenburg
+A40  14.4978 0.81104 +0.58306 Pieta
+A41  14.5911 0.69290 +0.71871 Rezman Observatory, Kamnik
+A42   9.5019 0.61280 +0.78760 Gehrden
+A43  13.0897 0.61201 +0.78821 Inastars Observatory, Potsdam (before 2006)
+A44  13.6972 0.66609 +0.74346 Altschwendt
+A45   9.3620 0.62525 +0.77786 Karrenkneul
+A46  16.5825 0.65349 +0.75447 Lelekovice
+A47  16.6031 0.75962 +0.64829 Matera
+A48  10.8885 0.70401 +0.70782 Povegliano Veronese
+A49  17.6372 0.50372 +0.86098 Uppsala-Angstrom
+A50  28.9973 0.64407 +0.76245 Andrushivka Astronomical Observatory
+A51  18.6667 0.5837  +0.8093  Danzig
+A52  18.7553 0.67756 +0.73304 Etyek
+A53  10.6883 0.70294 +0.70889 Peschiera del Garda
+A54  16.6217 0.60828 +0.79108 Ostrorog
+A55  13.1181 0.73871 +0.67204 Osservatorio Astronomico Vallemare di Borbona
+A56  10.3197 0.71406 +0.69784 Parma
+A57  11.1031 0.72364 +0.68791 Osservatorio Astron. Margherita Hack, Firenze
+A58   2.4694 0.66135 +0.74758 Observatoire de Chalandray-Canotiers
+A59  12.9071 0.64123 +0.76490 Karlovy Vary Observatory
+A60  20.8106 0.84556 -0.53260 YSTAR-NEOPAT Station, Sutherland
+A61   8.8581 0.70949 +0.70238 Tortona
+A62   9.2301 0.66233 +0.74678 Aichtal
+A63   4.7567 0.69879 +0.71298 Cosmosoz Obs., Tassin la Demi Lune
+A64   6.1151 0.69034 +0.72132 Couvaloup de St-Cergue
+A65   2.4083 0.71939 +0.69239 Le Couvent de Lentin
+A66  10.3161 0.72613 +0.68526 Stazione Osservativa Astronomica, Livorno
+A67   7.6785 0.71665 +0.69522 Chiusa di Pesio
+A68   9.6533 0.57755 +0.81362 Swedenborg Obs., Bockholmwik
+A69  11.3300 0.7287  +0.6826  Osservatorio Palazzo Bindi Sergardi
+A70  25.2033 0.42654 +0.90144 Lumijoki
+A71  15.4533 0.66486 +0.74459 Stixendorf
+A72  13.6222 0.62904 +0.77481 Radebeul Observatory
+A73  16.2895 0.66788 +0.74183 Penzing Astrometric Obs., Vienna
+A74   8.762400.641951+0.764216Bergen-Enkheim Observatory
+A75   2.1861 0.75124 +0.65783 Fort Pius Observatory, Barcelona
+A76  20.8356 0.66948 +0.74037 Andromeda Observatory, Miskolc
+A77   5.646930.720583+0.691196Observatoire Chante-Perdrix, Dauban
+A78  11.715090.730944+0.680264Stia
+A79  23.843400.743686+0.666622Zvezdno Obshtestvo Observatory, Plana
+A80  14.1222 0.61408 +0.78662 Lindenberg Observatory
+A81  12.4033 0.74578 +0.66397 Balzaretto Observatory, Rome
+A82  13.8744 0.70037 +0.71148 Osservatorio Astronomico di Trieste
+A83  29.9969 0.45945 +0.88525 Jakokoski Observatory
+A84  30.3333 0.80175 +0.59632 TUBITAK National Observatory
+A85  30.8065 0.68881 +0.72252 Odesa  Astronomical Observatory, Kryzhanovka
+A86   4.3547 0.70170 +0.71021 Albigneux
+A87   8.7662 0.64935 +0.75798 Rimbach
+A88   8.901330.714961+0.696835Bolzaneto
+A89  10.3308 0.67421 +0.73621 Sterni Observatory, Kempten
+A90   2.1431 0.75120 +0.65788 Sant Gervasi Observatory, Barcelona
+A91  26.5997 0.46678 +0.88143 Hankasalmi Observatory
+A92  26.0927 0.71506 +0.69673 Urseanu Observatory, Bucharest
+A93  10.4189 0.72222 +0.68935 Lucca
+A94  13.4577 0.69641 +0.71526 Cormons
+A95  28.3892 0.46584 +0.88193 Taurus Hill Observatory, Varkaus
+A96  16.2867 0.66656 +0.74303 Klosterneuburg
+A97  16.4219 0.66646 +0.74308 Stammersdorf
+A98  30.2092 0.58214 +0.81040 Observatory Mazzarot-1, Baran'
+A99  10.8589 0.69978 +0.71223 Osservatorio del Monte Baldo
+B00   2.5767 0.66289 +0.74622 Savigny-le-Temple
+B01   8.4464 0.64117 +0.76499 Taunus Observatory, Frankfurt
+B02  20.6566 0.63224 +0.77224 Kielce
+B03  16.2698 0.66759 +0.74211 Alter Satzberg, Vienna
+B04   7.478510.698677+0.713400OAVdA, Saint-Barthelemy
+B05  37.8831 0.57134 +0.81800 Ka-Dar Observatory, Barybino
+B06   2.533720.747520+0.662058Montseny Astronomical Observatory
+B07   9.0033 0.69383 +0.71778 Camorino
+B08  11.3807 0.71498 +0.69683 San Lazzaro di Savena
+B09  10.6708 0.72550 +0.68593 Capannoli
+B10   5.5150 0.71564 +0.69631 Observatoire des Baronnies Provencales, Moydans
+B11  10.6286 0.69881 +0.71318 Osservatorio Cima Rest, Magasa
+B12   4.4906 0.61329 +0.78721 Koschny Observatory, Noordwijkerhout
+B13   8.9311 0.69950 +0.71231 Osservatorio di Tradate
+B14   9.0758 0.71061 +0.70138 Ca del Monte
+B15  13.0129 0.61111 +0.78890 Inastars Observatory, Potsdam (since 2006)
+B16  36.9547 0.56382 +0.82317 1st Moscow Gymnasium Observatory, Lipki
+B17  33.162800.705588+0.706256AZT-8 Yevpatoriya
+B18  42.5008 0.72958 +0.68232 Terskol
+B19   2.4414 0.74963 +0.65966 Observatorio Iluro, Mataro
+B20   2.2636 0.75026 +0.65897 Observatorio Carmelita, Tiana
+B21  13.4744 0.66335 +0.74589 Gaisberg Observatory, Schaerding
+B22   0.7441 0.74412 +0.66598 Observatorio d'Ager
+B23  10.9710 0.70124 +0.71069 Fiamene
+B24   2.5983 0.66317 +0.74598 Cesson
+B25  15.0557 0.79386 +0.60614 Catania
+B26   5.6667 0.72204 +0.68966 Observatoire des Terres Blanches, Reillanne
+B27  14.1544 0.66425 +0.74516 Picard Observatory, St. Veit
+B28  13.1836 0.69466 +0.71696 Mandi Observatory, Pagnacco
+B29   0.6701 0.75801 +0.65008 L'Ampolla Observatory, Tarragona
+B30  16.5689 0.60872 +0.79074 Szamotuly-Galowo
+B31  20.8108 0.84560 -0.53254 Southern African Large Telescope, Sutherland
+B32  12.9486 0.63467 +0.77030 Gelenau
+B33  10.7783 0.72588 +0.68555 Libbiano Observatory, Peccioli
+B34  33.7258 0.81748 +0.57405 Green Island Observatory, Gecitkale
+B35  35.0317 0.84991 +0.52524 Bareket Observatory, Macabim
+B36  13.7125 0.66684 +0.74278 Redshed Observatory, Kallham
+B37   2.259340.748338+0.661147Obs. de L' Ametlla del Valles, Barcelona
+B38  11.857460.724995+0.686523Santa Mama
+B39   8.9072 0.69950 +0.71231 Tradate
+B40  15.0706 0.79331 +0.60690 Skylive Observatory, Catania
+B41  17.6925 0.65449 +0.75362 Zlin Observatory
+B42  30.3275 0.57401 +0.81614 Vitebsk
+B43   7.3089 0.63404 +0.77073 Hennef
+B44   5.5906 0.71772 +0.69419 Eygalayes
+B45  19.9356 0.64169 +0.76447 Narama
+B46  12.054390.714373+0.697420Sintini Observatory, Alfonsine
+B47  24.7503 0.49826 +0.86413 Metsala Observatory, Espoo
+B48   6.5981 0.61901 +0.78275 Bocholt
+B49   2.112500.749498+0.659844Paus Observatory, Sabadell
+B50   8.2767 0.65808 +0.75045 Corner Observatory, Durmersheim
+B51   7.066690.725612+0.685830Vallauris
+B52   2.997250.741344+0.668883Observatorio El Far
+B53  12.3536 0.74572 +0.66404 Casal Lumbroso, Rome
+B54   0.7439 0.74413 +0.66597 Ager
+B55  12.876000.689553+0.721975Comeglians
+B56   2.449350.749614+0.659663Observatorio Sant Pere, Mataro
+B57   2.224390.749316+0.660019Laietania Observatory, Parets del Valles
+B58  19.025290.676156+0.734318Polaris Observatory, Budapest
+B59   6.878810.619231+0.782586Borken
+B60   7.175310.612824+0.787576Deep Sky Observatorium, Bad Bentheim
+B61   2.043500.750575+0.658604Valldoreix Obs.,Sant Cugat del Valles
+B62   9.685310.609275+0.790314Brelingen
+B63  20.107990.642589+0.763698Solaris Observatory, Luczanowice
+B64  24.887790.491587+0.867927Slope Rock Observatory, Hyvinkaa
+B65  24.3878 0.49864 +0.86391 Komakallio Observatory, Kirkkonummi
+B66   9.006930.710595+0.701332Osservatorio di Casasco
+B67   9.224190.685858+0.725582Sternwarte Mirasteilas, Falera
+B68  13.539500.693458+0.718372Mount Matajur Observatory
+B69   9.017190.662152+0.746956Owls and Ravens Observatory, Holzgerlingen
+B70   2.4937 0.74787 +0.66165 Sant Celoni
+B71   1.5213 0.75363 +0.65510 Observatorio El Vendrell
+B72   7.681050.634701+0.770230Soerth Observatory
+B73   8.985030.662074+0.747029Mauren Valley Observatory, Holzgerlingen
+B74   1.105360.747550+0.662053Santa Maria de Montmagastrell
+B75   8.805190.701074+0.710741Stazione Astronomica Betelgeuse, Magnago
+B76  13.8944 0.63019 +0.77390 Sternwarte Schonfeld, Dresden
+B77   7.950830.677934+0.732833Schafmatt Observatory, Aarau
+B78  14.128110.670885+0.739158Astrophoton Observatory, Audorf
+B79  11.209900.700480+0.711457Marana Observatory
+B80  12.741260.742254+0.667919Osservatorio Astronomico Campomaggiore
+B81   2.8990 0.76967 +0.63634 Caimari
+B82   9.9716 0.64613 +0.76072 Maidbronn
+B83   5.797690.706034+0.705851Gieres
+B84   3.537750.622812+0.779749Cyclops Observatory, Oostkapelle
+B85   6.510110.604962+0.793587Beilen Observatory
+B86   7.455610.625931+0.777324Sternwarte Hagen
+B87   2.7701 0.74295 +0.66715 Banyoles
+B88   8.296810.710570+0.701309Bigmuskie Observatory, Mombercelli
+B89   2.2619 0.75018 +0.65907 Observatori Astronomic de Tiana
+B90  13.296860.693994+0.717600Malina River Observatory, Povoletto
+B91   7.255440.672149+0.737995Bollwiller
+B92   0.275390.681073+0.729781Chinon
+B93   6.478560.607102+0.791962Hoogeveen
+B94  34.2817 0.47422 +0.87748 Petrozavodsk
+B95   8.154500.602437+0.795492Achternholt
+B96   4.310310.628378+0.775301Brixiis Observatory, Kruibeke
+B97   6.1118 0.61688 +0.78442 Sterrenwacht Andromeda, Meppel
+B98  11.313000.728746+0.682563Siena
+B99   0.7443 0.74413 +0.66598 Santa Coloma de Gramenet
+C00  30.5150 0.55583 +0.82853 Velikie Luki
+C01  13.922930.630265+0.773855Lohrmann-Observatorium, Triebenberg
+C02   2.5305 0.74740 +0.66218 Observatorio Royal Park
+C03  24.961140.492892+0.867190Clayhole Observatory, Jokela
+C04  37.6331 0.65998 +0.74878 Kramatorsk
+C05  12.1153 0.68023 +0.73088 Konigsleiten
+C06  92.9744 0.56032 +0.82553 Krasnoyarsk
+C07   0.7442 0.74413 +0.66597 Anysllum Observatory, Ager
+C08  17.3761 0.50302 +0.86138 Fiby
+C09   3.803970.722660+0.688932Rouet
+C10   3.426220.661039+0.747874Maisoncelles
+C11  14.0901 0.64091 +0.76509 City Observatory, Slany
+C12   2.1107 0.74967 +0.65964 Berta Observatory, Sabadell
+C13   9.100310.698332+0.713430Como
+C14  15.967000.668463+0.741344Sky Vistas Observatory, Eichgraben
+C15 132.1656 0.72418 +0.68737 ISON-Ussuriysk Observatory
+C16  11.572610.673687+0.736691Isarwinkel Observatory, Bad Tolz
+C17   0.743810.744124+0.665978Observatorio Joan Roget, Ager
+C18   3.604000.634888+0.770037Frasnes-Lez-Anvaing
+C19   5.4231 0.71591 +0.69599 ROSA Observatory, Vaucluse
+C20  42.661910.723859+0.688104Kislovodsk Mtn. Astronomical Stn., Pulkovo Obs.
+C21   0.743830.744124+0.665978Observatorio Via Lactea, Ager
+C22  12.9599 0.63858 +0.76717 Oberwiesenthal
+C23   5.154390.628694+0.775052Olmen
+C24   9.1331 0.70036 +0.71145 Seveso
+C25  13.558060.739310+0.671605Pulkovo Observatory Station, Campo Imperatore
+C26   4.499280.614813+0.786032Levendaal Observatory, Leiden
+C27   1.353020.748763+0.660753Pallerols
+C28   7.483000.624224+0.778652Wellinghofen
+C29   1.078890.737202+0.673777Observatori Astronomic de Les Planes de Son
+C30  35.3425 0.47988 +0.87440 Petrozavodsk University Obs., Sheltozero Stn.
+C31   6.9825 0.62777 +0.77581 Sternwarte Neanderhoehe Hochdahl e.V., Erkrath
+C32  41.4258 0.72496 +0.68694 Ka-Dar Observatory, TAU Station, Nizhny Arkhyz
+C33   2.8989 0.76967 +0.63634 Observatorio CEAM, Caimari
+C34  19.0108 0.69361 +0.71796 Baja Astronomical Observatory
+C35   2.0349 0.74927 +0.66012 Terrassa
+C36  30.3086 0.58230 +0.81028 Starry Wanderer Observatory, Baran'
+C37   1.018300.614242+0.786484Stowupland
+C38   7.649110.703322+0.708581Varuna Observatory, Cuorgne
+C39   5.7992 0.61929 +0.78253 Nijmegen
+C40  39.0308 0.70806 +0.70380 Kuban State University Astrophysical Observatory
+C41  42.661260.723857+0.688105MASTER-II Observatory, Kislovodsk
+C42  87.1778 0.72711 +0.68469 Xingming Observatory, Mt. Nanshan
+C43  14.2792 0.62451 +0.77842 Hoyerswerda
+C44   9.022390.696268+0.715567A. Volta Observatory, Lanzo d'Intelvi
+C45  12.406390.744413+0.665514La Giustiniana
+C46  69.122190.576620+0.814296Horizon Observatory, Petropavlovsk
+C47  15.2356 0.66017 +0.74871 Nonndorf
+C48 100.9214 0.62235 +0.78051 Sayan Solar Observatory, Irkutsk
+C49                           STEREO-A
+C50                           STEREO-B
+C51                           WISE
+C52                           Swift
+C53                           NEOSSat
+C54                           New Horizons
+C55                           Kepler
+C56                           LISA-Pathfinder
+C57                           TESS
+C58                           NEO Surveyor
+C59                           Yangwang-1
+C60   7.069260.634261+0.770545Argelander Institute for Astronomy Obs., Bonn
+C61   2.582020.658892+0.749723Chelles
+C62  11.3467 0.68967 +0.72175 Eurac Observatory, Bolzano
+C63   9.9797 0.69363 +0.71819 Giuseppe Piazzi Observatory, Ponte in Valtellina
+C64  15.284390.671380+0.738819Puchenstuben
+C65   0.729650.743847+0.666488Observatori Astronomic del Montsec
+C66   2.8050 0.77084 +0.63493 Observatorio El Cielo de Consell
+C67  12.2199 0.59747 +0.79922 Gnevsdorf
+C68  23.893390.789058+0.612302Ellinogermaniki Agogi Observatory, Pallini
+C69  13.3611 0.65835 +0.75036 Bayerwald Sternwarte, Neuhuette
+C70   4.497750.614779+0.786055Uiterstegracht Station, Leiden
+C71   1.4892 0.74780 +0.66186 Sant Marti Sesgueioles
+C72  12.8717 0.74621 +0.66358 Palestrina
+C73  28.0325 0.70312 +0.70870 Galati Observatory
+C74   0.7449 0.74412 +0.66598 Observatorio El Teatrillo de Lyra, Ager
+C75  13.2225 0.69384 +0.71776 Whitestar Observatory, Borgobello
+C76   0.744310.744127+0.665974Observatorio Estels, Ager
+C77   7.4535 0.71589 +0.69600 Bernezzo Observatory
+C78  34.812420.849698+0.525519Martin S. Kraar Observatory, Rehovot
+C79   2.7855 0.74801 +0.66147 Roser Observatory, Blanes
+C80  39.7651 0.67959 +0.73115 Don Astronomical Observatory, Rostov-on-Don
+C81  10.840980.693023+0.718872Dolomites Astronomical Observatory
+C82  14.357590.760172+0.647614Osservatorio Astronomico Nastro Verde, Sorrento
+C83  91.8425 0.55930 +0.82626 Badalozhnyj Observatory
+C84   2.243720.750690+0.658447Badalona
+C85   1.2408 0.77939 +0.62448 Observatorio Cala d'Hort, Ibiza
+C86   2.7813 0.74801 +0.66147 Blanes
+C87   8.7689 0.64913 +0.75817 Rimbach
+C88  11.183310.729763+0.681487Montarrenti Observatory, Siena
+C89  21.555580.730958+0.680397Astronomical Station Vidojevica
+C90   1.051810.754546+0.654066Vinyols
+C91  11.226210.717604+0.694214Montevenere Observatory, Monzuno
+C92  13.609950.727425+0.683915Valdicerro Observatory, Loreto
+C93  13.4064 0.74042 +0.67004 Bellavista Observatory, L'Aquila
+C94 103.0670 0.61962 +0.78241 MASTER-II Observatory, Tunka
+C95   5.712390.721406+0.690350SATINO Remote Observatory, Haute Provence
+C96  13.8786 0.73544 +0.67537 OACL Observatory, Mosciano Sant Angelo
+C97  57.976330.916656+0.398354Al-Fulaij Observatory, Oman
+C98  11.1764 0.72335 +0.68818 Osservatorio Casellina, Scandicci
+C99   2.896310.746295+0.663419Observatori Can Roig, Llagostera
+D00  42.6536 0.72388 +0.68809 ASC-Kislovodsk Observatory
+D01  23.930610.495920+0.865471Andean Northern Observatory, Nummi-Pusula
+D02   2.051890.751414+0.657647Observatori Petit Sant Feliu
+D03  10.588920.715223+0.696709Rantiga Osservatorio, Tincana
+D04  38.8569 0.70960 +0.70225 Krasnodar
+D05  42.500050.729580+0.682314ISON-Terskol Observatory
+D06  12.770170.747232+0.662472Associazione Tuscolana di Astronomia, Domatore
+D07   6.2094 0.62867 +0.77508 Wegberg
+D08   8.9191 0.69024 +0.72136 Ghezz Observatory, Leontica
+D09   5.6794 0.63139 +0.77287 Observatory Gromme, Maasmechelen
+D10   8.901810.661976+0.747123Gaertringen
+D11   5.627970.723085+0.688551Bastidan Observatory
+D12  11.338060.690580+0.720900Filzi School Observatory, Laives
+D13  11.563690.738665+0.671859Cat's Eye Observatory
+D14 113.3231 0.92000 +0.39061 Nanchuan Observatory, Guangzhou
+D15  11.317810.630848+0.773359Sternwarte F.Schiller-Gymnasium, Weimar
+D16 113.964220.925155+0.378330Po Leung Kuk Observatory, Tuen Mun
+D17 114.2200 0.9245  +0.3799  Hong Kong
+D18 114.3580 0.86219 +0.50490 Mt. Guizi Observatory
+D19 114.323000.924955+0.378843Hong Kong Space Museum Sai Kung iObservatory
+D20 115.713110.854733-0.517343Zadko Observatory, Wallingup Plain
+D21 115.8150 0.8492  -0.5263  Shenton Park
+D22 115.816670.849044-0.526558UWA Observatory, Crawley
+D23   0.518530.749367+0.659977OAIA, Alcarras
+D24 117.089690.844095-0.534439LightBuckets Observatory, Pingelly
+D25 117.089780.844104-0.534424Tzec Maun Observatory, Pingelly (before 2010)
+D26   1.921310.722868+0.688750Peyrole Observatory, Peyrole
+D27   3.803610.725021+0.686446Observatoire de Fontcaude, Juvignac
+D28   2.182860.748708+0.660744Escaldarium Observatory,Caldes de Montbui
+D29 118.4639 0.84204 +0.53767 Purple Mountain Observatory, XuYi Station
+D30  11.083500.631405+0.772922Sternwarte Silbergraben, Erfurt
+D31  10.097970.714476+0.697520Osservatorio Aldebaran, Rivalba
+D32 119.599750.862770+0.504193JiangNanTianChi Observatory, Mt. Getianling
+D33 120.6982 0.92730 +0.37308 Kenting Observatory, Checheng
+D34 120.7839 0.92796 +0.37148 Kenting Observatory, Hengchun
+D35 120.8736 0.91818 +0.39597 Lulin Observatory
+D36 120.8897 0.91801 +0.39625 Tataka, Mt. Yu-Shan National Park
+D37 120.873250.918176+0.395972Lulin Widefield Telescope, Mt. Lulin
+D38   8.437640.709383+0.702495Tecnosky Astropark, Felizzano
+D39 122.049610.793971+0.605943Shandong University Observatory, Weihai
+D40  13.337720.748318+0.661176Frosinone
+D41  10.717040.727431+0.683991Osservatorio Astronomico Orciatico
+D42  11.190840.723565+0.687970Piero Angela Observatory, Scandicci
+D43   7.770390.707805+0.70416245th Parallel Observatory, Pino Torinese
+D44 124.139280.911427+0.410157Ishigakijima Astronomical Observatory
+D45  21.493250.639594+0.766177Kamyk, Trzesn
+D46   9.902650.671664+0.738525Observatory Bad Wurzach
+D47  11.563660.738665+0.671859BigBang Observatory, Manciano
+D48   7.263810.652979+0.754898Niederbexbach Observatory
+D49   0.794440.757213+0.650992L'Ametlla de Mar
+D50   5.215190.720062+0.691654Vaucluse Observatoire Celeste, Blauvac
+D51   1.948440.719539+0.692203Plateau Astronomique La Couronne
+D52   9.797500.707094+0.704768ULU Observatory, Caselle Landi
+D53 127.4820 0.63981 +0.76600 ISON-Blagoveschensk Observatory
+D54 127.4830 0.63981 +0.76601 MASTER-II Observatory, Blagoveshchensk
+D55 127.9747 0.79571 +0.60370 Kangwon Science High School Observatory, Ksho
+D56  11.674080.700775+0.711011Osservatorio Sideris Oculus, San Pietro in Gu
+D57 128.887440.817572+0.573996Gimhae Astronomical Observatory, Uhbang-dong
+D58 129.025000.818419+0.572736KSA SEM Observatory, Danggam-dong
+D59   7.156170.723595+0.688001MARIAMIR, Saint-Jeannet
+D60  13.551460.693649+0.718079Sparky's Stars, Masseris
+D61 134.9131 0.82671 +0.56075 Suntopia Marina, Sumoto
+D62 130.4494 0.83676 +0.54575 Miyaki-Argenteus
+D63  10.461380.719553+0.692176G. Pascoli Observatory, Barga (since June 2023)
+D64  14.109670.740711+0.669613Fucama, Casalincontrada
+D65  11.534800.702163+0.709679G. Beltrame, Arcugnano Vicenza
+D66   9.148390.703654+0.708197Civico Osservatorio Astronomico di Rozzano
+D67  37.624720.586136+0.807530Tula Rooftop Observatory, Tula
+D68  11.736220.702543+0.709270Osservatorio Galileo, Padova
+D69   9.970130.646988+0.760014JMU Space-Observatory
+D70 133.4686 0.83505 +0.54834 Tosa
+D71  15.892250.685516+0.725682ObservaSTYRium, Stainz bei Straden
+D72  16.361310.919630-0.392207WAA Remote Observatory, Hakos
+D73  16.361390.919632-0.392208SNX-NET, Hakos
+D74 134.6819 0.83041 +0.55530 Nakagawa
+D75  16.956080.772805+0.632534Cariati
+D76   2.007020.749354+0.660032AAT-Terrassa, Terrassa
+D77  10.717360.727433+0.683988TD-TRO (Tuscany Remote Observatory)
+D78 136.132810.822378+0.567077Iga-Ueno
+D79 138.630920.821212-0.568722YSVP Observatory, Vale Park
+D80 138.9728 0.80392 +0.59297 Gumma Astronomical Observatory
+D81 138.2239 0.80310 +0.59394 Nagano
+D82 137.6317 0.83058 -0.55504 Wallaroo
+D83 138.4681 0.80501 +0.59161 Miwa
+D84 138.5086 0.8192  -0.5716  Hallet Cove
+D85 138.6597 0.82186 -0.56782 Ingle Farm
+D86 138.6407 0.83075 -0.55490 Penwortham
+D87 138.5500 0.82079 -0.56931 Brooklyn Park
+D88 139.3142 0.81635 +0.57562 Hiratsuka
+D89 140.3383 0.7871  +0.6149  Yamagata
+D90 140.3420 0.82728 -0.55991 RAS Observatory, Moorook
+D91 140.8250 0.79261 +0.60775 Adati
+D92 140.946380.782920+0.620047Osaki
+D93 140.755160.786291+0.615826Sendai Astronomical Observatory
+D94 139.9962 0.80351 +0.59335 Takanezawa, Tochigi
+D95 141.0680 0.78035 +0.62325 Kurihara
+D96 140.342160.827287-0.559905Tzec Maun Observatory, Moorook
+D97 140.5700 0.82752 -0.55956 Berri
+D98  11.334090.717444+0.694448Loiano TANDEM
+D99   0.391220.717357+0.694422AstroKoT, Port-Ste-Marie
+E00 144.2089 0.79902 -0.59937 Castlemaine
+E01 144.541420.798618-0.599924Barfold
+E03 145.3822 0.78756 -0.61419 RAS Observatory, Officer
+E04 145.7403 0.96545 +0.25977 Pacific Sky Observatory, Saipan
+E05 145.697210.957625-0.287092Earl Hill Observatory, Trinity Beach
+E07 148.998890.820544-0.569830Murrumbateman
+E08 149.334310.855971-0.515472Wobblesock Observatory, Coonabarabran
+E09 149.0814 0.85551 -0.51630 Oakley Southern Sky Observatory, Coonabarabran
+E10 149.070850.855632-0.516198Siding Spring-Faulkes Telescope South
+E11 149.6627 0.84469 -0.53362 Frog Rock Observatory, Mudgee
+E12 149.0642 0.85563 -0.51621 Siding Spring Survey
+E13 149.0969 0.81622 -0.57597 Wanniassa
+E14 149.1100 0.81852 -0.57274 Hunters Hill Observatory, Ngunnawal
+E15 149.6061 0.82016 -0.57041 Magellan Observatory, near Goulburn
+E16 149.366240.831684-0.553656Grove Creek Observatory, Trunkey
+E17 150.3417 0.8329  -0.5519  Leura
+E18 151.027140.829819-0.556191BDI Observatory, Regents Park
+E19 151.0958 0.83042 -0.55528 Kingsgrove
+E20 151.103200.832146-0.552728Marsfield
+E21 151.5667 0.8838  -0.4665  Norma Rose Observatory, Leyburn
+E22 151.855000.885337-0.463616Univ. of Southern Queensland Obs., Mt. Kent
+E23 151.071190.833596-0.550574Arcadia
+E24 150.7769 0.83176 -0.55329 Tangra Observatory, St. Clair
+E25 153.1170 0.88713 -0.45997 Rochedale (APTA)
+E26 153.3971 0.88414 -0.46566 RAS Observatory, Biggera Waters
+E27 153.2667 0.8871  -0.4600  Thornlands
+E28 150.641050.833196-0.551210Kuriwa Observatory, Hawkesbury Heights
+E29 115.955330.845978-0.531426Mardella Observatory
+E62 149.081350.855509-0.516305Slooh.com Australia, Coonabarabran
+E81 173.2617 0.75267 -0.65622 Nelson
+E83 173.957030.749648-0.659621Wither Observatory, Witherlea
+E85 174.894000.800696-0.597064Farm Cove
+E87 175.6540 0.76249 -0.64485 Turitea
+E89 176.2040 0.78759 -0.61421 Geyserland Observatory, Pukehangi
+E94 177.883310.782217-0.620920Possum Observatory, Gisborne
+F51 203.744090.936241+0.351543Pan-STARRS 1, Haleakala
+F52 203.744090.936239+0.351545Pan-STARRS 2, Haleakala
+F59 201.941000.932037+0.361160Ironwood Remote Observatory, Hawaii
+F60 201.952830.929942+0.366558Ironwood Observatory, Hawaii
+F65 203.742500.936239+0.351538Haleakala-Faulkes Telescope North
+F84 210.3842 0.95330 -0.30100 Hibiscus Observatory, Punaauia
+F85 210.3842 0.95330 -0.30100 Tiki Observatory, Punaauia
+F86 210.383810.953304-0.301004Moana Observatory, Punaauia
+G00  15.126000.665508+0.744080AZM Martinsberg, Oed
+G01   8.165280.600977+0.796597Universitaetssternwarte Oldenburg
+G02  18.765390.653307+0.754650KYSUCE Observatory, Kysucke Nove Mesto
+G03  18.260610.678620+0.732104Capricornus Observatory, Csokako
+G04   7.141330.627502+0.776082Schuelerlabor Astronomie St. 7, Wuppertal
+G05 354.533630.787181+0.614802Piconcillo, Sierra Morena
+G06   4.671500.619980+0.781996Dordrecht, Sterrenburg
+G07   3.063860.719394+0.692378Millau Observatory
+G08   1.996940.748752+0.660794Observatorio Les Pedritxes, Matadepera
+G09   0.610560.621784+0.780574SWF Observatory, South Woodham Ferrers
+G10 354.450550.792574+0.607765Clavier Observatory, Lora Del Rio
+G11   7.183790.630712+0.773465Breitenweg Observatory, Herkenrath
+G12   8.3306 0.62140 +0.78090 Sternwarte EG, Lippstadt
+G13   9.771640.451870+0.889105Astronomihagen, Fannrem
+G14   7.005200.725247+0.686239Novaloop Observatory, Mougins
+G15   9.1183 0.71116 +0.70080 Magroforte Observatory, Alessandria
+G16  13.348690.787948+0.613701OmegaLab Observatory, Palermo
+G17  11.202610.723508+0.688023BAS Observatory, Scandicci
+G18  11.280560.712881+0.698947ALMO Observatory, Padulle
+G19  12.7460 0.63252 +0.77202 Immanuel Kant Observatory,Limbach
+G20   6.059890.727743+0.683615Brignoles Observatory
+G21  13.737890.796024+0.603377Osservatorio Castrofilippo
+G22   9.214390.655435+0.752770Experimenta Observatory, Heilbronn
+G23  19.092340.675698+0.734739Vulpecula Observatory, Budapest
+G24   9.093500.662443+0.746701Dettenhausen
+G25 288.1050 0.70317 +0.70867 Sherbrooke
+G26 109.8236 0.82499 +0.56338 Fushan Observatory, Mt Shaohua
+G27   0.729350.743842+0.666483Fabra Observatory, Montsec
+G28   1.008500.609900+0.789830Wyncroft Observatory, Attleborough
+G29 358.9124 0.77285 +0.63263 Requena
+G30 284.907190.704518+0.707320Casselman
+G31  13.7253 0.69946 +0.71233 CCAT Trieste
+G32 291.820400.921639-0.387713Elena Remote Observatory, San Pedro de Atacama
+G33   7.608790.623411+0.779293Wickede
+G34  13.701500.632547+0.772037Oberfrauendorf
+G35 249.157890.849476+0.526134Elephant Head Obsevatory, Sahuarita
+G36 357.452500.797538+0.601812Calar Alto-CASADO
+G37 248.577790.822900+0.566927Lowell Discovery Telescope
+G38 356.768420.759967+0.647951Observatorio La Senda, Cabanillas del Campo
+G39 291.820390.921640-0.387711ROAD, San Pedro de Atacama
+G40 343.491740.881470+0.471441Slooh.com Canary Islands Observatory
+G41 264.738160.867040+0.496575Insperity Observatory, Humble
+G42 259.0230 0.90391 +0.42687 Observatorio Astronomico UAdeC, Saltillo
+G43 293.6879 0.83817 -0.54382 Observatorio Buenaventura Suarez, San Luis
+G44 313.3061 0.92118 -0.38816 Observatorio Longa Vista, Sao Paulo
+G45 253.635640.832748+0.552480Space Surveillance Telescope, Atom Site
+G46 244.661530.818022+0.573711Pinto Valley Observatory
+G47 253.806540.819827+0.571261HillTopTop Observatory, Edgewood
+G48 251.101480.849514+0.526196Harlingten Research Observatory, Rancho Hildalgo
+G49 266.5943 0.70889 +0.70302 Minnetonka
+G50 253.3300 0.84629 +0.53134 Organ Mesa Observatory, Las Cruces
+G51 239.957780.823164+0.565990Byrne Observatory, Sedgwick Reserve
+G52 237.496040.785917+0.616275Stone Edge Observatory, El Verano
+G53 240.587270.799043+0.599625Alder Springs Observatory, Auberry
+G54 243.0630 0.83295 +0.55166 Hemet
+G55 241.095330.816361+0.575651Bakersfield
+G56 237.9294 0.78983 +0.61128 Walnut Creek
+G57 236.8564 0.70171 +0.71009 Dilbert Observatory, Forest Grove
+G58 237.8180 0.79100 +0.60988 Chabot Space and Science Center, Oakland
+G59 237.4530 0.67475 +0.73559 Maiden Lane Obs., Bainbridge Island
+G60 240.338880.825544+0.562496Carroll Observatory, Montecito
+G61 238.1524 0.79270 +0.60760 Pleasanton
+G62 238.5469 0.72214 +0.68971 Sunriver Nature Center Observatory, Sunriver
+G63 238.6858 0.70152 +0.71031 Mill Creek Observatory, The Dalles
+G64 239.2911 0.77535 +0.62979 Blue Canyon Observatory
+G65 238.3612 0.79616 +0.60338 Vulcan North, Lick Observatory, Mount Hamilton
+G66 238.9169 0.78135 +0.62206 Lake Forest Observatory, Forest Hills
+G67 239.3650 0.78134 +0.62225 Rancho Del Sol, Camino
+G68 240.2250 0.78044 +0.62355 Sierra Stars Observatory, Markleeville
+G69 241.0158 0.82829 +0.55850 Via Capote Sky Observatory, Thousand Oaks
+G70 241.4547 0.82543 +0.56273 Francisquito Observatory, Los Angeles
+G71 241.6047 0.83216 +0.55276 Rancho Palos Verdes
+G72 241.824080.829301+0.556970University Hills
+G73 241.9400 0.82804 +0.55925 Mount Wilson-TIE
+G74 242.885380.837429+0.544849Boulder Knolls Observatory, Escondido
+G75 243.2783 0.8351  +0.5487  Starry Knight Observatory, Coto de Caza
+G76 242.4178 0.83388 +0.55015 Altimira Observatory, Coto de Caza
+G77 243.7183 0.8274  +0.5603  Baldwin Lake
+G78 244.3127 0.84158 +0.53832 Desert Wanderer Observatory, El Centro
+G79 243.6165 0.82718 +0.56030 Goat Mountain Astronomical Research Station
+G80 240.5873 0.79904 +0.59962 Sierra Remote Observatories, Auberry
+G81 242.913000.834904+0.548639Temecula
+G82 248.400570.849482+0.526455SARA Observatory, Kitt Peak
+G83 250.110390.842740+0.537440Mt. Graham-LBT
+G84 249.210840.845112+0.533610Mount Lemmon SkyCenter
+G85 247.565180.799502+0.599067Vermillion Cliffs Observatory, Kanab
+G86 249.0697 0.84645 +0.53090 Tucson-Winterhaven
+G87 248.1894 0.74666 +0.66331 Calvin M. Hooper Memorial Observatory, Hyde Park
+G88 247.8881 0.83064 +0.55514 LAMP Observatory, New River
+G89 248.3069 0.81933 +0.57197 Kachina Observatory, Flagstaff
+G90 248.9658 0.84301 +0.53639 Three Buttes Observatory, Tucson
+G91 249.1219 0.85208 +0.52234 Whipple Observatory, Mt. Hopkins--2MASS
+G92 249.2814 0.84920 +0.52660 Jarnac Observatory, Vail
+G93 249.3726 0.85215 +0.52201 Sonoita Research Observatory, Sonoita
+G94 249.9267 0.84971 +0.52594 Sonoran Skies Observatory, St. David
+G95 249.7622 0.85404 +0.51888 Hereford Arizona Observatory, Hereford
+G96 249.211280.845107+0.533611Mt. Lemmon Survey
+G97 250.8694 0.84965 +0.52600 Astronomical League Alpha Observatory, Portal
+G98 251.343540.815037+0.578012Calvin-Rehoboth Observatory, Rehoboth
+G99 251.8104 0.84192 +0.53835 NF Observatory, Silver City
+H00 251.6987 0.84247 +0.53746 Tyrone
+H01 252.810670.830474+0.556096Magdalena Ridge Observatory, Socorro
+H02 253.3706 0.81146 +0.58309 Sulphur Flats Observatory, La Cueva
+H03 253.3553 0.81753 +0.57440 Sandia View Observatory, Rio Rancho
+H04 254.0260 0.81388 +0.57964 Santa Fe
+H05 256.0707 0.77126 +0.63477 Edmund Kline Observatory, Deer Trail
+H06 254.471300.840712+0.540310iTelescope Observatory, Mayhill
+H07 254.471340.840711+0.5403107300 Observatory, Cloudcroft
+H08 254.470810.840705+0.540319BlackBird Observatory, Cloudcroft
+H09 255.5886 0.77070 +0.63549 Antelope Hills Observatory, Bennett
+H10 254.471410.840711+0.540309Tzec Maun Observatory, Mayhill
+H11 250.9840 0.85029 +0.52492 LightBuckets Observatory, Rodeo
+H12 254.470780.840712+0.540307TechDome, Mayhill
+H13 248.252120.840489+0.540134Lenomiya Observatory, Casa Grande
+H14 249.212330.846402+0.530995Morning Star Observatory, Tucson
+H15 254.471560.840711+0.540308ISON-NM Observatory, Mayhill
+H16 253.2890 0.77152 +0.63472 HUT Observatory, Eagle
+H17 254.383330.783783+0.619652Angel Peaks Observatory
+H18 249.287980.849231+0.526572Vail View Observatory, Vail
+H19 263.862590.828144+0.558685Lone Star Observatory, Caney
+H20 271.816820.772950+0.632393Eastern Illinois University Obs., Charleston
+H21 272.031730.772885+0.632471Astronomical Research Observatory, Westfield
+H22 272.7371 0.77438 +0.63062 Terre Haute
+H23 273.498580.862319+0.504671Pear Tree Observatory, Valparaiso
+H24 274.598810.733648+0.677310J. C. Veen Observatory, Lowell
+H25 266.870820.714467+0.697388Harvest Moon Observatory, Northfield
+H26 270.789220.735075+0.675789Doc Greiner Research Observatory, Janesvillle
+H27 266.231340.780074+0.623645Moonglow Observatory, Warrensburg
+H28 263.231500.836912+0.545569Preston Hills Observatory, Celina
+H29 262.5494 0.81372 +0.57940 Ivywood Observatory, Edmond
+H30 262.5558 0.81808 +0.57328 University of Oklahoma Observatory, Norman
+H31 263.3300 0.87011 +0.49123 Star Ridge Observatory, Weimar
+H32 263.6334 0.86174 +0.50567 Texas A&M Physics Observatory, College Station
+H33 264.1217 0.80990 +0.58466 Bixhoma Observatory, Bixby
+H34 264.8258 0.84600 +0.53143 Chapel Hill
+H35 264.9517 0.77423 +0.63085 Leavenworth
+H36 264.293450.780428+0.623229Sandlot Observatory, Scranton
+H37 265.2003 0.72947 +0.68182 Grems Timmons Observatories, Graettinger
+H38 265.9864 0.75079 +0.65840 Timberline Observatory, Urbandale
+H39 266.6828 0.70944 +0.70247 S.O.S. Observatory, Minneapolis
+H40 266.7306 0.82519 +0.56302 Nubbin Ridge Observatory
+H41 267.0742 0.81870 +0.57238 Petit Jean Mountain
+H42 267.5078 0.73568 +0.67512 Wartburg College Observatory, Waverly
+H43 267.4998 0.81918 +0.57163 Conway
+H44 267.7982 0.81880 +0.57220 Cascade Mountain
+H45 267.0831 0.81890 +0.57210 Arkansas Sky Obs., Petit Jean Mountain South
+H46 265.7297 0.77818 +0.62602 Ricky Observatory, Blue Springs
+H47 269.1439 0.84639 +0.53079 Vicksburg
+H48 265.0139 0.79424 +0.60565 PSU Greenbush Observatory, Pittsburg
+H49 266.8636 0.81712 +0.57457 ATU Astronomical Observatory, Russellville
+H50 267.541390.819253+0.571536University of Central Arkansas Obs., Conway
+H51 270.4003 0.73117 +0.68011 Greiner Research Observatory, Verona
+H52 270.673540.739151+0.671335Hawkeye Observatory, Durand
+H53 271.228420.789618+0.611581Thompsonville
+H54 271.6514 0.71305 +0.69883 Cedar Drive Observatory, Pulaski
+H55 271.8558 0.77283 +0.63254 Astronomical Research Observatory, Charleston
+H56 272.167640.742693+0.667433Northbrook Meadow Observatory
+H57 275.972460.758850+0.649150Ohio State University Observatory, Lima
+H58 273.3353 0.82349 +0.56548 NASA/MSFC ALaMO, Redstone Arsenal
+H59 273.3651 0.76362 +0.64356 Prairie Grass Observatory, Camp Cullom
+H60 273.865420.767435+0.639034Heartland Observatory, Carmel
+H61 281.416890.721533+0.690080Newcastle
+H62 274.4117 0.73335 +0.67763 Calvin College Observatory
+H63 274.9276 0.75227 +0.65672 DeKalb Observatory, Auburn
+H64 275.4364 0.77796 +0.62623 Thomas More College Observatory, Crestview Hills
+H65 275.4364 0.77995 +0.62381 Waltonfields Observatory, Walton
+H66 276.1460 0.76956 +0.63651 Yellow Springs
+H67 276.162410.740813+0.669522Stonegate Observatory, Ann Arbor
+H68 276.348240.854246+0.518152Red Barn Observatory, Ty Ty
+H69 276.944630.764320+0.642741Perkins Observatory, Delaware
+H70 277.4458 0.81412 +0.57897 Asheville
+H71 276.482820.852885+0.520378Chula
+H72 278.2258 0.89584 +0.44289 Evelyn L. Egan Observatory, Fort Myers
+H73 278.6351 0.74850 +0.66097 Lakeland Astronomical Observatory, Kirtland
+H74 278.8747 0.87602 +0.48066 Bar J Observatory, New Smyrna Beach
+H75 278.918560.749551+0.659816Indian Hill North Observatory, Huntsburg
+H76 279.4133 0.90197 +0.43036 Oakridge Observatory, Miami
+H77 279.7653 0.89877 +0.43695 Buehler Observatory
+H78 282.708961.000183+0.021030University of Narino Observatory, Pasto
+H79 280.492700.723258+0.688308York University Observatory, Toronto
+H80 285.335670.763194+0.644015Halsted Observatory, Princeton
+H81 283.615390.738959+0.671615Hartung-Boothroyd Observatory, Ithaca
+H82 281.7839 0.77836 +0.62576 CBA-NOVAC Observatory, Front Royal
+H83 282.6641 0.77926 +0.62463 Timberlake Observatory, Oakton
+H84 282.4961 0.73259 +0.67843 Northview Observatory, Mendon
+H85 283.0029 0.77784 +0.62638 Silver Spring
+H86 283.1576 0.77693 +0.62749 CBA-East Observatory, Laurel
+H87 282.4361 0.79309 +0.60708 Fenwick Observatory, Richmond
+H88 283.7577 0.77295 +0.63235 Hope Observatory, Belcamp
+H89 284.2975 0.70235 +0.70945 Galaxy Blues Observatory, Gatineau
+H90 284.4731 0.70267 +0.70914 Ottawa
+H91 285.048390.712263+0.699590Reynolds Observatory, Potsdam
+H92 285.6211 0.76785 +0.63849 Arcturus Observatory
+H93 285.5758 0.75934 +0.64853 Berkeley Heights
+H94 285.5439 0.75781 +0.65032 Cedar Knolls
+H95 285.821200.758745+0.649211NJIT Observatory, Newark
+H96 286.6142 0.69143 +0.72005 Observatoire des Pleiades, Mandeville
+H97 287.201320.746487+0.663233Talcott Mountain Science Center, Avon
+H98 287.2655 0.74987 +0.65938 Dark Rosanne Obs., Middlefield
+H99 288.8036 0.74040 +0.66992 Sunhill Observatory, Newton
+I00 288.2294 0.74794 +0.66157 Carbuncle Hill Observatory, Coventry
+I01 288.862530.740677+0.669630Clay Center Observatory, Brookline
+I02 289.1949 0.86558 -0.49976 Cerro Tololo Observatory, La Serena--2MASS
+I03 289.266260.873440-0.486052European Southern Obs., La Silla--ASTROVIRTEL
+I04 289.3152 0.86693 -0.49697 Mamalluca Observatory
+I05 289.2980 0.87559 -0.48217 Las Campanas Observatory-TIE
+I06 289.8061 0.74801 +0.66147 Werner Schmidt Obs., Dennis-Yarmouth Regional HS
+I07 288.0971 0.74279 +0.66735 Conlin Hill Observatory, Oxford
+I08 290.6932 0.85116 -0.52394 Alianza S4, Cerro Burek
+I09 289.803770.910166-0.413875Cerro Armazones
+I10 291.8200 0.92165 -0.38770 CAO, San Pedro de Atacama (until 2012)
+I11 289.263450.865020-0.500901Gemini South Observatory, Cerro Pachon
+I12 288.870530.736679+0.673998Phillips Academy Observatory, Andover
+I13 282.930060.779116+0.624793Burleith Observatory, Washington D.C.
+I14 288.589310.740298+0.670040Tigh Speuran Observatory, Framingham
+I15 288.700760.747034+0.662558Wishing Star Observatory, Barrington
+I16 291.820330.921638-0.387715IAA-AI Atacama, San Pedro de Atacama
+I17 284.322060.748993+0.660451Thomas G. Cupillari Observatory, Fleetville
+I18 281.3067 0.79038 +0.61070 Fan Mountain Observatory, Covesville
+I19 295.407110.854834-0.517422Observatorio El Gato Gris, Tanti
+I20 295.681610.838551-0.543122Observatorio Astronomico Salvador, Rio Cuarto
+I21 295.8281 0.85465 -0.51760 El Condor Observatory, Cordoba
+I22 296.173990.712120+0.699724Abbey Ridge Observatory, Stillwater Lake
+I23 292.266490.714173+0.697623Frosty Cold Observatory, Mash Harbor
+I24 282.2306 0.78534 +0.61702 Lake of the Woods Observatory, Locust Grove
+I25 295.443810.850887-0.523945ECCCO Observatory, Bosque Alegre
+I26 295.8214 0.85417 -0.51839 Observatorio Kappa Crucis, Cordoba
+I27 284.0006 0.70401 +0.70783 Barred Owl Observatory, Carp
+I28 289.0889 0.74643 +0.66324 Starhoo Observatory, Lakeville
+I29 288.633040.738432+0.672081Middlesex School Observatory, Concord
+I30 299.3417 0.83966 -0.54131 Observatorio Geminis Austral
+I31 299.3649 0.83995 -0.54086 Observatorio Astronomico del Colegio Cristo Rey
+I32 299.3464 0.83969 -0.54125 Observatorio Beta Orionis, Rosario
+I33 289.266310.865052-0.500865SOAR, Cerro Pachon
+I34 284.1297 0.76548 +0.64134 Morgantown
+I35 301.5572 0.82198 -0.56762 Sidoli
+I36 301.282710.819978-0.570483Observatorio Los Campitos, Canuelas
+I37 301.352750.825603-0.562360Astrodomi Observatory, Santa Rita
+I38 302.021410.854400-0.517885Observatorio Los Algarrobos, Salto
+I39 301.426610.823342-0.565652Observatorio Cruz del Sur, San Justo
+I40 289.260610.873472-0.485986La Silla--TRAPPIST
+I41 243.140220.836322+0.546875Palomar Mountain--ZTF
+I42 288.9081 0.74895 +0.66041 Westport Observatory
+I43 261.902370.846901+0.530084Tarleton State University Obs., Stephenville
+I44 273.5176 0.86201 +0.50521 Northwest Florida State College, Niceville
+I45 301.4281 0.82326 -0.56577 W Crusis Astronomical Observatory, San Justo
+I46 281.6108 0.76192 +0.64558 The Cottage Observatory, Altoona
+I47 290.5503 0.81526 -0.57753 Pierre Auger Observatory, Malargue
+I48 295.6757 0.80340 -0.59348 Observatorio El Catalejo, Santa Rosa
+I49 253.986170.813183+0.580617Sunflower Observatory, Santa Fe
+I50 254.471420.840712+0.540309P2 Observatory, Mayhill
+I51 283.0547 0.78133 +0.62203 Clinton
+I52 249.211080.845109+0.533609Steward Observatory, Mt. Lemmon Station
+I53 356.3783 0.79822 +0.60052 Armilla
+I54 353.030810.779853+0.623912Observatorio Las Vaguadas, Badajoz
+I55 359.642140.772769+0.632566Valencia
+I56 357.710660.801182+0.596429Observatorio Astronomico John Beckman, Almeria
+I57 359.3256 0.78579 +0.61646 Elche
+I58 359.5374 0.77206 +0.63345 Betera
+I59 356.1558 0.72754 +0.68377 Observatorio Fuente de los matos, Muriedas
+I60 357.1781 0.67397 +0.73630 Guernanderf
+I61 352.1494 0.74047 +0.66989 Ourense
+I62 356.426390.767072+0.639561Observatorio Helios Ontigola
+I63 358.8330 0.62944 +0.77446 Cygnus Observatory, New Airesford
+I64 359.293860.623532+0.779182Maidenhead
+I65 355.0796 0.80245 +0.59491 Yunquera
+I66 312.0000 0.96235 -0.27153 Taurus Australis Observatory, Brasilia
+I67 359.087530.626440+0.776870Hartley Wintney
+I68 312.4981 0.96931 -0.24573 Pousada dos Anoes Observatory
+I69 352.0069 0.85232 +0.52140 AGM Observatory, Marrakech
+I70 359.941580.604128+0.794217Gedney House Observatory, Kirton
+I71 353.6698 0.77330 +0.63205 Observatorio Los Milanos, Caceres
+I72 355.9849 0.75923 +0.64893 Observatorio Carpe-Noctem, Madrid
+I73 359.587110.670611+0.739353Salvia Observatory, Saulges
+I74 358.187390.629588+0.774337Baxter Garden Observatory, Salisbury
+I75 359.9650 0.76735 +0.63910 Observatorio Los Caracoles, Castello
+I76 355.936810.761573+0.646107Observatorio Tesla, Valdemorillo
+I77 316.0025 0.94119 -0.33714 CEAMIG-REA Observatory, Belo Horizonte
+I78 355.5721 0.80240 +0.59481 Observatorio Principia, Malaga
+I79 357.6733 0.78743 +0.61474 AstroCamp, Nerpio
+I80 358.133280.590762+0.804183Rose Cottage Observatory, Keighley
+I81 356.201110.533510+0.842967Tarbatness Observatory, Portmahomack
+I82 343.5797 0.88105 +0.47156 Guimar
+I83 353.1900 0.59630 +0.80008 Cherryvalley Observatory, Rathmolyon
+I84 353.0212 0.77967 +0.62415 Cerro del Viento, Badajoz
+I85 357.9848 0.80086 +0.59686 Las Negras
+I86 356.2739 0.76211 +0.64543 Observatorio UCM, Madrid
+I87 352.9593 0.60121 +0.79643 Astroshot Observatory, Monasterevin
+I88 356.0823 0.79287 +0.60753 Fuensanta de Martos
+I89 357.6739 0.78744 +0.61474 iTelescope Observatory, Nerpio
+I90 351.597600.618315+0.783298Blackrock Castle Observatory
+I91 357.692500.801192+0.596407Retamar
+I92 353.952890.795987+0.603315Astreo Observatory, Mairena del Aljarafe
+I93 359.797040.713717+0.698101St Pardon de Conques
+I94 356.1367 0.76162 +0.64603 Observatorio Rho Ophiocus, Las Rozas de Madrid
+I95 356.813940.771993+0.633666Observatorio de la Hita
+I96 356.503840.758233+0.649960Hyperion Observatory, Urbanizacion Caraquiz
+I97 359.501780.621889+0.780493Penn Heights Observatory, Rickmansworth
+I98 356.413390.757256+0.651181El Berrueco
+I99 356.460430.763221+0.644121Observatorio Blanquita, Vaciamadrid
+J00 359.5056 0.76880 +0.63744 Segorbe
+J01 354.284500.739938+0.670609Observatorio Cielo Profundo, Leon
+J02 359.5550 0.78391 +0.61884 Busot
+J03 355.132500.638787+0.766833Gothers Observatory, St. Dennis
+J04 343.488170.881471+0.471466ESA Optical Ground Station, Tenerife
+J05 355.296390.749617+0.659822Bootes Observatory, Boecillo
+J06 358.812470.604374+0.794039Trent Astronomical Observatory, Clifton
+J07 353.895430.767881+0.638546Observatorio SPAG Monfrague, Palazuelo-Empalme
+J08 359.6549 0.77127 +0.63439 Observatorio Zonalunar, Puzol
+J09 353.7917 0.59450 +0.80141 Balbriggan
+J10 359.598390.784437+0.618151Alicante
+J11 351.317690.746984+0.662617Matosinhos
+J12 356.510610.758248+0.649949Caraquiz
+J13 342.1208 0.87763 +0.47851 La Palma-Liverpool Telescope
+J14 345.992810.880303+0.472891La Corte
+J15 352.830610.755420+0.653125Muxagata
+J16 354.203560.584292+0.808826An Carraig Observatory, Loughinisland
+J17 357.203130.609723+0.790018Ragdon
+J18 356.906000.609920+0.789845Dingle Observatory, Montgomery
+J19 359.830360.764671+0.642359El Maestrat
+J20 356.219260.762019+0.645541Aravaca
+J21 356.080030.759065+0.649062El Boalo
+J22 342.132350.878415+0.476543Tacande Observatory, La Palma
+J23 358.493610.671765+0.738300Centre Astronomique de La Couyere
+J24 343.557190.881661+0.470499Observatorio Altamira
+J25 354.488830.728241+0.683076Penamayor Observatory, Nava
+J26 356.981190.612507+0.787898The Spaceguard Centre, Knighton
+J27 355.968990.760373+0.647528El Guijo Observatory
+J28 356.213810.791408+0.609366Jaen
+J29 346.342130.875695+0.481318Observatorio Nira, Tias
+J30 356.293000.761925+0.645666Observatorio Ventilla, Madrid
+J31 355.774110.802445+0.594759La Axarquia
+J32 352.977690.796769+0.602268Aljaraque
+J33 359.906000.620040+0.781953University of Hertfordshire Obs., Bayfordbury
+J34 355.227110.748695+0.660858La Fecha
+J35 356.029110.792167+0.608432Tucci Observatory, Martos
+J36 356.945190.765179+0.641659Observatorio DiezALaOnce, Illana
+J37 353.064690.796893+0.602104Huelva
+J38 353.609240.726887+0.684518Observatorio La Vara, Valdes
+J39 344.5636 0.88429 +0.46547 Ingenio
+J40 355.558470.802546+0.594601Malaga
+J41 353.8189 0.59779 +0.79897 Raheny
+J42 359.6989 0.77138 +0.63425 Puzol
+J43 352.133540.856441+0.515339Oukaimeden Observatory, Marrakech
+J44 357.6552 0.73506 +0.67596 Observatorio Iturrieta, Alava
+J45 344.467350.883626+0.466916Observatorio Montana Cabreja, Vega de San Mateo
+J46 346.3594 0.87569 +0.48131 Observatorio Montana Blanca, Tias
+J47 346.4440 0.87501 +0.48260 Observatorio Nazaret
+J48 343.6960 0.87977 +0.47393 Observatory Mackay, La Laguna
+J49 359.4482 0.78695 +0.61496 Santa Pola
+J50 342.1176 0.87764 +0.47847 La Palma-NEON
+J51 343.728980.879789+0.473809Observatorio Atlante, Tenerife
+J52 358.6608 0.74198 +0.66826 Observatorio Pinsoro
+J53 354.892780.791142+0.609607Posadas
+J54 343.4906 0.88149 +0.47142 Bradford Robotic Telescope
+J55 344.3144 0.88549 +0.46313 Los Altos de Arguineguin Observatory
+J56 344.4536 0.88416 +0.46624 Observatorio La Avejerilla
+J57 358.890890.767817+0.638833Centro Astronomico Alto Turia, Valencia
+J58 356.6644 0.62304 +0.77959 Brynllefrith Observatory, Llantwit Fardre
+J59 356.202560.726956+0.684386Observatorio Linceo, Santander
+J60 354.3406 0.74773 +0.66201 Tocororo Observatory, Arquillinos
+J61 353.4264 0.59719 +0.79942 Brownstown Observatory, Kilcloon
+J62 351.6345 0.59017 +0.80459 Kingsland Observatory, Boyle
+J63 359.4831 0.78548 +0.61683 San Gabriel
+J64 359.3459 0.78871 +0.61271 La Mata
+J65 353.4497 0.59830 +0.79860 Celbridge
+J66 357.7833 0.61071 +0.78922 Kinver
+J67 359.4667 0.77114 +0.63457 Observatorio La Puebla de Vallbona
+J68 357.7055 0.61813 +0.78345 Tweenhills Observatory, Hartpury
+J69 358.980340.631443+0.772863North Observatory, Clanfield
+J70 358.8404 0.78968 +0.61149 Obs. Astronomico Vega del Thader, El Palmar
+J71 357.8947 0.59350 +0.80217 Willow Bank Observatory
+J72 358.9664 0.79065 +0.61028 Valle del Sol
+J73 359.0833 0.6187  +0.7830  Quainton
+J74 357.0961 0.72950 +0.68169 Bilbao
+J75 357.434710.789388+0.612222OAM Observatory, La Sagra
+J76 358.797180.790771+0.610163La Murta
+J77 357.5947 0.63154 +0.77276 Golden Hill Observatory, Stourton Caundle
+J78 358.8244 0.78887 +0.61253 Murcia
+J79 358.380660.795516+0.603908Observatorio Calarreona, Aguilas
+J80 359.1083 0.70862 +0.70323 Sainte Helene
+J81 358.134890.735984+0.674878Guirguillano
+J82 357.3067 0.5935  +0.8021  Leyland
+J83 357.3883 0.59274 +0.80270 Olive Farm Observatory, Hoghton
+J84 358.9803 0.63144 +0.77285 South Observatory, Clanfield
+J85 357.4833 0.5666  +0.8213  Makerstoun
+J86 356.6153 0.79930 +0.59968 Sierra Nevada Observatory
+J87 355.5067 0.76047 +0.64753 La Canada
+J88 358.5592 0.63165 +0.77266 Strawberry Field Obs., Southampton
+J89 356.2861 0.76045 +0.64739 Tres Cantos Observatory
+J90 358.5317 0.62251 +0.78000 West Challow
+J91 357.0483 0.7411  +0.6692  Alt emporda Observatory, Figueres
+J92 359.3487 0.62214 +0.78031 Beaconsfield
+J93 357.7426 0.61927 +0.78255 Mount Tuffley Observatory, Gloucester
+J94 357.7886 0.61909 +0.78270 Abbeydale
+J95 358.553010.624152+0.778715Great Shefford
+J96 356.056690.735326+0.675690Observatorio de Cantabria
+J97 359.5333 0.7754  +0.6293  Alginet
+J98 359.5344 0.77275 +0.63259 Observatorio Manises
+J99 359.578080.772589+0.632790Burjassot
+K00   8.948360.642630+0.763639Hanau
+K01   0.620910.618636+0.783060Astrognosis Observatory, Bradwell
+K02   0.667610.622858+0.779718Eastwood Observatory, Leigh on Sea
+K03   0.744110.744133+0.665979Observatori AAS Montsec
+K04   0.744160.744130+0.665983Lo Fossil Observatory, Ager
+K05   1.023110.610689+0.789233Eden Observatory, Banham
+K06   1.999500.749658+0.659703Observatorio Montagut, Can Sola
+K07   2.4614 0.65973 +0.74902 Observatoire de Gravelle, St. Maurice
+K08   1.8800 0.75142 +0.65773 Observatorio Lledoner, Vallirana
+K09   2.2400 0.74889 +0.66051 Llica d'Amunt
+K10   5.4214 0.71851 +0.69332 Micro Palomar, Reilhanette
+K11   2.880790.697458+0.714390Observatoire de Pommier
+K12   2.7267 0.77121 +0.63447 Obsevatorio Astronomico de Marratxi
+K13   2.9124 0.77015 +0.63575 Albireo Observatory, Inca
+K14   2.9131 0.77090 +0.63485 Observatorio de Sencelles
+K15   3.755220.725152+0.686311Murviel-les-Montpellier
+K16   5.421060.718540+0.693283Reilhanette
+K17   7.026790.692802+0.718806Observatoire des Valentines, Bex
+K18   7.5242 0.67588 +0.73460 Hesingue
+K19   5.647310.720582+0.691187PASTIS Observatory, Banon
+K20   4.680150.642261+0.763954Danastro Observatory, Romeree
+K21   4.9292 0.72101 +0.69061 Saint-Saturnin-les-Avignon
+K22   5.076110.724222+0.687283Les Barres Observatory, Lamanon
+K23   9.4023 0.70168 +0.71014 Gorgonzola
+K24   6.860690.651487+0.756168Schmelz
+K25   5.7136 0.72157 +0.69014 Haute Provence Sud, Saint-Michel-l'Observatoire
+K26   6.2201 0.64965 +0.75775 Contern
+K27   6.2094 0.68296 +0.72816 St-Martin Observatory, Amathay Vesigneux
+K28   6.8947 0.63326 +0.77137 Sternwarte Eckdorf
+K29   7.783470.696415+0.715918Stellarium Gornergrat
+K30   7.148390.682674+0.728365Luscherz
+K31   7.003610.713656+0.698546Osservatorio Astronomico di Bellino
+K32   7.529640.716152+0.695733Maritime Alps Observatory, Cuneo
+K33   7.497610.715775+0.696117San Defendente
+K34   7.7005 0.70697 +0.70492 Turin
+K35   8.163690.639883+0.765937Huenfelden
+K36   8.248870.645167+0.761522Ebersheim
+K37   8.3148 0.70738 +0.70449 Cereseto
+K38   8.918240.697505+0.714297M57 Observatory, Saltrio
+K39   8.955560.714080+0.697844Serra Observatory
+K40   9.0135 0.66228 +0.74685 Altdorf
+K41   8.7930 0.71113 +0.70075 Vegaquattro Astronomical Obs., Novi Ligure
+K42   8.3332 0.65685 +0.75151 Knielingen
+K43   9.8389 0.69215 +0.71970 OVM Observatory, Chiesa in Valmalencom
+K44   9.973310.615161+0.785779Marienburg Sternwarte, Hildesheim
+K45  10.498140.733299+0.677639Oss. Astronomico di Punta Falcone, Piombino
+K46  10.9114 0.64561 +0.76115 Bamberg
+K47  10.688220.724257+0.687222BSCR Observatory, Santa Maria a Monte
+K48  10.838810.705714+0.706127Keyhole Observatory, San Giorgio di Mantova
+K49  11.185810.724381+0.687146Carpione Observatory, Spedaletto
+K50  11.133000.646903+0.760116Sternwarte Feuerstein, Ebermannstadt
+K51  11.657890.695636+0.716268Osservatorio del Celado, Castello Tesino
+K52   7.6478 0.70548 +0.70642 Gwen Observatory, San Francesco al Campo
+K53  12.045640.744479+0.665409Marina di Cerveteri
+K54  11.336780.728803+0.682494Astronomical Observatory University of Siena
+K55   7.765000.645586+0.761172Wallhausen
+K56  12.704970.732993+0.678008Osservatorio di Foligno
+K57  13.0444 0.69854 +0.71317 Fiore Observatory
+K58   7.4497 0.62655 +0.77685 Gevelsberg
+K59  13.277440.620411+0.781663Elsterland Observatory, Jessnigk
+K60  13.510690.568623+0.819848Lindby
+K61  13.6026 0.64741 +0.75967 Rokycany Observatory
+K62  13.846750.635514+0.769557Teplice Observatory
+K63  10.462520.719536+0.692195G. Pascoli Observatory, Barga (before June 2023)
+K64  11.743970.644963+0.761748Waizenreuth
+K65  12.2339 0.71879 +0.69290 Cesena
+K66  12.628610.750491+0.658684Osservatorio Astronomico di Anzio
+K67  13.3610 0.65835 +0.75036 Bayerwald Sternwarte, Spiegelau
+K68  14.905120.759709+0.648110Osservatorio Elianto, Pontecagnano
+K69  10.9941 0.62938 +0.77452 Riethnordhausen
+K70  15.9736 0.78375 +0.61901 Rosarno
+K71  12.2159 0.65748 +0.75101 Neutraubling
+K72  16.3396 0.77485 +0.63021 Celico
+K73  16.4158 0.75789 +0.65029 Gravina in Puglia
+K74  10.2364 0.64667 +0.76025 Muensterschwarzach Observatory, Schwarzach
+K75  11.7289 0.68897 +0.72269 Astro Dolomites, Santa Cristina Valgardena
+K76   7.628980.713488+0.698410BSA Osservatorio, Savigliano
+K77  11.2903 0.64680 +0.76019 EHB01 Observatory, Engelhardsberg
+K78   9.853560.718987+0.692718iota Scorpii Observatory, La Spezia
+K79  11.057890.631175+0.773097Erfurt
+K80  16.637330.610859+0.789111Platanus Observatory, Lusowko
+K81  13.785110.748666+0.660819P.M.P.H.R. Deep Sky Observatory, Atina
+K82  17.5894 0.75937 +0.64854 Alphard Observatory, Ostuni
+K83  11.043170.723487+0.688080Beppe Forti Astronomical Observatory, Montelupo
+K84  10.758610.718340+0.693581Felliscopio Observatory, Fellicarolo
+K85   6.031610.634354+0.770499Kelmis
+K86  10.181890.701516+0.710308Brescia
+K87  10.170110.646647+0.760288Dettelbach Vineyard Observatory
+K88  19.893670.671543+0.738689GINOP-KHK, Piszkesteto
+K89  11.563390.738665+0.671860Digital Stargate Observatory, Manciano
+K90  20.545770.714093+0.697776Sopot Astronomical Observatory
+K91  20.810190.845561-0.532618Sutherland-LCO A
+K92  20.810040.845561-0.532618Sutherland-LCO B
+K93  20.810110.845560-0.532620Sutherland-LCO C
+K94  20.810970.845561-0.532606Sutherland
+K95  20.811060.845555-0.532613MASTER-SAAO Observatory, Sutherland
+K96  16.751190.774870+0.630302Savelli Observatory
+K97   7.180260.664361+0.745050Freconrupt
+K98  17.072170.608205+0.7911426ROADS Observatory 1, Wojnowko
+K99  22.453500.663064+0.746102Derenivka Observatory
+L00  12.5375 0.74535 +0.66446 East Rome Observatory, Rome
+L01  13.749300.704742+0.707169Visnjan Observatory, Tican
+L02  20.816580.771051+0.634781NOAK Observatory, Stavraki
+L03  14.730810.671765+0.738393SGT Observatory, Gaflenz
+L04  23.596400.685544+0.725675ROASTERR-1 Observatory, Cluj-Napoca
+L05  10.0699 0.70093 +0.71089 Dridri Observatory, Franciacorta
+L06   9.254030.696280+0.715445Sormano 2 Observatory, Bellagio Via Lattea
+L07  14.564060.760166+0.647727Osservatorio Salvatore di Giacomo, Agerola
+L08  24.394470.497926+0.864325Metsahovi Optical Telescope, Metsahovi
+L09  20.809870.845559-0.532619Sutherland-LCO Aqawan A #1
+L10  22.6186 0.78943 +0.61203 Kryoneri Observatory
+L11  17.2092 0.50421 +0.86070 Sandvreten Observatory
+L12   2.677890.629068+0.774754Koksijde
+L13  25.621930.700409+0.711479Stardust Observatory, Brasov
+L14   4.922470.698669+0.713095Planetarium de Vaulx-en-Velin Observatory
+L15  25.978390.708234+0.703665St. George Observatory, Ploiesti
+L16  26.045610.705820+0.706098Stardreams Observatory, Valenii de Munte
+L17   2.7114 0.74071 +0.66964 Observatori Astronomic Albanya
+L18  26.718280.659348+0.749399QOS Observatory, Zalistsi
+L19  11.152580.716257+0.695653Osservatorio Felsina AAB, Montepastore
+L20  18.320690.722441+0.689239AG_Sarajevo Observatory, Sarajevo
+L21  27.421280.720179+0.691479Ostrov Observatory, Constanta
+L22  27.669530.692963+0.718573Barlad Observatory
+L23  27.8319 0.70211 +0.70968 Schela Observatory
+L24  27.9289 0.89882 -0.43743 Gauteng
+L25  14.437390.598174+0.798700Smolecin
+L26  11.810190.743368+0.666653Sanderphil Urban Observatory, Civitavecchia
+L27   5.647040.720583+0.69119729PREMOTE Observatory, Dauban
+L28  15.463390.758034+0.650341ISON-Castelgrande Observatory
+L29  18.0169 0.91802 -0.39574 Drebach-South Observatory, Windhoek
+L30   7.514690.624126+0.778737Lohbach Observatory, Benninghofen
+L31  12.856150.632524+0.772019RaSo Observatory, Chemnitz
+L32  20.810440.845576-0.532593Korea Microlensing Telescope Network-SAAO
+L33  29.9546 0.67379 +0.73646 Ananiv
+L34  14.020610.789742+0.611548Galhassin Robotic Telescope, Isnello
+L35  30.5086 0.64055 +0.76537 DreamSky Observatory, Lisnyky
+L36  14.780080.645319+0.761467Ondrejov--BlueEye600 Telescope
+L37 353.738830.803937+0.592739Observatorio Alnitak, El Puerto de Santa Maria
+L38   9.699970.615648+0.785407Gartensternwarte Schafsweide, Sehlde
+L39  11.040310.723062+0.688490Osservatorio Spica, Signa
+L40   6.956810.654011+0.754011Sternwarte Saarbruecken Rastpfuhl
+L41  12.301810.720683+0.691022Ponte Uso
+L42  11.5633 0.73670 +0.67400 Observatory-Astrocamp Manciano
+L43   0.744390.744131+0.665982Ager, Leida
+L44   6.221110.688185+0.723360AstroVal, Le Chenit
+L45  15.062430.793975+0.605979ObsCT, Catania
+L46 356.119390.762017+0.645574Observatorio Majadahonda
+L47  12.507110.725542+0.685961Osservatorio Astronomico, Piobbico
+L48  23.568730.674816+0.735566CNVL Observatory, Baia Mare
+L49  13.007300.671444+0.738747VEGA-Sternwarte, Dorfleiten
+L50  34.0114 0.71157 +0.70039 GenShtab Observatory, Nauchnyi
+L51  34.0164 0.71169 +0.70028 MARGO, Nauchnyi
+L52  34.016940.711679+0.700287MASTER-Tavrida
+L53   9.033810.699589+0.712226Lomazzo Observatory, Como
+L54  22.888780.700704+0.711156Berthelot Observatory, Hunedoara
+L55  35.087500.666222+0.743283Sura Gardens, Dnipro
+L56   8.058580.638960+0.766697Sternwarte Limburg, Limburg
+L57  26.904190.688762+0.722601Bacau Observatory, Bacau
+L58  30.571080.691710+0.719771Heavenly Owl observatory
+L59   1.226060.651546+0.756108Compustar Observatory, Rouen
+L60  30.697220.644961+0.761695Popovich Observatory, Ivanivka
+L61  20.810280.845575-0.532593MONET South, Sutherland
+L62  12.528890.719467+0.692209Hypatia Observatory, Rimini
+L63  11.009140.723671+0.687849HOB Observatory, Capraia Fiorentina
+L64   9.363140.701822+0.710005Martesana Observatory, Cassina de Pecchi
+L65   8.828310.602059+0.795784Bredenkamp Observatory, Bremen
+L66  20.811220.845577-0.532615MeerLICHT-1, Sutherland
+L67  37.798890.561057+0.825033Cherkizovo Observatory, Moscow Oblast
+L68  25.536830.830048-0.555874PESCOPE, Port Elizabeth
+L69  28.2142 0.90084 -0.43323 LaCaille Observatory, Pretoria
+L70  15.923330.698145+0.713600Zvjezdarnica Graberje, Zagreb
+L71  38.5839 0.71089 +0.70101 Vedrus Observatory, Azovskaya
+L72  38.6928 0.55979 +0.82589 Melezhy Astrophoto Observatory
+L73  11.261830.724459+0.687083Beato Ermanno Observatory, Impruneta
+L74  14.211090.757212+0.651048AstroColauri, Naples
+L75  26.463940.527292+0.846853Tartu Observatory of Tartu University
+L76  39.651610.683530+0.727483Nomad Observatory, Kochevanchik
+L77  39.820250.678927+0.731765RDSS, Kovalevka
+L78  14.7800 0.75943 +0.64844 San Marco Observatory, Salerno
+L79  18.220390.696477+0.715222BOSZA Observatory, Szalanta
+L80  18.0175 0.91802 -0.39574 SpringBok Observatory, Tivoli
+L81  16.361690.919631-0.392204Skygems Namibia Remote Observatory
+L82 352.679500.775227+0.629726Crow Observatory, Portalegre
+L83 356.222310.791355+0.609451UJA Observatory, Jaen
+L84  41.279890.695443+0.716182Kairos Observatory, Letnik
+L85  15.863250.766873+0.639830BiAnto Observatory, Lauria
+L86   9.2631 0.71140 +0.70062 Giordano Bruno Observatory, Brallo
+L87  16.361890.919631-0.392204Moonbase South Observatory, Hakos
+L88  16.5422 0.77721 +0.62746 Stazione Astronomica Le Pleiadi, Pantane
+L89  11.144390.722146+0.689445PAO, Prato
+L90  15.979490.784120+0.618560ABObservatory, Rosarno
+L91  13.8078 0.74776 +0.66189 Antares MTM Observatory, S. Donato
+L92  16.002110.781423+0.621967San Costantino
+L93   1.772210.752844+0.65601 Garraf Observatory, Sant Pere de Ribes
+L94 354.145610.728187+0.683146Observatorio MOMA, Oviedo
+L95 358.951590.793164+0.607000Observatorio Astronomico de Cartagena
+L96  44.2745 0.76340 +0.64416 ISON-Byurakan Observatory
+L97 357.991610.624666+0.778298Castle Fields Observatory, Calne
+L98 357.434250.789394+0.612232La Sagra Observatory, Puebla de Don Fadrique
+L99  30.602810.635913+0.769201Novosilky
+M00  26.211540.490116+0.868754Viestikallio, Artjarvi
+M02   0.863860.754439+0.654271Astropriorat Observatory
+M03   2.258220.750568+0.658591Badalona Boreal
+M04   1.4256 0.74764 +0.66207 Pujalt Observatory, Barcelona
+M05   1.331610.729979+0.681267Observatoire de la Nine, Canens
+M06   0.743810.744130+0.665983PeLe's Observatory, Ager
+M07  10.294470.594202+0.801641Siek
+M08   4.0381 0.62786 +0.77573 CHON, Stekene
+M09   5.600940.630164+0.773882Observatory Gromme - Oudsbergen
+M10   6.854110.724305+0.687343CPF Observatory, St Vallier de Thiey
+M11   5.647180.720589+0.691192Novaastro Observatory, Banon
+M12  47.8639 0.55891 +0.82648 Puschino
+M13   7.742500.662866+0.746267Lucie Berger Observatory, Strasbourg
+M14   8.789390.699981+0.711832Schiaparelli Gallarate Station
+M15   9.1506 0.70039 +0.71142 Virgo Oservatory, Seveso
+M16   9.773190.719401+0.692358Osservatorio Il Coreggiolo
+M17   9.809220.719163+0.692525SN1572 Tycho Observatory, La Spezia
+M18  11.839390.639618+0.766239Koeditz
+M19  13.883270.709976+0.701881Osservatorio Explorer, Pula
+M20  13.011690.690044+0.721515Polse di Cougnes Observatory, Zuglio
+M21  16.361440.919630-0.392206Schiaparelli Southern Observatory, Hakos
+M22  20.810590.845564-0.532612ATLAS South Africa, Sutherland
+M23  16.603500.679955+0.730852ELTE Gothard Observatory, Szombathely
+M24  16.200500.787195+0.614649La Macchina del Tempo, Ardore Marina
+M25  23.8283 0.47849 +0.87517 Einarin Observatory, Tampere
+M26  11.134940.723236+0.688304Zen Observatory, Scandicci
+M27  10.7175 0.72743 +0.68399 Elijah Observatory, Lajatico
+M28  20.810640.845568-0.532607Lesedi Telescope-SAAO Observatory, Sutherland
+M29  12.248640.718724+0.692984O.M.Ni.A. Observatory, Cesena
+M30  25.620000.700380+0.711516Zeta Aquarii Observatory, Brasov
+M31  26.212810.490130+0.868745Ursa Havaintokeskus,  Artjarvi
+M32  22.709190.665464+0.743964Sunny Transcarpathian, Mukachevo
+M33  34.763340.861632+0.506111OWL-Net, Mitzpe Ramon
+M34  17.273630.665591+0.743936AGO70, Astronomical Observatory, Modra
+M35  26.616690.688654+0.722734PS Observatory, Parjol
+M36  13.796470.699732+0.712090Opicina, Trieste
+M37  13.912430.696956+0.714892Astronomsko drustvo Nanos, Ajdovscina
+M38  21.767190.671089+0.738924Harsona Observatory, Nyiregyhaza
+M39  22.958880.760013+0.647750AUTH Observatory, Thessaloniki
+M40  31.827080.867372+0.496143OSTS-NRIAG, Kottamia
+M41  39.258270.930706+0.364567Jeddah
+M42  54.6708 0.90990 +0.41343 Emirates Observatory, Al Rahba
+M43  54.684780.912805+0.407034Al Sadeem Observatory, Abu Dhabi
+M44  54.920310.912502+0.407722Al-Khatim Observatory, Abu Dhabi
+M45  25.768890.697617+0.714205Starhopper Observatory, Sfantu Gheorghe
+M46  55.450330.905280+0.423399Althuraya Astronomy Center, Dubai
+M47  55.462050.904763+0.424484Sharjah Observatory, Sharjah
+M48  15.092220.794277+0.605535GAC - Via L. Sturzo Observatory, Catania
+M49  16.361720.919630-0.392206IAS Remote Observatory, Hakos
+M50  11.563750.738663+0.671862Virtual Telescope Project, Manciano
+M51   9.226970.655500+0.752709Robert Mayer Sternwarte, Heilbronn
+M52   8.578500.758941+0.649052Sassari
+M53  10.282190.585977+0.807623CAS Observatory, Preetz
+M54   7.077810.725140+0.686335Observatoire Albireo de Biot
+M55  19.987000.656685+0.751814Luckystar Observatory, Vazec
+M56   9.174830.700833+0.710985Varedo
+M57  14.020200.790651+0.610701Wide-field Mufara Telescope, Isnello
+M58  16.361330.919630-0.392207VdS Remote Observatory, Hakos
+M59   7.228830.680334+0.730616Rondchamp Observatory, Reconvilier
+M60  11.325540.717411+0.694492Virgil Observatory, Loiano
+M61   6.585810.624893+0.778108Observatory Moers Kapellen
+M62   7.134170.679741+0.731214Lajoux Observatory
+M63  18.369690.768886+0.637286RPF Observatory, Gagliano del Capo
+M64   0.239640.631065+0.773170Holbrook, Heathfield
+M65  28.324940.485072+0.871558Mustola Observatory, Lappeenranta
+M66  32.840190.820917+0.569526SNX-NET, Prodromos
+M68  37.830520.563964+0.823064School 1502 Rooftop Obs., Moscow
+M70  26.404090.875173-0.482645BOOTES-6, Bloemfontein
+M75  39.511550.699085+0.712651Online observatory, Peschany
+M77  39.965530.718110+0.693769Mezmay Comet Search Center
+M90  65.4286 0.54672 +0.83452 Chervishevo
+N27  73.7253 0.57847 +0.81298 Omsk-Yogik Observatory
+N30  74.3694 0.85369 +0.51909 Zeds Astronomical Observatory, Lahore
+N31  74.444220.853321+0.519690Eden Astronomical Observatory, Lahore
+N42  76.971810.732126+0.679511Tien-Shan Astronomical Observatory
+N43  77.1167 0.16712 -0.98328 Plateau Observatory for Dome A, Kunlun Station
+N44  77.139310.785023+0.617693Shache Station, Langan Village
+N50  78.963830.842176+0.538692Himalayan Chandra Telescope, IAO, Hanle
+N51  78.964610.842178+0.538687GROWTH India Telescope, IAO, Hanle
+N54  80.026740.846505+0.532071Purple Mountain Observatory, Jiama'erdeng
+N55  80.026230.846497+0.532089Corona Borealis Observatory, Ngari, Tibet
+N56  80.026750.846503+0.532073Jiama'erdeng Tianwentai, Ali, Tibet
+N57  80.046000.846724+0.531820YLT, NAOC
+N82  85.954940.641844+0.764450Multa Observatory
+N83  86.235040.749549+0.659927LW-1, NAOC-Korla
+N86  87.178520.727070+0.684719Xingming Observatory-KATS, Nanshan
+N87  87.175030.727076+0.684720Nanshan Station, Xinjiang Observatory
+N88  87.173220.727098+0.684697Xingming Observatory #3, Nanshan
+N89  87.179060.727107+0.684682Xingming Observatory #2, Nanshan
+N94  88.727920.675788+0.734831Altay Astronomical Observatory
+O02  90.526140.866434+0.498958Galaxy Tibet YBJ Observatory,Yangbajing
+O17  93.886690.783127+0.620730Purple Mountain Observatory, Lenghu-1
+O18  93.895220.782966+0.621021WFST, Lenghu
+O37  98.485530.948521+0.316891TRT-NEO, Chiangmai
+O39 100.031050.894458+0.446769BOOTES-4, Lijiang
+O40 100.228610.875727+0.482435Xingyuan, Daocheng
+O41  99.465560.949569+0.312613Choakanan Observatory, Lampang
+O42 100.029000.894239+0.447183Gaomeigu Gemini Observatory, LiJiang
+O43  99.781110.994005+0.109127Observatori Negara, Langkawi
+O44 100.029730.894468+0.446765Lijiang Station, Yunnan Observatories
+O45 100.032610.894444+0.446808Yunnan-HK Observatory, Gaomeigu
+O46 100.226640.875738+0.482415Daocheng Glacier Observatory
+O47 101.134150.902535+0.429998Yunling Observatory, Yunnan
+O48 101.181540.903223+0.428442Purple Mountain Observatory, Yaoan (0.8-m)
+O49 101.181110.903206+0.428474Purple Mountain Observatory, Yaoan Station
+O50 101.439420.998617+0.052565Hin Hua Observatory, Klang
+O51 101.278690.975556+0.218996Akin Observatory, Rayong
+O52 100.729720.972224+0.233250Astro820, Samut Prakan
+O53 101.404030.967655+0.251610Pakchong, Nachonratchasima
+O54 100.949390.973370+0.228460TSky Observatory, Chonburi
+O55 101.854500.999100+0.042381Telok Kemang Observatory, Port Dickson
+O56 101.454550.967528+0.252097Jaichalad-Pailin Observatory
+O68 105.330900.793121+0.607347LW-2, NAOC-Zhongwei
+O72 106.334760.672017+0.738399OWL-Net, Songino
+O75 107.051800.672284+0.738151ISON-Hureltogoot Observatory
+O85 109.213000.826583+0.561181LiShan Observatory, Lintong
+P07 114.089870.928304-0.370597Space Surveillance Telescope, HEH Station
+P13 115.573330.769058+0.637315Baihuashan Observatory, Beijing
+P14 115.811670.848989-0.526638Nedlands Observatory, Perth
+P18 116.610830.757010+0.651328Birch Forest Observatory, LaBaGouMen
+P21 117.281460.850540-0.5242466R-AUS1, Youndegin
+P22 117.575880.762782+0.644702LW-3, NAOC-Xinglong
+P25 118.312740.910976+0.411089Kinmen Educational Remote Observatory, Jincheng
+P30 119.597080.862775+0.504181Jiangnantianchi Observatory, Anji
+P31 119.597360.862772+0.504189Starlight Observatory, Tianhuangping
+P34 120.320310.855040+0.516826Lvye Observatory, Suzhou
+P35 120.556990.913398+0.405722Cuteip Remote Observatory, Changhua
+P36 120.626690.855207+0.516553ULTRA Observatory,Suzhou
+P37 120.639720.912980+0.406672HuiWen High School Observatory, Taichung City
+P38 120.714290.927137+0.373477Checheng Elementary School Observatory
+P40 121.539580.905916+0.422185Chinese Culture University, Taipei
+P41 121.7860 0.797583+0.601303Merak, NAOC
+P48 123.324030.258064-0.963413ASTEP, Concordia Station
+P61 126.330470.722664+0.688958Jilin Observatory
+P63 126.847500.817778+0.573621GSA Observatory, Gwangju
+P64 127.004890.796371+0.602805GSHS Observatory, Suwon
+P65 127.375680.805889+0.590124OWL-Net, Daedeok
+P66 127.446750.824763+0.563603Deokheung Optical Astronomy Observatory
+P67 127.7415 0.79040 +0.61057 Kangwon National University Observatory
+P68 127.474400.806556+0.589222DDSHS Biryong Observatory
+P71 128.761080.815026+0.577520Miryang Arirang Astronomical Observatory
+P72 128.975950.808423+0.586939OWL-Net, Mt. Bohyun
+P73 129.0820 0.81744 +0.57412 BSH Byulsem Observatory, Busan
+P87 132.094190.830358+0.555374Hirao Observatory, Yamaguchi
+P93 133.544330.823371+0.565729Space Tracking and Communications Center, JAXA
+Q02 135.493440.825315+0.562809Sakai Observatory, Osaka
+Q06 136.495470.816116+0.575990Tarui Observatory, Tarui
+Q10 137.329440.821623+0.568142Toyokawa Observatory
+Q11 137.520690.820236+0.570158Shinshiro
+Q12 137.825360.805147+0.591292Nagano Observatory
+Q19 139.4390 0.81430 +0.57852 Machida
+Q20 139.570080.824585-0.563856Swan Reach Imaging, Glenalta
+Q21 139.853350.804747+0.591654Southern Utsunomiya
+Q22 140.341920.827286-0.559911SNX-NET, Moorook
+Q23 140.3864 0.79654 +0.60264 Sukagawa
+Q24 140.523500.810991+0.583108Katori
+Q33 142.482780.715989+0.695814Nayoro Observatory, Hokkaido University
+Q38 143.5506 0.81654 -0.57538 Swan Hill
+Q54 147.287720.739290-0.671278Harlingten Telescope, Greenhill Observatory
+Q55 149.061420.855643-0.516191SkyMapper, Siding Spring
+Q56 148.976420.821480-0.568478Heaven's Mirror Observatory, Yass
+Q57 149.061730.855649-0.516175Korea Microlensing Telescope Network-SSO
+Q58 149.070850.855632-0.516199Siding Spring-LCO Clamshell #1
+Q59 149.070810.855626-0.516197Siding Spring-LCO Clamshell #2
+Q60 149.069000.855626-0.516198ISON-SSO Observatory, Siding Spring
+Q61 149.0619 0.85564 -0.51618 PROMPT, Siding Spring
+Q62 149.064420.855629-0.516206iTelescope Observatory, Siding Spring
+Q63 149.070640.855632-0.516202Siding Spring-LCO A
+Q64 149.070780.855632-0.516202Siding Spring-LCO B
+Q65 149.193130.855519-0.516201Warrumbungle Observatory
+Q66 149.064250.855627-0.516205Siding Spring-Janess-G, JAXA
+Q67 149.492330.835816-0.547369JBL Observatory, Bathurst
+Q68 150.337420.832917-0.551813Blue Mountains Observatory, Leura
+Q69 150.449330.832777-0.551945Hazelbrook
+Q70 150.500440.919153-0.392623Glenlee Observatory, Glenlee
+Q71 149.069800.855626-0.516205SNX-NET, Siding Spring
+Q73 151.648940.841722-0.538113Buckthorn, Thornton
+Q78 152.947890.886807-0.460619Woogaroo Observatory, Forest Lake
+Q79 152.8481 0.88871 -0.45696 Samford Valley Observatory
+Q80 153.2160 0.88762 -0.45904 Birkdale
+Q81 153.096220.893194-0.448181Caloundra West
+R56 170.483890.720473-0.691324Scott Street Observatory, Lake Tekapo
+R57 170.472780.720489-0.691309Aorangi Iti Observatory, Lake Tekapo
+R58 170.490390.697579-0.714138Beverly-Begg Observatory, Dunedin
+R65 172.349810.726556-0.684830R. F. Joyce Observatory, Christchurch
+R66 172.587610.726587-0.684777Mooray Observatory, Christchurch
+R78 175.091040.788021-0.613626Crystal Lake Observatory, Ngutunui
+T02 203.495720.934614+0.354517SNX-NET, Wailuku
+T03 203.742470.936240+0.351538Haleakala-LCO Clamshell #3
+T04 203.742490.936241+0.351538Haleakala-LCO OGG B #2
+T05 203.742990.936236+0.351547ATLAS-HKO, Haleakala
+T07 204.423870.943290+0.332467ATLAS-MLO Auxiliary Camera, Mauna Loa
+T08 204.423950.943290+0.332467ATLAS-MLO, Mauna Loa
+T09 204.523960.941711+0.337239Subaru Telescope, Maunakea
+T10 204.522410.941706+0.337212Submillimeter Array, Maunakea (SMA)
+T11 204.529650.941734+0.337191United Kingdom Infrared Telescope, Maunakea
+T12 204.530540.941733+0.337201University of Hawaii 88-inch telescope, Maunakea
+T13 204.527970.941707+0.337251NASA Infrared Telescope Facility, Maunakea
+T14 204.531090.941717+0.337240Canada-France-Hawaii Telescope, Maunakea
+T15 204.530930.941728+0.337214Gemini North Observatory, Maunakea
+T16 204.525260.941708+0.337246W. M. Keck Observatory, Keck 1, Maunakea
+T17 204.525740.941704+0.337256W. M. Keck Observatory, Keck 2, Maunakea
+T35 210.390200.953686-0.299837Astronomical Society of Tahiti
+U52 237.451000.749240+0.660270Shasta Valley Observatory, Grenada
+U53 237.1603 0.70274 +0.70909 Murray Hill Observatory, Beaverton
+U54 237.312860.782952+0.620081Hume Observatory, Santa Rosa
+U55 237.414560.653977+0.753984Golden Ears Observatory, Maple Ridge
+U56 237.869170.795044+0.604511Palo Alto
+U57 237.841280.795776+0.603616Black Mountain Observatory, Los Altos
+U63 239.194560.681217+0.729770Burnt Tree Hill Observatory, Cle Elum
+U64 239.461510.683272+0.727821CWU-Lind Observatory, Ellensburg
+U65 239.459830.683247+0.727841CWU Observatory, Ellensburg
+U67 240.203580.776325+0.628595Jack C. Davis Observatory, Carson City
+U68 240.587010.799040+0.599620JPL SynTrack Robotic Telescope, Auberry
+U69 240.5870 0.79904 +0.59962 iTelescope SRO Observatory, Auberry
+U70 240.5869 0.79904 +0.59962 RASC Observatory, Alder Springs
+U71 241.3633 0.82520 +0.56305 AHS Observatory, Castaic
+U72 241.460000.828150+0.558687Tarzana
+U73 241.6172 0.83164 +0.55346 Redondo Beach
+U74 240.587200.799040+0.599619JPL SynTrack Robotic Telescope 2, Auberry
+U75 242.183660.833735+0.550383Newport Beach
+U76 242.1279 0.82855 +0.55810 Maury Lewin Observatory, Glendora
+U77 242.9181 0.84002 +0.54076 Rani Observatory, San Diego
+U78 242.8449 0.82758 +0.55989 Cedar Glen Observatory
+U79 242.791870.838837+0.542598Cosmos Research Center, Encinitas
+U80 243.6151 0.82737 +0.56004 CS3-DanHenge Observatory, Landers
+U81 243.615140.827367+0.560037CS3-Trojan Station, Landers
+U82 243.615190.827368+0.560036CS3-Palmer Divide Station, Landers
+U83 243.573110.841238+0.53938 Mount Laguna Observatory
+U86 244.535560.857900+0.512937BOOTES-5, Bajo California
+U93 246.287610.791740+0.609209Skygems Dreamscope Utah, Beryl Junction
+U94 246.302500.792006+0.608864iTelescope Observatory, Beryl Junction
+U96 246.686000.579007+0.812698Athabasca University Geophysical Observatory
+U97 248.332920.818306+0.573452JPL SynTrack Robotic Telescope 3, Flagstaff
+U98 249.743000.849529+0.526090NAC Observatory, Benson
+U99 247.8537 0.829354+0.557017BCC Observatory, Black Canyon City
+V00 248.399810.849456+0.526492Kitt Peak-Bok
+V01 248.239110.762243+0.645493Mountainville Observatory, Alpine
+V02 248.057940.835743+0.547377Command Module, Tempe
+V03 248.3314 0.79889 +0.59979 Big Water
+V04 248.463310.819378+0.571927FRoST, Anderson Mesa
+V05 248.631950.836631+0.546101Rusty Mountain Observatory, Gold Canyon
+V06 249.267450.845313+0.533209Catalina Sky Survey-Kuiper
+V07 249.1219 0.85208 +0.52234 Whipple Observatory, Mount Hopkins-PAIRITEL
+V08 249.339000.848249+0.528126Mountain Creek Ranch, Vail
+V09 249.742020.849537+0.526080Moka Observatory, Benson
+V10 248.327720.818623+0.572977Sierra Sinagua Observatory, Flagstaff
+V11 249.211190.847025+0.530011Saguaro Observatory, Tucson
+V12 249.398190.852110+0.522050Elgin
+V13 248.782780.762335+0.645641Little Moose Observatory, Timber Lakes
+V14 248.783360.762292+0.645691Moose Springs Observatory, Timber Lakes
+V15 249.210690.845110+0.533602OWL-Net, Mt. Lemmon
+V16 251.102880.849510+0.526194Dark Sky New Mexico, Animas
+V17 248.983190.845476+0.532429Leo Observatory, Tucson
+V18 249.6181 0.85776 +0.51308 MASTER-OAGH Observatory, Sonora
+V19 251.790860.841371+0.539217Whiskey Creek Observatory
+V20 251.778220.827004+0.560943Killer Rocks Observatory, Pie Town
+V21 251.102310.849511+0.526188Cewanee Observatory at DSNM
+V22 251.815500.827009+0.560941Insight Remote Observatory, Pie Town
+V23 252.764060.828722+0.558332FOAH Observatory, Magdalena
+V24 250.484030.850261+0.525020Sonoran Desert Skies Observatory, Pearce
+V25 253.301940.846331+0.531305Tortugas Mountain Observatory, Las Cruces
+V26 253.390200.911283+0.410639UAS-ISON Observatory, Cosala
+V27 253.718190.811354+0.583180North Mesa Observatory, Los Alamos
+V28 254.346470.817018+0.575271Deep Sky West Observatory, Rowe
+V29 254.266600.840062+0.541466Tzec Maun Cloudcroft Facility
+V30 254.471050.840710+0.540313Heaven on Earth Observatory, Mayhill
+V31 254.4750 0.84061 +0.54046 Hazardous Observatory, Mayhill
+V32 254.471310.840709+0.540308Canvas View New Mexico Skies, Mayhill
+V33 254.720390.806382+0.590114Finlaystone Observatory, Angel Fire
+V34 255.369920.778401+0.626222Baker Observatory, Black Forest
+V35 255.918810.861839+0.506046Deep Sky Observatory Collaborative, Pier 5
+V36 255.617420.843042+0.536333The Ranch Observatory, Lakewood
+V37 255.984830.861053+0.507428McDonald Observatory-LCO ELP
+V38 255.984930.861051+0.507431McDonald Observatory-LCO ELP Aqawan A #1
+V39 255.984830.861053+0.507427McDonald Observatory-LCO ELP B
+V40 255.918730.861839+0.506046Divine Creation Observatory, Fort Davis
+V41 256.725780.719992+0.691890Rapid City
+V42 254.474720.840614+0.540448Dimension Point, Mayhill
+V43 250.4842 0.85026 +0.52502 Chiricahua Skies Observatory, Sunizona
+V44 251.829830.827057+0.560864Coyote Watcher, Pie Town
+V54 259.692190.936737+0.349756Observatoire LAURIER, El Marques
+V56 260.304030.849505+0.525995Stonehenge Observatory, Novice
+V57 260.617730.853050+0.520209Starfront Observatories, Rockwood
+V58 260.734970.868735+0.493762Medina Dome, Medina
+V59 261.0734 0.86642 +0.49781 Millwood Observatory, Comfort
+V60 261.094730.862140+0.505126Putman Mountain Observatory
+V61 261.057100.858216+0.511725Shed of Science South, Pontotoc
+V62 261.056610.858216+0.511726Live Oak Observatory, Pontotoc
+V63 261.057280.858219+0.511721Tara Observatory, Cherokee
+V70 263.335720.870056+0.491332Starry Night Observatory, Columbus
+V72 263.890110.752696+0.656235JDP Observatory, Omaha
+V74 264.156890.869320+0.492598Katy Observatory, Katy
+V75 264.565780.874931+0.482617Live Oak Observatory, Lake Jackson
+V78 265.107800.700141+0.711688Spirit Marsh Observatory. Sauk Centre
+V81 265.7604 0.80902 +0.58590 Fayetteville
+V83 266.257280.781733+0.621590Rolling Hills Observatory, Warrensburg
+V86 266.8927 0.78221 +0.62099 Rattle Snake Observatory, Sedalia
+V88 267.428110.820618+0.569618River Ridge Observatory, Conway
+V92 268.349830.817712+0.573711White County Observatory, Searcy
+V93 268.616110.759765+0.648058Pin Oak Observatory, Fort Madison
+V94 268.661690.759876+0.647933Cherokeeridge Observatory, Fort Madison
+W04 271.009440.761606+0.645927Mark Evans Observatory, Bloomington
+W05 271.267190.836205+0.546596Tree Gate Farm Observatory, Starkville
+W08 271.883310.747086+0.662545Jimginny Observatory, Naperville
+W09 272.147530.752886+0.655985Willowed Plains Observatory, Manteno
+W11 272.6247 0.75272 +0.65618 Northwest Indiana Robotic Telescope, Lowell
+W13 273.473610.778448+0.625642Star Quarry Observatory, Bedford
+W14 273.245110.821914+0.567774Harvest
+W15 273.190830.810875+0.583314Wayne Observatory, Franklin
+W16 273.768690.822976+0.566292Pleasant Groves Observatory
+W17 273.771220.765700+0.641103Arrowhead, Sheridan
+W18 274.249620.767039+0.639505Red Fox Observatory, Pendleton
+W19 274.372830.740783+0.669559Kalamazoo
+W22 275.004470.844595+0.533635WestRock Observatory, Columbus
+W23 275.380190.772786+0.632594Hevonen Farm Observatory, Oxford
+W24 275.238170.722574+0.689025Shamrock Banks Observatory, Clare
+W25 275.635060.776417+0.628165RMS Observatory, Cincinnati
+W28 276.3883 0.83011 +0.55581 Ex Nihilo Observatory, Winder
+W29 276.9939 0.76659 +0.64004 Adena Brook Observatory, Columbus
+W30 276.771170.838735+0.542749Georgia College Observatory, Milledgeville
+W31 277.237360.834226+0.549613Deerlick Observatory, Crawfordville
+W32 277.237500.834222+0.549619Crawfordville Observatory
+W33 277.834510.819315+0.571499Transit Dreams Observatory, Campobello
+W34 277.8453 0.81784 +0.57360 Squirrel Valley Observatory, Columbus
+W35 278.039100.856610+0.514230Buffalo Creek Observatory, Nahunta
+W38 278.585310.807479+0.588163Dark Sky Observatory, Boone
+W42 279.465710.885510+0.463056Mind's Eye Observatory, Vero Beach
+W44 286.220160.755635+0.652808Duo Ursi de Saltu, Scarsdale
+W45 283.938270.802431+0.594736Benito Loyola Observatory, Virginia Beach
+W46 280.411920.818614+0.572448Foxfire Village
+W47 289.235010.862850-0.504261SNX-NET, Rio Hurtado
+W48 280.887000.811693+0.582156BKH Observatory, Chapel Hill
+W49 281.067570.778794+0.625380CBA-MM Observatory, Mountain Meadows
+W50 281.254040.813127+0.580167Apex
+W51 287.565440.755204+0.653287Custer Institute and Observatory
+W52 283.514190.778335+0.625736US Naval Academy Hopper Hall Observatory
+W53 282.315240.771140+0.634559Hagerstown
+W54 282.289440.785431+0.616890Mark Slade Remote Observatory, Wilderness
+W55 282.583890.773703+0.631447Natelli Observatory, Frederick
+W56 282.525830.773143+0.632153Pineapple Observatory, Frederick
+W57 289.260940.873475-0.486000ESA TBT La Silla Observatory
+W58 283.149640.777667+0.626574ALPHA Observatory, South Laurel
+W59 284.107580.757005+0.651302The Dark Side Observatory, Weatherly
+W60 286.366260.995574+0.097155AstroExplor Observatory, Tinjaca
+W61 283.744920.713380+0.698447Leeside Observatory, Elgin
+W62 284.137610.758729+0.649276Comet Hunter Observatory2, New Ringgold
+W63 284.309580.996767+0.082976Observatorio Astronomico UTP, Pereira
+W64 285.270040.768364+0.637863Red Lion Observatory, Southampton Twsp
+W65 284.791690.697761+0.713966Observatoire GOZ, Montpellier
+W66 285.053810.756278+0.652109SVH Observatory, Blairstown
+W67 285.102110.759453+0.648444Paul Robinson Observatory, Voorhees State Park
+W68 289.235020.862845-0.504269ATLAS Chile, Rio Hurtado
+W69 285.985000.759912+0.647855OLPH Observatory, Brooklyn
+W70 285.913860.698475+0.713264Loose Goose Observatory, Saint-Jerome
+W71 285.992970.717404+0.694456Rand II Observatory, Lake Placid
+W72 286.8211 0.75302 +0.65580 Trumbull Observatory, Trumbull
+W73 289.321560.957949-0.287797Observatorio Astronomico de Moquegua, Carumas
+W74 289.262450.873451-0.486040Danish Telescope, La Silla
+W75 289.609440.910001-0.414150SPECULOOS-South Observatory, Paranal
+W76 289.236950.862826-0.504288CHILESCOPE Observatory, Rio Hurtado
+W77 287.4010 0.75196 +0.65702 Skyledge Observatory, Killingworth
+W78 288.883250.739859+0.670509Clay Telescope, Harvard University
+W79 289.195350.865587-0.499763Cerro Tololo-LCO Aqawan B #1
+W80 288.7678 0.74138 +0.66885 Westwood
+W81 288.999670.724557+0.686948Nebula Knoll Observatoy, East Wakefield
+W82 288.878040.736419+0.674274Mendel Observatory, Merrimack College
+W83 288.697470.740821+0.669461Whitin Observatory, Wellesley
+W84 289.193580.865572-0.499793Cerro Tololo-DECam
+W85 289.195190.865591-0.499760Cerro Tololo-LCO A
+W86 289.195330.865592-0.499759Cerro Tololo-LCO B
+W87 289.195320.865591-0.499761Cerro Tololo-LCO C
+W88 289.465700.837136-0.545574Slooh.com Chile Observatory, La Dehesa
+W89 289.195330.865589-0.499764Cerro Tololo-LCO Aqawan A #1
+W90 289.058140.732740+0.678229Phillips Exeter Academy Grainger Observatory
+W91 289.602570.910007-0.414148VHS-VISTA, Cerro Paranal
+W92 290.673570.850987-0.524150MASTER-OAFA Observatory, San Juan
+W93 289.196000.865589-0.499755Korea Microlensing Telescope Network-CTIO
+W94 291.820190.921646-0.387713MAP, San Pedro de Atacama
+W95 291.820120.921639-0.387712Observatorio Panameno, San Pedro de Atacama
+W96 291.820060.921637-0.387717CAO, San Pedro de Atacama (since 2013)
+W97 291.820240.921638-0.387716Atacama Desert Observatory, San Pedro de Atacama
+W98 291.820300.921639-0.387712Polonia Observatory, San Pedro de Atacama
+W99 291.820150.921638-0.387716SON, San Pedro de Atacama Station
+X00 292.601250.910349-0.413802Observatorio Astronomico Tolar
+X01 289.235020.862846-0.504270Observatory Hurtado, El Sauce
+X02 289.235170.862833-0.504255Telescope Live, El Sauce
+X03 289.203610.862286-0.505209Observatoire SADR, Poroto
+X04 291.567470.664264+0.745000MCD Observatory, Saint-Anaclet
+X05 289.250580.864981-0.500958Simonyi Survey Telescope, Rubin Observatory
+X06 289.146490.862374-0.505110Skygems Chile, Rio Hurtado
+X07 289.146390.862374-0.505109iTelescope Deep Sky Chile, Rio Hurtado
+X08 289.235000.862852-0.504255ShAO Chile station, El Sauce
+X09 289.146700.862375-0.505108Deep Random Survey, Rio Hurtado
+X10 291.820400.921644-0.387717OVTLN, San Pedro de Atacama
+X11 289.596040.909953-0.414324VLT Survey Telescope, Paranal
+X12 295.712000.803430-0.593455Observatorio Los Cabezones
+X13 295.4498 0.85269 -0.52103 Observatorio Remoto Bosque Alegre
+X14 295.832220.854475-0.517879Observatorio Orbis Tertius, Cordoba
+X15 291.820530.921647-0.387711ABYO, San Pedro de Atacama
+X16 293.8497 0.95511 -0.29667 Astronomia Sigma Octante, Cochabamba
+X17 289.262080.873456-0.486033BlackGEM
+X18 291.820530.921646-0.3877106R-POL2, San Pedro de Atacama
+X19 290.673830.850988-0.524154Santel Observatory, El Leoncito
+X20 291.820510.921646-0.387713BOOTES-7, San Pedro Atacama
+X21 289.146810.862374-0.505109RoSaMund Obervatory - DSC, Rio Hurtado
+X31 299.479340.850485-0.524263Galileo Galilei Observatory, Oro Verde
+X33 299.990390.998647-0.051941OARU, Manaus
+X38 301.137110.825648-0.562299Observatorio Pueyrredon, La Lonja
+X39 301.1378 0.82615 -0.56158 Observatorio Antares, Pilar
+X40 301.616890.822572-0.566762Cielos de Banfield, Banfield
+X50 303.824190.821025-0.568999Observatorio Astronomico de Montevideo
+X57 305.406260.903659-0.426885Polo Astronomico CMF,Foz do Iguacu
+X60 306.425560.895232-0.444317Guaraciaba Observatory
+X70 308.433220.931623-0.362375Observatorio OATU, Tupi Paulista
+X72 308.878890.868775-0.493560Waccobs, Sao Leopoldo
+X74 309.494220.931569-0.362525Observatorio Campo dos Amarais
+X77 309.924750.900184-0.434346Centro Astron. Nevoeiro, Antonio Olinto
+X86 312.218330.918367-0.394621Ottoservatorio, Tatui
+X87 312.0889 0.96218 -0.27210 Dogsheaven Observatory, Brasilia
+X88 312.491310.918012-0.395458Observatorio Adhara, Sorocaba
+X89 312.217860.962401-0.271311Rocca Observatory, Brasilia
+X90 312.132080.963322-0.268189Carina Observatory, Brasilia
+X91 312.788810.917193-0.397452Orion-Colesanti observatory, Mairinque
+X93 313.6047 0.92363 -0.38244 Munhoz Observatory
+Y00 315.215040.935906-0.351562SONEAR Observatory, Oliveira
+Y01 316.015800.940890-0.337985SONEAR 2 Observatory, Belo Horizonte
+Y05 316.310000.941320-0.337075SONEAR Wykrota-CEAMIG, Serra da Piedade
+Y16 318.687940.929268-0.368170ROCG, Campos dos Goytacazes
+Y28 321.3126 0.98840 -0.15179 OASI, Nova Itacuruba
+Y40 324.038890.989706-0.143217Discovery Observatory, Caruaru
+Y63 352.133680.856447+0.515346SNX-NET, Oukaimeden
+Y64 343.489610.881484+0.471433Transient Survey Telescope (TST), Teide
+Y65 343.490420.881484+0.471429Two-Meter Twin Telescope, TTT1, Teide
+Y66 343.490530.881484+0.471429Two-Meter Twin Telescope, TTT2, Teide
+Y67 352.132920.856451+0.515335High Atlas Window to the Kosmos,Oukaimeden
+Y68 343.490760.881482+0.471432Two-Meter Twin Telescope, TTT3, Teide
+Y70 353.372380.786766+0.615329ApolloIV5, Fregenal de la Sierra
+Y71 353.372510.786768+0.615327Makroskooppi, Fregenal de la Sierra
+Y75 354.581280.786275+0.615972Abraham Zacut, Salamanca
+Y76 359.791890.770614+0.635186Observatorio NovaCanet, Canet de Berenguer
+Y77 356.388580.758313+0.649939Cotos de Monterrey, Venturada
+Y78 359.466170.773792+0.631365Tros Alt
+Y79 359.992700.701911+0.709914Observatoire de la grande vallee
+Y80 357.166420.673761+0.736498Brenehuen, Grand-Champ
+Y81 356.5733 0.56175 +0.82456 Forthimage, Edinburgh
+Y82 358.065480.630258+0.773810LPMR Observatory, Broad Chalke
+Y83 359.047610.748699+0.660768Observatorio Arcosur, Zaragoza
+Y84 358.119720.665503+0.743909Observatoire de Saint Domineuc
+Y85 351.853890.727084+0.684321Magalofes Observatory, Fene
+Y86 357.480030.796010+0.603469Observatorio de Seron
+Y87 353.011940.741821+0.668656Trevinca Skies-Amalthea, Trevinca
+Y88 353.011940.741819+0.668659ASERO, Valdin
+Y89 353.011890.741825+0.668670Proxima Centauri Observatory, Valdin
+Y90 354.5553 0.73015 +0.68115 Observatorio ESTELIA, Ladines
+Y91 354.833500.802497+0.594854Ras Algethi, Ronda
+Y92 354.534820.787182+0.614800JD Cassini, Piconcillo
+Y93 355.433220.746699+0.663112Observatorio Azahar, Valoria la Buena
+Y94 354.585710.732833+0.678415LCB Lugueros observatory, Valdelugueros
+Y95 357.998640.785356+0.617157Pradillos Ferez
+Y96 358.089320.762606+0.645079Observatorio de Vega del Codorno
+Y97 359.643030.713822+0.697993Bommes Observatory, Bommes
+Y98 358.686920.617953+0.783613Southside Observatory, Steeple Aston
+Y99 359.072990.748454+0.661036Observatorio del Lucero del Alba
+Z00 353.265860.798528+0.599968BOOTES-1, Mazagon
+Z01 352.133210.856462+0.515344OWL-Net, Oukaimeden
+Z02 352.133310.856450+0.515339HAO observatory, Oukaimeden
+Z03 355.733460.761330+0.646426Rio Cofio, Robledo de Chavela
+Z04 352.982030.833809+0.550302MAO, Ain Laqsab
+Z05 355.363890.802644+0.594495Observatorio Horus, Cartama
+Z06 357.673240.787439+0.614746Marina Sky, Nerpio
+Z07 356.360500.798537+0.600132Ad Astra Sangos Observatory, Alhendin
+Z08 357.591390.794477+0.605566Telescope Live, Oria
+Z09 356.8786 0.62844 +0.77527 Old Orchard Observatory, Fiddington
+Z10 353.372350.786766+0.615329PGC, Fregenal de la Sierra
+Z11 358.966690.601635+0.796115Appledorne Observatory, Farnsfield
+Z12 359.0961 0.78494 +0.61762 La Romaneta, Monovar
+Z13 355.545190.802515+0.594662Observatorio AGP GUAM 4, Malaga
+Z14 353.372260.786773+0.615335ART, Fregenal de la Sierra
+Z15 359.653310.630352+0.773724Southwater
+Z16 358.951920.793166+0.607001Asociacion Astronomica de Cartagena
+Z17 343.488270.881476+0.471456Tenerife-LCO Aqawan A #2
+Z18 342.108110.877671+0.478415Gran Telescopio Canarias, Roque de los Muchachos
+Z19 342.110940.877701+0.478380La Palma-TNG
+Z20 342.1217 0.87763 +0.47850 La Palma-MERCATOR
+Z21 343.488300.881475+0.471455Tenerife-LCO Aqawan A #1
+Z22 343.4894 0.88148 +0.47143 MASTER-IAC Observatory, Tenerife
+Z23 342.114920.877679+0.478433Nordic Optical Telescope, La Palma
+Z24 343.488480.881475+0.471460Tenerife Observatory-LCO B, Tenerife
+Z25 343.490310.881476+0.471450Artemis Observatory, Teide
+Z26 343.389690.883010+0.467899Observatorio Astronomico Arcangel, Las Zocas
+Z27 343.6998 0.87976 +0.47393 Observatorio Coralito, La Laguna
+Z28 357.673310.787438+0.614748Northern Skygems Observatory, Nerpio
+Z29 354.119440.751634+0.657576Observatorio Astronomico Sobradillo
+Z30 355.525000.586571+0.807215Glyn Marsh Observatory, Douglas
+Z31 343.488350.881474+0.471457Tenerife Observatory-LCO A, Tenerife
+Z32 358.983720.766879+0.640130Observatorio Astrofisico de Javalambre
+Z33 357.673310.787438+0.6147486ROADS Observatory 2, Nerpio
+Z34 359.112330.612800+0.787622NNHS Drummonds Observatory
+Z35 358.8985 0.76788 +0.63877 OAO University Observatory Station Aras
+Z36 354.945530.805224+0.591005Cancelada
+Z37 357.804260.632788+0.771754Northolt Branch Observatory 3, Blandford Forum
+Z38 351.152940.768722+0.637456Picoto Observatory, Leiria
+Z39 346.4989 0.87535 +0.48189 Observatorio Costa Teguise
+Z40 355.5127 0.80240 +0.59482 El Manzanillo Observatory, Puerto de la Torre
+Z41 356.6264 0.76087 +0.64689 Irydeo Observatory, Camarma de Esteruelas
+Z42 357.665790.631495+0.772801Rushay Farm Observatory, Sturminster Newton
+Z43 357.462160.664742+0.744597Landehen
+Z44 351.672480.728723+0.682549Observatorio Terminus, A Coruna
+Z45 355.142640.804657+0.591779Cosmos Observatory, Marbella
+Z46 356.807000.623612+0.779131Cardiff
+Z47 357.2925 0.59846 +0.79849 Runcorn
+Z48 359.749150.623799+0.778975Northolt Branch Observatory 2, Shepherd's Bush
+Z49 357.406310.591893+0.803336Alston Observatory
+Z50 355.284310.744053+0.666069Mazariegos
+Z51 356.4486 0.76313 +0.64423 Anunaki Observatory, Rivas Vaciamadrid
+Z52 359.338990.604299+0.794113The Studios Observatory, Grantham
+Z53 352.1336 0.85645 +0.51534 TRAPPIST-North, Oukaimeden
+Z54 358.922140.623422+0.779306Greenmoor Observatory, Woodcote
+Z55 354.9150 0.79391 +0.60604 Uraniborg Observatory, Ecija
+Z56 350.2119 0.61577 +0.78529 Knocknaboola
+Z57 355.425890.803207+0.593753Observatorio Zuben, Alhaurin de la Torre
+Z58 355.630680.762093+0.645483ESA TBT Cebreros Observatory
+Z59 357.715400.599292+0.797871Chelford Observatory
+Z60 357.8506 0.73205 +0.67900 Observatorio Zaldibia
+Z61 359.064000.748594+0.660857Montecanal Observatory, Zaragoza
+Z62 351.629120.737181+0.673585Observatorio Forcarei
+Z63 358.470020.746291+0.663495Skybor Observatory, Borja
+Z64 352.1424 0.74016 +0.67021 Observatorio el Miron del Cielo
+Z65 352.172520.741388+0.668906Observatorio Astronomico Corgas
+Z66 355.591560.783284+0.619848DeSS Deimos Sky Survey, Niefla Mountain
+Z67 353.523140.597320+0.799328Dunboyne Castle Observatory
+Z68 353.4003 0.77964 +0.62418 Observatorio Torreaguila, Barbano
+Z69 353.1870 0.79823 +0.60034 Observatorio Mazagon Huelva
+Z70 353.357110.737583+0.673113Ponferrada
+Z71 353.609720.773272+0.632064Observatorio Norba Caesarina, Aldea Moret
+Z72 353.888640.599295+0.797856Cademuir Observatory, Dalkey
+Z73 353.967310.795365+0.604101Observatorio Nuevos Horizontes, Camas
+Z74 354.1562 0.79610 +0.60315 Amanecer de Arrakis
+Z75 354.4676 0.73736 +0.67346 Observatorio Sirius, Las Lomas
+Z76 354.5644 0.72675 +0.68460 Observatorio Carda, Villaviciosa
+Z77 354.889580.797212+0.601739Osuna
+Z78 358.324200.788031+0.613690Arroyo Observatory, Arroyo Hurtado
+Z79 357.453270.797556+0.601783Calar Alto TNO Survey
+Z80 359.628080.623054+0.779568Northolt Branch Observatory
+Z81 355.732400.802530+0.594629Observatorio Estrella de Mar
+Z82 355.959030.802135+0.595173BOOTES-2 Observatory, Algarrobo
+Z83 356.2881 0.76033 +0.64755 Chicharronian 3C Observatory, Tres Cantos
+Z84 357.451840.797536+0.601835Calar Alto-Schmidt
+Z85 356.750280.801058+0.596932Observatorio Sierra Contraviesa
+Z86 356.8900 0.62347 +0.77923 St. Mellons
+Z87 357.102100.608005+0.791293Stanley Laver Observatory, Pontesbury
+Z88 357.5101 0.62716 +0.77632 Fosseway Observatory, Stratton-on-the-Fosse
+Z89 357.8281 0.59942 +0.79777 Macclesfield
+Z90 357.8482 0.79540 +0.60418 Albox
+Z91 358.749990.631731+0.772595Curdridge
+Z92 358.392220.591378+0.803713Almalex Observatory, Leeds
+Z93 359.855890.782380+0.620769Observatorio Polop, Alicante
+Z94 358.8565 0.62725 +0.77623 Kempshott
+Z95 358.8909 0.76782 +0.63883 Astronomia Para Todos Remote Observatory
+Z96 359.193690.747818+0.661731Observatorio Cesaraugusto
+Z97 359.416470.704568+0.707270OPERA Observatory, Saint Palais
+Z98 359.5216 0.77156 +0.63405 Observatorio TRZ, Betera
+Z99 359.978740.595468+0.800687Clixby Observatory, Cleethorpes

--- a/src/kete_core/data/readme.md
+++ b/src/kete_core/data/readme.md
@@ -3,8 +3,9 @@ Collection of data files which are used by kete_core.
 Files ending in BSP or BPC are are packed binary SPICE kernels.
 These are loaded and packed into the final rust binary, and are included automatically.
 
-`mpc_obs.tsv` - Tab separated table containing known ground observatory codes and
-    locations. This is also loaded and compiled into the final binary.
+`mpc_obs.tsv` - Downloaded from https://minorplanetcenter.net/iau/lists/ObsCodes.html
+    Contains obs codes and locations. These are loaded and compiled into the final
+    binary. Entries with gaps, such as spacecraft are ignored.
 
 `naif_ids.csv` - CSV containing a table of many of the known NAIF identifiers to full
     names. This is not 100% guaranteed to match, as JPL may decide to renumber objects.

--- a/src/kete_core/src/frames/wgs_84.rs
+++ b/src/kete_core/src/frames/wgs_84.rs
@@ -3,17 +3,21 @@
 /// Earth semi major axis in km as defined by WGS84
 pub const EARTH_A: f64 = 6378.1370;
 
+/// Earth semi minor axis in km as defined by WGS84
+pub const _EARTH_B: f64 = 6356.7523142;
+
 // /// Earth inverse flattening as defined by WGS84
-const _EARTH_INV_FLAT: f64 = 298.257223563;
+const _EARTH_INV_FLAT: f64 = 298.2572235629972;
 
 /// Earth surface eccentricity squared, calculated from above.
-const EARTH_E2: f64 = 0.00669437999014;
+/// e^2 = (2 - flattening) * flattening
+const EARTH_E2: f64 = 0.0066943799901413165;
 
 /// Prime vertical radius of curvature.
 /// This is the radius of curvature of the earth surface at the specific geodetic
 /// latitude.
 pub fn prime_vert_radius(geodetic_lat: f64) -> f64 {
-    EARTH_A / (1.0 - EARTH_E2 * geodetic_lat.sin().powi(2))
+    EARTH_A / (1.0 - EARTH_E2 * geodetic_lat.sin().powi(2)).sqrt()
 }
 
 /// Compute geodetic lat/lon/height in radians/km from ECEF position in km.

--- a/src/kete_core/src/spice/obs_codes.rs
+++ b/src/kete_core/src/spice/obs_codes.rs
@@ -33,7 +33,7 @@ impl FromStr for ObsCode {
     /// Load an ObsCode from a single string.
     fn from_str(row: &str) -> KeteResult<Self> {
         let code = row[0..3].to_string();
-        let lon = f64::from_str(row[5..13].trim())?;
+        let lon = f64::from_str(row[3..13].trim())?;
         let cos = f64::from_str(row[13..21].trim())?;
         let sin = f64::from_str(row[21..30].trim())?;
         let vec = Vector3::new(cos, 0.0, sin) * EARTH_A;

--- a/src/kete_core/src/spice/pck.rs
+++ b/src/kete_core/src/spice/pck.rs
@@ -14,9 +14,9 @@ use lazy_static::lazy_static;
 
 use std::io::Cursor;
 
-const PRELOAD_PCK: &[&[u8]] = &[
-    include_bytes!("../../data/earth_1962_240827_2124_combined.bpc"),
-];
+const PRELOAD_PCK: &[&[u8]] = &[include_bytes!(
+    "../../data/earth_1962_240827_2124_combined.bpc"
+)];
 
 /// A collection of segments.
 #[derive(Debug)]


### PR DESCRIPTION
This updates all the observatory codes to use the most recent.

This fixes a missing sqrt in the wgs84 conversion from geodetic to ECEF, improving accuracy by 10s to 100s of meters for earth observatories.
