### PR TITLE
SPK lookup performance improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Improved SPICE kernel lookup performance when using large numbers of kernels.
+  Testing with 1500 kernels has increased lookup speed by ~26x.
 - Added `HorizonsProperties.desigs` which lists all of the designations in horizons.
   This will use a cached json file, for existing installations you will have to update
   the cached horizons properties: `HorizonsProperties.fetch(desig, update_cache=True)`

--- a/src/kete_core/src/flux/common.rs
+++ b/src/kete_core/src/flux/common.rs
@@ -130,9 +130,11 @@ impl ModelResults {
 /// this by `c / wavelength**2`.
 ///
 /// # Arguments
-///
-/// * `temp` - Temperature in kelvin.
+/// * `temp` - Temperature in Kelvin.
 /// * `wavelength` - Wavelength in nm.
+///
+/// # Returns
+/// * Flux in Jy / steradian.
 #[inline(always)]
 pub fn black_body_flux(temp: f64, wavelength: f64) -> f64 {
     if wavelength < 10.0 || temp < 30.0 {

--- a/src/kete_core/src/spice/daf.rs
+++ b/src/kete_core/src/spice/daf.rs
@@ -56,24 +56,26 @@ pub enum DafSegments {
     Pck(PckSegment),
 }
 
-impl DafSegments {
-    /// Return the contained SPK segment.
-    /// Panic if not SPK.
-    pub fn spk(self) -> SpkSegment {
-        if let Self::Spk(seg) = self {
-            seg
+impl TryFrom<DafSegments> for SpkSegment {
+    type Error = Error;
+
+    fn try_from(value: DafSegments) -> Result<Self, Self::Error> {
+        if let DafSegments::Spk(seg) = value {
+            Ok(seg)
         } else {
-            panic!("Not an SPK segment.")
+            Err(Error::ValueError("Not an SPK segment.".into()))
         }
     }
+}
 
-    /// Return the contained PCK segment.
-    /// Panic if not PCK.
-    pub fn pck(self) -> PckSegment {
-        if let Self::Pck(seg) = self {
-            seg
+impl TryFrom<DafSegments> for PckSegment {
+    type Error = Error;
+
+    fn try_from(value: DafSegments) -> Result<Self, Self::Error> {
+        if let DafSegments::Pck(seg) = value {
+            Ok(seg)
         } else {
-            panic!("Not an PCK segment.")
+            Err(Error::ValueError("Not a PCK segment.".into()))
         }
     }
 }

--- a/src/kete_core/src/spice/mod.rs
+++ b/src/kete_core/src/spice/mod.rs
@@ -9,7 +9,6 @@ mod pck_segments;
 mod spk;
 mod spk_segments;
 
-// expose the public methods in spk to the outside world.
 pub use daf::*;
 pub use naif_ids::try_name_from_id;
 pub use obs_codes::OBS_CODES;
@@ -17,6 +16,12 @@ pub use pck::*;
 pub use spk::*;
 
 /// Convert seconds from J2000 into JD.
+///
+/// # Arguments
+/// * `jd_sec` - The number of seconds from J2000.
+///
+/// # Returns
+/// The Julian Date (TDB).
 fn spice_jds_to_jd(jd_sec: f64) -> f64 {
     // 86400.0 = 60 * 60 * 24
     jd_sec / 86400.0 + 2451545.0
@@ -26,4 +31,39 @@ fn spice_jds_to_jd(jd_sec: f64) -> f64 {
 fn jd_to_spice_jd(jd: f64) -> f64 {
     // 86400.0 = 60 * 60 * 24
     (jd - 2451545.0) * 86400.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_spice_jds_to_jd() {
+        let jd_sec = 0.0;
+        let jd = spice_jds_to_jd(jd_sec);
+        assert_eq!(jd, 2451545.0);
+
+        let jd_sec = 86400.0; // 1 day in seconds
+        let jd = spice_jds_to_jd(jd_sec);
+        assert_eq!(jd, 2451546.0);
+    }
+
+    #[test]
+    fn test_jd_to_spice_jd() {
+        let jd = 2451545.0;
+        let jd_sec = jd_to_spice_jd(jd);
+        assert_eq!(jd_sec, 0.0);
+
+        let jd = 2451546.0; // 1 day after J2000
+        let jd_sec = jd_to_spice_jd(jd);
+        assert_eq!(jd_sec, 86400.0);
+    }
+
+    #[test]
+    fn test_spice_jds_to_jd_and_back() {
+        let jd_sec = 1.0;
+        let jd = spice_jds_to_jd(jd_sec);
+        let jd_sec_back = jd_to_spice_jd(jd);
+        assert!((jd_sec - jd_sec_back).abs() < 1e-5);
+    }
 }

--- a/src/kete_core/src/spice/pck.rs
+++ b/src/kete_core/src/spice/pck.rs
@@ -39,8 +39,11 @@ impl PckCollection {
                 filename
             )))?;
         }
-        self.segments
-            .extend(file.segments.into_iter().map(|x| x.pck()));
+        self.segments.extend(
+            file.segments
+                .into_iter()
+                .map(|x| x.try_into().expect("Failed to load PCK")),
+        );
         Ok(())
     }
 
@@ -70,8 +73,11 @@ impl PckCollection {
         for preload in PRELOAD_PCK {
             let mut buffer = Cursor::new(preload);
             let file = DafFile::from_buffer(&mut buffer).unwrap();
-            self.segments
-                .extend(file.segments.into_iter().map(|x| x.pck()))
+            self.segments.extend(
+                file.segments
+                    .into_iter()
+                    .map(|x| x.try_into().expect("Failed to load PCK")),
+            );
         }
     }
 }

--- a/src/kete_core/src/spice/spk.rs
+++ b/src/kete_core/src/spice/spk.rs
@@ -146,6 +146,19 @@ impl SpkCollection {
                 ));
             }
         }
+
+        self.de440_segments.iter().for_each(|segment| {
+            if segment.obj_id == id {
+                let jd_range = segment.jd_range();
+                segment_info.push((
+                    jd_range.0,
+                    jd_range.1,
+                    segment.center_id,
+                    segment.ref_frame,
+                    segment.segment_type,
+                ));
+            }
+        });
         if segment_info.is_empty() {
             return segment_info;
         }
@@ -178,6 +191,13 @@ impl SpkCollection {
     /// anything else.
     pub fn loaded_objects(&self, include_centers: bool) -> HashSet<i64> {
         let mut found = HashSet::new();
+
+        self.de440_segments.iter().for_each(|x| {
+            let _ = found.insert(x.obj_id);
+            if include_centers {
+                let _ = found.insert(x.center_id);
+            };
+        });
 
         self.segments.iter().for_each(|(obj_id, segs)| {
             let _ = found.insert(*obj_id);

--- a/src/kete_core/src/spice/spk.rs
+++ b/src/kete_core/src/spice/spk.rs
@@ -95,13 +95,16 @@ impl SpkCollection {
     #[inline(always)]
     pub fn try_get_state(&self, id: i64, jd: f64, center: i64, frame: Frame) -> KeteResult<State> {
         let mut state = self.try_get_raw_state(id, jd)?;
-        self.try_change_center(&mut state, center)?;
-        state.try_change_frame_mut(frame)?;
+        if state.center_id != center {
+            self.try_change_center(&mut state, center)?;
+        }
+        if state.frame != frame {
+            state.try_change_frame_mut(frame)?;
+        }
         Ok(state)
     }
 
     /// Use the data loaded in the SPKs to change the center ID of the provided state.
-    #[inline(always)]
     pub fn try_change_center(&self, state: &mut State, new_center: i64) -> KeteResult<()> {
         match (state.center_id, new_center) {
             (a, b) if a == b => (),
@@ -116,7 +119,7 @@ impl SpkCollection {
                 state.try_change_center(self.try_get_raw_state(i, state.jd)?)?;
                 state.try_change_center(self.try_get_raw_state(10, state.jd)?)?;
             }
-            (10, i) if i < 10 => {
+            (10, i) if (i > 1) & (i < 10) => {
                 state.try_change_center(self.try_get_raw_state(10, state.jd)?)?;
                 state.try_change_center(self.try_get_raw_state(i, state.jd)?)?;
             }

--- a/src/kete_core/src/spice/spk_segments.rs
+++ b/src/kete_core/src/spice/spk_segments.rs
@@ -1101,14 +1101,13 @@ impl SpkSegmentType21 {
     }
 }
 
+// This segment type has poor documentation on the NAIF website.
 /// Segments of type 10 and 14 use a "generic segment" definition.
-/// This segment type has poor documentation on the NAIF website, a significant amount
-/// of reverse engineering was to understand this.
 /// The DAF Array is big flat vector of floats.
-
 #[derive(Debug)]
 #[allow(dead_code)]
 struct GenericSegment {
+    /// Underlying DAF array
     array: DafArray,
 
     /// Number of metadata value stored in this segment.


### PR DESCRIPTION
Fixes #175 

TLDR:
Performance on spice kernel lookups when  thousands of spice kernels are loaded has been improved by about 25x.


# Underlying reason for perf issue:

Structurally, the spice kernels were being stored as a single list in loaded order (this is cSPICE requirements in terms of ordering). However if you requested the location of an object near the end of the list it would have to iterate over the list until it found it. This means if you loaded 1k spice kernels, then asked for the state of an object which was loaded last it would have to iterate until it found that object.

# Solutions
- **Vector** - Original solution - Keep everything in a big ol' list. Looking up items near the end means having to iterate over the whole list, but items near the front are speedy.

- **HashMap** - The first clear improvement is to add a hashmap from object id to all of the spice segments. This means that you can O(1) lookup the available states without iterating. It turns out however that if you are looking for an object near the start of the list, for example the Sun (which is loaded first), then the overhead of the new pointer indirection results in slower performance than the original list solution. Though lookups for items further down the list can be 10 to 100x faster.

- **HashMap + Vector** - Best of both worlds (this is what is implemented here) - Put the DE440 spice kernels into their own special vector, meaning they have fast lookups as they used to, but all other spice kernels get put into a hashmap as described above. This gives perf which is the best of both worlds, fast lookup of de440 for numerical integration, and you dont have to iterate through the entire list for all other spice kernels.

