### PR TITLE
fix: Wrong path specified for the docs archive in the github workflow

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -288,4 +288,4 @@ jobs:
           read -r package_name package_version < <(uv version)
           cd docs
           zip -rz "${package_name}-${package_version}.doc.zip" html/*
-          devpi upload "docs/${package_name}-${package_version}.doc.zip"
+          devpi upload "${package_name}-${package_version}.doc.zip"


### PR DESCRIPTION
This pull request makes a minor fix to the release workflow. The path used when uploading the zipped documentation to `devpi` is corrected to ensure the file is referenced from the current directory rather than a subdirectory.