### PR TITLE
fix: typo in search for 'combined.bpc' in pck cache files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [project]
 name = "kete"
-version = "1.1.2"
+version = "1.1.3"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [
         { name = "Dar Dahlen", email = "ddahlen@ipac.caltech.edu" },
         { name = "Joe Masiero", email = "jmasiero@ipac.caltech.edu" },
         { name = "Annie Ehler", email = "aehler@ipac.caltech.edu" },
+        { name = "Faria Chowdhury", email = "faria@ipac.caltech.edu" },
 ]
 license = { text = "BSD" }
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "1.1.3"
+version = "1.1.2"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [

--- a/src/kete/spice.py
+++ b/src/kete/spice.py
@@ -293,7 +293,7 @@ def _download_core_files():
 
     # Look for PCK files
     cache_files = glob.glob(os.path.join(cache_path(), "kernels", "*.bpc"))
-    if not any(["combined.bsp" in file for file in cache_files]):
+    if not any(["combined.bpc" in file for file in cache_files]):
         pck_path = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/"
 
         # cannot find the combined file, so download it


### PR DESCRIPTION
Problem: there is a typo in the filename being searched for in the list of PCK files in the cache which have .bpc extension.

The correct search string is: combined.bpc (not combined.bsp).

Issue: https://github.com/IPAC-SW/kete/issues/15