### PR TITLE
Release Version 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [v1.0.7]
 
 ### Added
 
@@ -387,6 +387,7 @@ Initial Release
 
 
 [Unreleased]: https://github.com/IPAC-SW/kete/tree/main
+[1.0.7]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.7
 [1.0.6]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.6
 [1.0.5]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.5
 [1.0.4]: https://github.com/IPAC-SW/kete/releases/tag/v1.0.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "_core"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "1.0.6"
+version = "1.0.7"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "ddahlen@ipac.caltech.edu"},

--- a/src/kete_core/Cargo.toml
+++ b/src/kete_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kete_core"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION

## [v1.0.7]

### Added

- Added functions for estimating the position of Earth coordinates outside of the PCK
  limits. This allows for estimating Palomar's position in 1950.

### Changed

- Switched to using the MPC Observatory code file for the source of observatory
  locations.

### Fixed

- WGS84 conversion between ECEF and Lat/Lon/Alt was missing a square-root causing a
  small offset (typically 10s to 100s of meters). This has been fixed.